### PR TITLE
Add Kodein to OSS projects

### DIFF
--- a/_data/oss-projects.yml
+++ b/_data/oss-projects.yml
@@ -113,6 +113,11 @@
   type: Library
   link: https://github.com/klutter/klutter
   
+- name: Kodein
+  description: Painless Kotlin Dependency Injection
+  type: Library
+  link: https://github.com/SalomonBrys/Kodein
+
 - name: Kovert
   description: An invisible REST framework for Kotlin
   type: Library


### PR DESCRIPTION
Add another dependency injection library to the list of OSS projects.