### PR TITLE
Make the header sexier

### DIFF
--- a/css/com/layout/header.css
+++ b/css/com/layout/header.css
@@ -172,8 +172,9 @@
 
 .page_index .global-header {
   padding: 64px 0;
-  height: 432px;
+  height: 832px;
   background-image: url("images/index-page-header-bg.jpg");
+  background-attachment: fixed;
   background-position: center center; }
   .page_index .global-header .get-kotlin-button {
     text-transform: uppercase; }

--- a/css/com/layout/header.css
+++ b/css/com/layout/header.css
@@ -172,7 +172,7 @@
 
 .page_index .global-header {
   padding: 64px 0;
-  height: 832px;
+  height: 569px;
   background-image: url("images/index-page-header-bg.jpg");
   background-attachment: fixed;
   background-position: center center; }


### PR DESCRIPTION
This PR makes the header of the index page sexier by increasing the height of the header image from `432px` to `569px` (the height of the image) and adding `background-attachment: fixed;`. This makes the header image stay in place when scrolling, making it look nicer.