### PR TITLE
Fix rendering glitch in generics.md

### DIFF
--- a/docs/reference/generics.md
+++ b/docs/reference/generics.md
@@ -301,6 +301,7 @@ abstract class Default<T> {
 ```
 
 For example, the class Int could extend Default in the following way:
+
 ``` kotlin
 class Int {
   class object : Default<Int> {


### PR DESCRIPTION
The current HTML renders the kotlin code inline instead of formatted due to missing whitespace.
