### PR TITLE
Fix typo in delegated-properties.md

### DIFF
--- a/docs/reference/delegated-properties.md
+++ b/docs/reference/delegated-properties.md
@@ -115,7 +115,7 @@ By default, the evaluation of lazy properties is **synchronized**: the value is 
 will see the same value. If the synchronization of initialization delegate is not required, so that multiple threads
 can execute it simultaneously, pass `LazyThreadSafetyMode.PUBLICATION` as a parameter to the `lazy()` function. 
 And if you're sure that the initialization will always happen on a single thread, you can use `LazyThreadSafetyMode.NONE` mode, 
-which doesn't incur any thread-safety guaratees and the related overhead.
+which doesn't incur any thread-safety guarantees and the related overhead.
 
 
 ### Observable


### PR DESCRIPTION
Change `guaratees` to `guarantees`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jetbrains/kotlin-web-site/305)
<!-- Reviewable:end -->
