### PR TITLE
doc corrections: show a better example for 'where', document SAM adap…

### DIFF
--- a/docs/reference/generics.md
+++ b/docs/reference/generics.md
@@ -282,8 +282,9 @@ The default upper bound (if none specified) is `Any?`. Only one upper bound can 
 If the same type parameter needs more than one upper bound, we need a separate **where**\-clause:
 
 ``` kotlin
-fun <T : Comparable<T>> cloneWhenGreater(list: List<T>, threshold: T): List<T>
-    where T : Cloneable {
-  return list when {it > threshold} map {it.clone()}
+fun <T> cloneWhenGreater(list: List<T>, threshold: T): List<T>
+    where T : Comparable,
+          T : Cloneable {
+  return list.filter{ it > threshold }.map { it.clone() }
 }
 ```

--- a/docs/reference/java-interop.md
+++ b/docs/reference/java-interop.md
@@ -381,6 +381,14 @@ val executor = ThreadPoolExecutor()
 executor.execute { println("This runs in a thread pool") }
 ```
 
+If the Java class has multiple methods taking functional interfaces, you can choose the one you need to call by
+using an adapter function that converts a lambda to a specific SAM type. Those adapter functions are also generated
+by the compiler when needed.
+
+``` kotlin
+executor.execute(Runnable { println("This runs in a thread pool") })
+```
+
 Note that SAM conversions only work for interfaces, not for abstract classes, even if those also have just a single
 abstract method.
 


### PR DESCRIPTION
…ter functions