### PR TITLE
Update link to kotlin-vim to the up-to-date version

### DIFF
--- a/_data/oss-projects.yml
+++ b/_data/oss-projects.yml
@@ -41,7 +41,7 @@
 - name: Kotlin Vim
   description: Kotlin Syntax Highlighter for Vim
   type: Tools
-  link: https://github.com/ignatov/kotlin-vim
+  link: https://github.com/udalov/kotlin-vim
 
 - name: Griffon Plugin
   description: Griffon Support


### PR DESCRIPTION
May I kindly advertise and suggest to use my own version of kotlin-vim which supports highlighting of almost all language features at the moment and also some basic indentation :)
