### PR TITLE
Add Blaze tool

### DIFF
--- a/_data/oss-projects.yml
+++ b/_data/oss-projects.yml
@@ -152,3 +152,8 @@
   description: Library for obtaining screen orientation when orientation is blocked in AndroidManifest
   type: Library
   link: https://github.com/TouK/bubble
+  
+- name: Blaze
+  description: Replacement for shell scripts. A speedy, flexible, general purpose scripting stack for the JVM
+  type: Tools
+  link: https://github.com/fizzed/blaze


### PR DESCRIPTION
Execute your Kotlin or Kotlin scripts with the Blaze scripting stack for the JVM