### PR TITLE
Substituting type `E` for `T` as, `T` is used throughout the page

### DIFF
--- a/docs/reference/generics.md
+++ b/docs/reference/generics.md
@@ -49,8 +49,8 @@ interface. What's the signature of this method? Intuitively, we'd put it this wa
 
 ``` java
 // Java
-interface Collection<E> ... {
-  void addAll(Collection<E> items);
+interface Collection<T> ... {
+  void addAll(Collection<T> items);
 }
 ```
 
@@ -71,8 +71,8 @@ That's why the actual signature of `addAll()` is the following:
 
 ``` java
 // Java
-interface Collection<E> ... {
-  void addAll(Collection<? extends E> items);
+interface Collection<T> ... {
+  void addAll(Collection<? extends T> items);
 }
 ```
 


### PR DESCRIPTION
Second fixed entry, where `? extends E` is substituted with `? extends T` is not just for overall conciseness, but also due to the explanation after corresponding code example, where `? extends T` is used.