### PR TITLE
added "Kotlin tour" section

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,6 +12,16 @@ Provides a complete reference to Kotlin
 * *Interop*: What you need to know about interoperability with Java and JavaScript.
 * *FAQ*: Every question you could possibly think of, might be answered.
 
+### Kotlin tour
+This refference is designed for you to easily learn Kotlin in a matter of hours.
+Start with [basic syntax](basic-syntax.html), then proceed to more advanced topics. 
+Combine the reading with some first-hand experience in the [online IDE](http://try.kotlinlang.org/). 
+
+After you grasp a fealing of what Kotlin is, try yourself in solving [some Kotlin Koans](/docs/tutorials/koans.html). 
+If you are not sure how to solve a Koan, or you seek a more elegant solution, check out [Kotlin idioms](idioms.html).
+
+Have a question, or just want to say "Hi"? Join our [Kotlin community](/community.html)!
+
 ### Browse offline
 You can download the entire reference documentation as a single [PDF file]({{ site.pdf_url }}).
 


### PR DESCRIPTION
As was rightfully mentioned here https://medium.com/@elviraw/kotlin-and-ceylon-3ee011125b7d#.7ega2fcy9

 > Ceylon has a very nice Tour to get you started. Kotlin, not so much.

I personally think that the kotlin documentation in its current state is very good at "touring" a beginner through the kotlin language. So the problem here IMHO is it that many people do not read the reference through. I assume this happens because they think it is boring and takes a lot of time. The section I wrote is meant to solve the problem by attracting their attention and point the beginners to reading the reference.