### PR TITLE
"Java Interop" updated according to the recent changes in members of Any

### DIFF
--- a/docs/reference/using-ant.md
+++ b/docs/reference/using-ant.md
@@ -24,7 +24,7 @@ When the project consists of exclusively Kotlin source code, the easiest way to 
 
 ``` xml
 <project name="Ant Task Test" default="build">
-    <typedef resource="org.jetbrains.jet.buildtools.ant.antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
+    <typedef resource="org/jetbrains/jet/buildtools/ant/antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
 
     <target name="build">
         <kotlinc src="hello.kt" output="hello.jar"/>
@@ -40,7 +40,7 @@ If a project consists of multiple source roots, use *src* as elements to define 
 
 ``` xml
 <project name="Ant Task Test" default="build">
-    <typedef resource="org.jetbrains.jet.buildtools.ant.antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
+    <typedef resource="org/jetbrains/jet/buildtools/ant/antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
 
     <target name="build">
         <kotlinc output="hello.jar">
@@ -87,7 +87,7 @@ recommended to use *withKotlin* task
 
 ``` xml
 <project name="Ant Task Test" default="build">
-  <typdef resource="org.jetbrains.jet.buildtools.ant.antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
+  <typdef resource="org/jetbrains/jet/buildtools/ant/antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
 
   <target name="build">
     <kotlin2js src="root1" output="out.js"/>
@@ -99,7 +99,7 @@ recommended to use *withKotlin* task
 
 ``` xml
 <project name="Ant Task Test" default="build">
-  <taskdef resource="org.jetbrains.jet.buildtools.ant.antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
+  <taskdef resource="org/jetbrains/jet/buildtools/ant/antlib.xml" classpath="${kotlin.lib}/kotlin-ant.jar"/>
 
   <target name="build">
     <kotlin2js src="root1" output="out.js" outputPrefix="prefix" outputPostfix="postfix" sourcemap="true"/>


### PR DESCRIPTION
Ant paths fixed: see [this comment](https://github.com/JetBrains/kotlin-web-site/commit/5da828f48dd49ffe9c6262cf33fb609a5c253600#commitcomment-7859776)
