### PR TITLE
Add maven example without using process-sources

### DIFF
--- a/docs/reference/using-maven.md
+++ b/docs/reference/using-maven.md
@@ -84,48 +84,46 @@ In maven terms that means kotlin-maven-plugin should be run before maven-compile
 
 ``` xml
 <plugin>
-	<artifactId>kotlin-maven-plugin</artifactId>
-	<groupId>org.jetbrains.kotlin</groupId>
-	<version>${kotlin.version}</version>
-	<executions>
-		<execution>
-			<id>compile</id>
-			<goals>	<goal>compile</goal> </goals>
-		</execution>
-		<execution>
-			<id>test-compile</id>
-			<goals>
-				<goal>test-compile</goal>
-			</goals>
-		</execution>
-	</executions>
+    <artifactId>kotlin-maven-plugin</artifactId>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <version>${kotlin.version}</version>
+    <executions>
+        <execution>
+            <id>compile</id>
+                <goals> <goal>compile</goal> </goals>
+        </execution>
+        <execution>
+            <id>test-compile</id>
+            <goals> <goal>test-compile</goal> </goals>
+        </execution>
+    </executions>
 </plugin>
 <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>3.5.1</version>
-	<executions>
-		<!-- Replacing default-compile as it is treated specially by maven -->
-		<execution>
-			<id>default-compile</id>
-			<phase>none</phase>
-		</execution>
-		<!-- Replacing default-testCompile as it is treated specially by maven -->
-		<execution>
-			<id>default-testCompile</id>
-			<phase>none</phase>
-		</execution>
-		<execution>
-			<id>java-compile</id>
-			<phase>compile</phase>
-			<goals> <goal>compile</goal> </goals>
-		</execution>
-		<execution>
-			<id>java-test-compile</id>
-			<phase>test-compile</phase>
-			<goals> <goal>testCompile</goal> </goals>
-		</execution>
-	</executions>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <version>3.5.1</version>
+    <executions>
+        <!-- Replacing default-compile as it is treated specially by maven -->
+        <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+        </execution>
+        <!-- Replacing default-testCompile as it is treated specially by maven -->
+        <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+        </execution>
+        <execution>
+            <id>java-compile</id>
+            <phase>compile</phase>
+            <goals> <goal>compile</goal> </goals>
+        </execution>
+        <execution>
+            <id>java-test-compile</id>
+            <phase>test-compile</phase>
+            <goals> <goal>testCompile</goal> </goals>
+        </execution>
+    </executions>
 </plugin>
 ```
 
@@ -135,17 +133,17 @@ To create a small Jar file containing just the code from your module, include th
 
 ``` xml
 <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-jar-plugin</artifactId>
-	<version>2.6</version>
-	<configuration>
-		<archive>
-			<manifest>
-				<addClasspath>true</addClasspath>
-				<mainClass>${main.class}</mainClass>
-			</manifest>
-		</archive>
-	</configuration>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+    <version>2.6</version>
+    <configuration>
+        <archive>
+            <manifest>
+                <addClasspath>true</addClasspath>
+                <mainClass>${main.class}</mainClass>
+            </manifest>
+        </archive>
+    </configuration>
 </plugin>
 ```
 
@@ -155,26 +153,26 @@ To create a self-contained Jar file containing the code from your module along w
 
 ``` xml
 <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-assembly-plugin</artifactId>
-	<version>2.6</version>
-	<executions>
-		<execution>
-			<id>make-assembly</id>
-			<phase>package</phase>
-			<goals> <goal>single</goal>	</goals>
-			<configuration>
-				<archive>
-					<manifest>
-						<mainClass>${main.class}</mainClass>
-					</manifest>
-				</archive>
-				<descriptorRefs>
-					<descriptorRef>jar-with-dependencies</descriptorRef>
-				</descriptorRefs>
-			</configuration>
-		</execution>
-	</executions>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-assembly-plugin</artifactId>
+    <version>2.6</version>
+    <executions>
+        <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals> <goal>single</goal>	</goals>
+            <configuration>
+                <archive>
+                    <manifest>
+                        <mainClass>${main.class}</mainClass>
+                    </manifest>
+                </archive>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+            </configuration>
+        </execution>
+    </executions>
 </plugin>
 ```
 

--- a/docs/reference/using-maven.md
+++ b/docs/reference/using-maven.md
@@ -172,7 +172,7 @@ To create a self-contained Jar file containing the code from your module along w
         <execution>
             <id>make-assembly</id>
             <phase>package</phase>
-            <goals> <goal>single</goal>	</goals>
+            <goals> <goal>single</goal> </goals>
             <configuration>
                 <archive>
                     <manifest>

--- a/docs/reference/using-maven.md
+++ b/docs/reference/using-maven.md
@@ -80,30 +80,108 @@ The Kotlin Maven Plugin needs to be referenced to compile the sources:
 ## Compiling Kotlin and Java sources
 
 To compile mixed code applications Kotlin compiler should be invoked before Java compiler.
