### PR TITLE
Update oss-projects.yml

### DIFF
--- a/_data/oss-projects.yml
+++ b/_data/oss-projects.yml
@@ -147,3 +147,8 @@
   description: Type Extensions (Long, Int, Enum, Date) for Klaxon
   type: Library
   link: https://github.com/fboldog/ext4klaxon
+  
+- name: Bubble
+  description: Library for obtaining screen orientation when orientation is blocked in AndroidManifest
+  type: Library
+  link: https://github.com/TouK/bubble


### PR DESCRIPTION
By default, Android supports screen orientation changes by providing a callback. Unfortunately this mechanism has a huge drawback. When system handles the screen orientation change it recreates the view from scratch, making it impossible to create smooth transitions. Moreover if you lock the activity's orientation in AndroidManifest, the callback is not invoked any more. Thus if you would like to have a custom view transition on a screen orientation change, you have to detect it by yourself what is pretty complicated.

Junit tests are also written in Koltin.