### PR TITLE
Reconfigure maven-compiler-plugin

### DIFF
--- a/docs/reference/using-maven.md
+++ b/docs/reference/using-maven.md
@@ -127,7 +127,7 @@ The Kotlin Maven Plugin needs to be referenced to compile the sources:
 To compile mixed code applications Kotlin compiler should be invoked before Java compiler.
 In maven terms that means kotlin-maven-plugin should be run before maven-compiler-plugin.
 
-It could be done by moving Kotlin compilation to previous phase, process-sources (feel free to suggest a better solution if you have one):
+Because the maven-compiler-plugin's executions are inherited from the packaging pom, by default they will always run before any executions defined in the project pom. To run the maven-copiler-plugin in the correct order, we must redefine the executions of maven-compiler-plugin and disable inheritance:
 
 ``` xml
 <plugin>
@@ -138,14 +138,33 @@ It could be done by moving Kotlin compilation to previous phase, process-sources
     <executions>
         <execution>
             <id>compile</id>
-            <phase>process-sources</phase>
+            <phase>compile</phase>
             <goals> <goal>compile</goal> </goals>
         </execution>
 
         <execution>
             <id>test-compile</id>
-            <phase>process-test-sources</phase>
+            <phase>test-compile</phase>
             <goals> <goal>test-compile</goal> </goals>
+        </execution>
+    </executions>
+</plugin>
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <version>3.3</version>
+    <executions>
+        <execution>
+            <id>default-compile</id>
+            <inherited>false</inherited>
+            <phase>compile</phase>
+            <goals><goal>compile</goal></goals>
+        </execution>
+        <execution>
+            <id>default-testCompile</id>
+            <inherited>false</inherited>
+            <phase>test-compile</phase>
+            <goals><goal>testCompile</goal></goals>
         </execution>
     </executions>
 </plugin>


### PR DESCRIPTION
Instead of running the kotlin compiler in the `process-sources` phase, we should run it in the `compile` phase and configure the `maven-compiler-plugin` to run after the kotlin plugin. This can be achieved by redefining the `maven-compiler-plugin`'s executions after the `kotlin-maven-plugin`'s executions with the same execution `id` as the original definition.