### PR TITLE
Add space before colon when notating trait

### DIFF
--- a/docs/reference/traits.md
+++ b/docs/reference/traits.md
@@ -26,7 +26,7 @@ trait MyTrait {
 A class or object can implement one or more traits
 
 ``` kotlin
-class Child: MyTrait {
+class Child : MyTrait {
 
    fun bar() {
       // body
@@ -47,7 +47,7 @@ trait MyTrait {
     }
 }
 
-class Child: MyTrait {
+class Child : MyTrait {
     override val property: Int = 29
 }
 ```


### PR DESCRIPTION
The rest of the document uses the format

``` kotlin
class A : B, C {...}
```
