### PR TITLE
Clarified abstract classes / functions not needing open

### DIFF
--- a/docs/reference/classes.md
+++ b/docs/reference/classes.md
@@ -283,7 +283,7 @@ class C() : A(), B {
 }
 ```
 
-Note that we do not need to annotate an abstract class open – it goes without saying. Neither need we annotate an abstract function open.
+Note that we do not need to annotate an abstract class or function with open – it goes without saying.
 
 We can override a non-abstract open member with an abstract one
 


### PR DESCRIPTION
I think the new text is clearer around not needing open on abstract classes and functions.