### PR TITLE
Fix wrong name in Collections/map example

### DIFF
--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -70,6 +70,6 @@ Maps follow the same pattern. They can be easily instantiated and accessed like 
 
 ``` kotlin
 val readWriteMap = hashMapOf("foo" to 1, "bar" to 2)
-println(map["foo"])
+println(readWriteMap["foo"])
 val snapshot: Map<String, Int> = HashMap(readWriteMap)
 ```


### PR DESCRIPTION
Small typographic error in Map usage sample: 'map' should be 'readWriteMap'