### PR TITLE
Specify bash shell in INSTALL.sh shebang

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 RUBY_VERSION_=`ruby -e "puts RUBY_VERSION"`
 BUNDLER_VERSION_=1.6.2
 GEM_LOCAL_PATH_=~/.gem/ruby/$RUBY_VERSION_/gems


### PR DESCRIPTION
On Ubuntu, the install script produces the following syntax error with default shebang `#!/bin/sh`
``` 
./INSTALL.sh: 10: ./INSTALL.sh: [[: not found
```
Default `/bin/sh` on ubuntu is a link to `/bin/dash` and it seems the script is intended for bash shell.

Specifying the shebang explicitly as `/bin/bash` should work on linux and osx