### PR TITLE
clarified that `invoke` may be used without parameters

### DIFF
--- a/docs/reference/operator-overloading.md
+++ b/docs/reference/operator-overloading.md
@@ -98,6 +98,7 @@ Square brackets are translated to calls to `get` and `set` with appropriate numb
 
 | Symbol | Translated to |
 |--------|---------------|
+| `a()`  | `a.invoke()` |
 | `a(i)`  | `a.invoke(i)` |
 | `a(i, j)`  | `a.invoke(i, j)` |
 | `a(i_1, ...,  i_n)`  | `a.invoke(i_1, ...,  i_n)` |


### PR DESCRIPTION
Not sure, but may be worth it to mention that `get` and `set` have at least one parameter. 