### PR TITLE
Fixing Kotlin Example that shows Java Code

### DIFF
--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -65,7 +65,7 @@ So it results into this kind of code all over the place:
 try {
   log.append(message)
 }
-catch (IOException e) {
+catch (e: IOException) {
   // Must be safe
 }
 ```


### PR DESCRIPTION
Catch block was in Java format instead of Kotlin