### PR TITLE
Example error

### DIFF
--- a/docs/reference/basic-types.md
+++ b/docs/reference/basic-types.md
@@ -51,7 +51,7 @@ Note that boxing of numbers does not preserve identity:
 
 ``` kotlin
 val a: Int = 10000
-print(a identityEquals a) // Prints 'true'
+print(a identityEquals a) // Prints 'false'
 val boxedA: Int? = a
 val anotherBoxedA: Int? = a
 print(boxedA identityEquals anotherBoxedA) // !!!Prints 'false'!!!


### PR DESCRIPTION
Tried to run an example, related to "boxing of numbers does not preserve identity" and got the results:
falsefalse
But the example says it must be truefalse
I have no idea why that's happening, using latest Kotlin. Just learning language and noticed that example is wrong. Can someone explain me what's going on? :)