### PR TITLE
Escaped List<out Bar> for markdown in docs/reference/java-interop.md

### DIFF
--- a/docs/reference/java-interop.md
+++ b/docs/reference/java-interop.md
@@ -72,11 +72,11 @@ fun render(list : List<out Any?>, to : Appendable) {
 Kotlin's generics are a little different from Java's (see Generics). When importing Java types to Kotlin we perform some conversions:
 
 * Java's wildcards are converted into type projections
-  * Foo<? extends Bar> becomes Foo<out Bar>
-  * Foo<? super Bar> becomes Foo<in Bar>
+  * Foo<? extends Bar> becomes Foo\<out Bar>
+  * Foo<? super Bar> becomes Foo\<in Bar>
 
 * Java's raw types are converted into star projections
-  * List becomes List<*>, i.e. List<out Any?>
+  * List becomes List<*>, i.e. List\<out Any?>
 
 Like Java's, Kotlin's generics are not retained at runtime, i.e. objects do not carry information about actual type arguments passed to their constructors, i.e. ArrayList<Integer>() is indistinguishable from ArrayList<Character>(). This makes it impossible to perform is-checks that take generics into account. Kotlin only allows is-checks for star-projected generic types:
 


### PR DESCRIPTION
Markdown syntax allows HTML tags, so in "List<out Bar>" the generic part does not display properly without escaping.
