### PR TITLE
add trimMargin() example to basic-types.md

### DIFF
--- a/docs/reference/basic-types.md
+++ b/docs/reference/basic-types.md
@@ -245,6 +245,18 @@ val text = """
 """
 ```
 
+You can remove leading whitespace with [`trimMargin()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/trim-margin.html) function:
+
+```
+val text = """
+    |Tell me and I forget. 
+    |Teach me and I remember. 
+    |Involve me and I learn.
+    |(Benjamin Franklin)
+    """.trimMargin()
+```
+
+By default `|` is used as margin prefix, but you can choose another character and pass it as a parameter, like `trimMargin(">")`.
 
 ### String Templates
 


### PR DESCRIPTION
Explain trimMargin with an example. This is an important function to make multiline strings useful.