### PR TITLE
Add class member references in Kotlin but not in Scala

### DIFF
--- a/docs/reference/comparison-to-scala.md
+++ b/docs/reference/comparison-to-scala.md
@@ -42,3 +42,4 @@ Taking this into account, if you are happy with Scala, you most likely do not ne
 * [Smart casts](typecasts.html)
 * [Kotlin's Inline functions facilitate Nonlocal jumps](inline-functions.html#inline-functions)
 * [First-class delegation](delegation.html). Also implemented via 3rd party plugin: Autoproxy
+* [Class member references](reflection.html). Also supported in Java 8, but not in Scala


### PR DESCRIPTION
For the Scala vs Kotlin comparison: https://kotlinlang.org/docs/reference/comparison-to-scala.html
A feature in Kotlin that Scala doesn't have.