### PR TITLE
Add a "Open Points" section

### DIFF
--- a/docs/reference/classes.md
+++ b/docs/reference/classes.md
@@ -264,3 +264,6 @@ A description of some more interesting features related to class objects can be 
 
 Note: if you think that class objects are a great way of implementing singletons in Kotlin, please see [Object expressions and Declarations](object-declarations.html).
 
+## Open Points
+
+* Why should an anonymous initializer be used? Is it just for clearity or is there a technical limitation? In Scala everything goes into the class body.


### PR DESCRIPTION
This section should be on every page to help to improve the documentation. There are many missing details at the moment and it would be useful for the documentation authors to know what is missing. This should not replace the forum, it should just name missing things.
