### PR TITLE
Add operator keyword to rangeTo methods

### DIFF
--- a/docs/reference/ranges.md
+++ b/docs/reference/ranges.md
@@ -80,9 +80,9 @@ The `rangeTo()` functions in number types simply call the constructors of `*Rang
 ``` kotlin
 class Int {
   //...
-  fun rangeTo(other: Byte): IntRange = IntRange(this, other)
+  operator fun rangeTo(other: Byte): IntRange = IntRange(this, other)
   //...
-  fun rangeTo(other: Int): IntRange = IntRange(this, other)
+  operator fun rangeTo(other: Int): IntRange = IntRange(this, other)
   //...
 }
 ```


### PR DESCRIPTION
As per [Operator Overloading](https://kotlinlang.org/docs/reference/operator-overloading.html):

> Functions that overload operators need to be marked with the `operator` modifier.