-In maven terms that means kotlin-maven-plugin should be run before maven-compiler-plugin.
-
-It could be done by moving Kotlin compilation to previous phase, process-sources (feel free to suggest a better solution if you have one):
+In maven terms that means kotlin-maven-plugin should be run before maven-compiler-plugin using the following method, making sure that the kotlin plugin is above the maven-compiler-plugin in your pom.xml file.
 
 ``` xml
 <plugin>
-    <artifactId>kotlin-maven-plugin</artifactId>
-    <groupId>org.jetbrains.kotlin</groupId>
-    <version>${kotlin.version}</version>
-
-    <executions>
-        <execution>
-            <id>compile</id>
-            <phase>process-sources</phase>
-            <goals> <goal>compile</goal> </goals>
-        </execution>
-
-        <execution>
-            <id>test-compile</id>
-            <phase>process-test-sources</phase>
-            <goals> <goal>test-compile</goal> </goals>
-        </execution>
-    </executions>
+	<artifactId>kotlin-maven-plugin</artifactId>
+	<groupId>org.jetbrains.kotlin</groupId>
+	<version>${kotlin.version}</version>
+	<executions>
+		<execution>
+			<id>compile</id>
+			<goals>	<goal>compile</goal> </goals>
+		</execution>
+		<execution>
+			<id>test-compile</id>
+			<goals>
+				<goal>test-compile</goal>
+			</goals>
+		</execution>
+	</executions>
 </plugin>
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-compiler-plugin</artifactId>
+	<version>3.5.1</version>
+	<executions>
+		<!-- Replacing default-compile as it is treated specially by maven -->
+		<execution>
+			<id>default-compile</id>
+			<phase>none</phase>
+		</execution>
+		<!-- Replacing default-testCompile as it is treated specially by maven -->
+		<execution>
+			<id>default-testCompile</id>
+			<phase>none</phase>
+		</execution>
+		<execution>
+			<id>java-compile</id>
+			<phase>compile</phase>
+			<goals> <goal>compile</goal> </goals>
+		</execution>
+		<execution>
+			<id>java-test-compile</id>
+			<phase>test-compile</phase>
+			<goals> <goal>testCompile</goal> </goals>
+		</execution>
+	</executions>
+</plugin>
+```
+
+## Jar file
+
+To create a small Jar file containing just the code from your module, include the following under build->plugins in your Maven pom.xml file, where main.class is defined as a property and points to the main Kotlin or Java class.
+
+``` xml
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-jar-plugin</artifactId>
+	<version>2.6</version>
+	<configuration>
+		<archive>
+			<manifest>
+				<addClasspath>true</addClasspath>
+				<mainClass>${main.class}</mainClass>
+			</manifest>
+		</archive>
+	</configuration>
+</plugin>
+```
+
+## Self-contained Jar file
+
+To create a self-contained Jar file containing the code from your module along with dependencies, include the following under build->plugins in your Maven pom.xml file, where main.class is defined as a property and points to the main Kotlin or Java class.
+
+``` xml
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-assembly-plugin</artifactId>
+	<version>2.6</version>
+	<executions>
+		<execution>
+			<id>make-assembly</id>
+			<phase>package</phase>
+			<goals> <goal>single</goal>	</goals>
+			<configuration>
+				<archive>
+					<manifest>
+						<mainClass>${main.class}</mainClass>
+					</manifest>
+				</archive>
+				<descriptorRefs>
+					<descriptorRef>jar-with-dependencies</descriptorRef>
+				</descriptorRefs>
+			</configuration>
+		</execution>
+	</executions>
+</plugin>
+```
+
+This self-contained jar file can be passed directly to a JRE to run your application:
+
+``` bash
+java -jar target\mymodule-0.0.1-SNAPSHOT-jar-with-dependencies.jar
 ```
 
 ## OSGi

--- a/docs/reference/using-maven.md
+++ b/docs/reference/using-maven.md
@@ -90,11 +90,23 @@ In maven terms that means kotlin-maven-plugin should be run before maven-compile
     <executions>
         <execution>
             <id>compile</id>
-                <goals> <goal>compile</goal> </goals>
+            <goals> <goal>compile</goal> </goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                    <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                </sourceDirs>
+            </configuration>
         </execution>
         <execution>
             <id>test-compile</id>
             <goals> <goal>test-compile</goal> </goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                    <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                </sourceDirs>
+            </configuration>
         </execution>
     </executions>
 </plugin>


### PR DESCRIPTION
Adds a maven example that doesn't require the process-sources hack by switching off the default-compile and default-testCompile targets that are treated specially by maven.

Also add examples of maven configurations that will generate the two types of Jar file, a minimal and a self-contained Jar file.
