### PR TITLE
Fix mistakes and remove subjective opinions in Comparison to Scala for fair comarison.

### DIFF
--- a/docs/reference/comparison-to-scala.md
+++ b/docs/reference/comparison-to-scala.md
@@ -7,39 +7,33 @@ title: "Comparison to Scala"
 
 # Comparison to Scala
 
-The main goal of the Kotlin team is to create a pragmatic and productive programming language, rather than to advance the state of the art in programming language research.
+The main goal of the Kotlin team is to create a pragmatic and productive programming language.
 Taking this into account, if you are happy with Scala, you most likely do not need Kotlin.
 
 ## What Scala has that Kotlin does not
 
-* Implicit conversions, parameters, etc
-    * In Scala, sometimes it's very hard to tell what's happening in your code without using a debugger, because too many implicits get into the picture
+* Implicit conversions, parameters
+    * In Scala, sometimes it's very hard to tell what's happening in your code, because too many implicits get into the picture
     * To enrich your types with functions in Kotlin use [Extension functions](extensions.html).
 * Overridable type members
 * Path-dependent types
 * Macros
 * Existential types
-    * [Type projections](generics.html#type-projections) are a very special case
-* Complicated logic for initialization of traits
-    * See [Classes and Inheritance](classes.html)
-* Custom symbolic operations
+    * [Type projections](generics.html#type-projections) are a special case
+* Custom symbolic operators
     * See [Operator overloading](operator-overloading.html)
 * Built-in XML
     * See [Type-safe Groovy-style builders](type-safe-builders.html)
 * Structural types
 * Value types
-    * We plan to support [Project Valhalla](http://openjdk.java.net/projects/valhalla/) once it is released as part of the JDK
-* Yield operator
-* Actors
-    * Kotlin supports [Quasar](http://www.paralleluniverse.co/quasar/), a third-party framework for actor support on the JVM
 * Parallel collections
     * Kotlin supports Java 8 streams, which provide similar functionality
 
 ## What Kotlin has that Scala does not
 
 * [Zero-overhead null-safety](null-safety.html)
-    * Scala has Option, which is a syntactic and run-time wrapper
+    * Scala has Option, which is just a first-class value in Scala
 * [Smart casts](typecasts.html)
 * [Kotlin's Inline functions facilitate Nonlocal jumps](inline-functions.html#inline-functions)
-* [First-class delegation](delegation.html). Also implemented via 3rd party plugin: Autoproxy
-* [Member references](reflection.html#function-references) (also supported in Java 8).
+* [function type with receiver](type-safe-builders.html)
+* [First-class delegation](delegation.html)

--- a/docs/reference/comparison-to-scala.md
+++ b/docs/reference/comparison-to-scala.md
@@ -23,7 +23,6 @@ Taking this into account, if you are happy with Scala, you most likely do not ne
 * Custom symbolic operators
     * See [Operator overloading](operator-overloading.html)
 * Built-in XML
-    * See [Type-safe Groovy-style builders](type-safe-builders.html)
 * Structural types
 * Value types
 * Parallel collections


### PR DESCRIPTION
I would like to fix (many) mistakes and correct unfair comparison. 

> rather than to advance the state of the art in programming language research.

Its' not correct.  Scala is **not** a language to **advance the state of the art  in programming language research** but a **pragmatic** language.  As witness, there are many Scala users in industry.

> Implicit conversions, parameters, etc

Why did you use a word like `etc`?  I removed the word `etc` from this sentence.
    
> In Scala, sometimes it’s very hard to tell what’s happening in your code without using a debugger, because too many implicits get into the picture
    
Because implicit conversions and parameters are resolved in compile time, the debugger is useless in such a case.      

> Complicated logic for initialization of traits

It's only your subjective opinions.  You should write facts.

> Yield operator
    
Scala has no 'yield' operator(`yield` is just a keyword used in for-expression.

> See Type-safe Groovy-style builders

Kotlin's Type-safe Groovy-style builders are not features but just techniques using function type with receiver.  It's moved to list item 'function type with receiver', which is a correct feature in Kotlin.
    
> We plan to support [Project Valhalla](http://openjdk.java.net/projects/valhalla/) once it is released as part of the JDK
    
In serious comparison to actual language, a word such as `plan` should not be used.  And project Valhalla is just a vapor ware now yet.

> Actors

Scala no longer has Actor library in the standard library(Scala 2.11).  [Akka](http://akka.io/) is defato standard Actor library in Scala.

> Member references

Scala has member references. See below:

```scala
def  isOdd(x: Int) = x % 2 != 0
val numbers = List(1, 2, 3)
println(numbers.filter(isOdd _)) // prints List(1, 3)
```

> Also implemented via 3rd party plugin: Autoproxy

Autoproxy is obsolete because few people used it.
