### PR TITLE
Adding square brackets to getter/setter

### DIFF
--- a/docs/reference/properties.md
+++ b/docs/reference/properties.md
@@ -40,8 +40,8 @@ The full syntax for declaring a property is
 
 ``` kotlin
 var <propertyName>: <PropertyType> [= <property_initializer>]
-  <getter>
-  <setter>
+  [<getter>]
+  [<setter>]
 ```
 
 The initializer, getter and setter are optional. Property type is optional if it can be inferred from the initializer or from the base class member being overridden.


### PR DESCRIPTION
Aren't getter and setter optional? Probably having square brackets around it in the full syntax could be better?