### PR TITLE
Adds note about unimplemented feature.

### DIFF
--- a/docs/reference/generics.md
+++ b/docs/reference/generics.md
@@ -325,6 +325,7 @@ fun replaceNullsWithDefaults<T : Any>(list: List<T?>): List<T> {
 
 For this function to compile, we need to specify a type constraint that requires a **class object** of `T` to be of a subtype of `Default<T>`:
 
+*NOTE: This feature is not implemented yet (https://youtrack.jetbrains.com/issue/KT-1437)*
 ``` kotlin
 fun replaceNullsWithDefaults<T : Any>(list : List<T?>) : List<T>
     where class object T : Default<T> {


### PR DESCRIPTION
The feature being used in this code block is not yet implemented in the latest build.  Either it should be removed from the documentation or annotated as such.  I have chosen to annotate it so it will be easy to add the documentation back in later, but removal also works if that is preferred.