### PR TITLE
Point the navbar at the actual API docs

### DIFF
--- a/_data/_nav.yml
+++ b/_data/_nav.yml
@@ -105,7 +105,7 @@ reference:
   - title: Reference
     description: API and Grammar
     content:
-      - /docs/api/index.html: API Reference
+      - /api/latest/jvm/stdlib: API Reference
       - /docs/reference/grammar.html: Grammar
 
 


### PR DESCRIPTION
Currently it goes to a useless page that simply redirects users to an ancient 0.1-SNAPSHOT view of the docs.