### PR TITLE
Use the new Android plugin name for Gradle

### DIFF
--- a/docs/reference/using-gradle.md
+++ b/docs/reference/using-gradle.md
@@ -117,7 +117,7 @@ Android's Gradle model is a little different from ordinary Gradle, so if you wan
 buildscript {
     ...
 }
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 ```
 


### PR DESCRIPTION
The Android gradle plugin was renamed and the "android" one is deprecated.