### PR TITLE
Fixed typo with arrayOf

### DIFF
--- a/docs/reference/generics.md
+++ b/docs/reference/generics.md
@@ -191,7 +191,7 @@ fun copy(from: Array<Any>, to: Array<Any>) {
 This function is supposed to copy items from one array to another. Let's try to apply it in practice:
 
 ``` kotlin
-val ints: Array<Int> = array(1, 2, 3)
+val ints: Array<Int> = arrayOf(1, 2, 3)
 val any = Array<Any>(3)
 copy(ints, any) // Error: expects (Array<Any>, Array<Any>)
 ```

--- a/docs/reference/java-interop.md
+++ b/docs/reference/java-interop.md
@@ -226,7 +226,7 @@ javaObj.removeIndices(array)  // passes int[] to method
 When compiling to JVM byte codes, the compiler optimizes access to arrays so that there's no overhead introduced:
 
 ``` kotlin
-val array = array(1, 2, 3, 4)
+val array = arrayOf(1, 2, 3, 4)
 array[x] = array[x] * 2 // no actual calls to get() and set() generated
 for (x in array) // no iterator created
   print(x)


### PR DESCRIPTION
Incorrect init method: array() instead of arrayOf()