### PR TITLE
Add AppDialer as project where Kotlin uses in production

### DIFF
--- a/_data/companies-using-kotlin.yml
+++ b/_data/companies-using-kotlin.yml
@@ -45,3 +45,7 @@
 - company: Level Money
   url: https://play.google.com/store/apps/details?id=com.levelmoney.mobile
   description: Most new non-UI code written in Kotlin
+
+- company: AppDialer
+  url: https://play.google.com/store/apps/details?id=name.pilgr.appdialer
+  description: Fuzzy app/contact search and new UI written in Kotlin


### PR DESCRIPTION
I been invited to add my android project AppDialer as I started to use Kotlin in production. 
https://twitter.com/hhariri/status/543356014738018304
