### PR TITLE
Fix github's search query to return kotlin repos

### DIFF
--- a/_layouts/resources.html
+++ b/_layouts/resources.html
@@ -10,7 +10,7 @@ main_nav_id: docs
     </div>
 
     <article role="main" class="page-content g-9">
-        <p>There are over <a href="https://github.com/search?q=Kotlin&ref=cmdform"> 400 repositories on GitHub</a> alone with Kotlin projects. These are just a few of them.
+        <p>There are over <a href="https://github.com/search?q=language:Kotlin&ref=cmdform"> 400 repositories on GitHub</a> alone with Kotlin projects. These are just a few of them.
         If you have an OSS project in Kotlin or know of one, please   <a href="https://github.com/JetBrains/kotlin-web-site/edit/master/_data/oss-projects.yml">
             add it</a>.</p>
         <br/>


### PR DESCRIPTION
![lol](http://i.imgur.com/0sbasbp.gif)