### PR TITLE
precedence of "?:" over "===" ?!?!

### DIFF
--- a/docs/reference/equality.md
+++ b/docs/reference/equality.md
@@ -22,7 +22,7 @@ true if and only if `a` and `b` point to the same object.
 Structural equality is checked by the `==` operation (and its negated counterpart `!=`). By convention, an expression like `a == b` is translated to
 
 ``` kotlin
-a?.equals(b) ?: b === null
+a?.equals(b) ?: (b === null)
 ```
 
 I.e. if `a` is not `null`, it calls the `equals(Any?)` function, otherwise (i.e. `a` is `null`) it checks that `b` is referentially equal to `null`.


### PR DESCRIPTION
On the page http://try.kotlinlang.org/#/Examples/Hello, world!/Simplest version/Simplest version.kt
the following:

```java
class X(){
    fun equals(x:X) = x===this
}

fun main(args: Array<String>) {
    var x=X()
    println ( x ) 
    println ( x.equals(x) )
    println ( x == x )
    println ( if (x==null) x===null else x==x )
    println ( x?.equals(x) ?: x === null ) // this yields "false"
    println ( x?.equals(x) ?: (x === null) )
}
```
prints:
```java
X@40bde56d
true
true
true
false
true
```