### PR TITLE
Added Datawire to Companies and OSS Projects Data

### DIFF
--- a/_data/companies-using-kotlin.yml
+++ b/_data/companies-using-kotlin.yml
@@ -1,7 +1,11 @@
 - company: JetBrains
   url: http://www.jetbrains.com/
   description: IntelliJ IDEA plugins, YouTrack vNext, CRM apps, new products etc.
-
+  
+- company: Datawire
+  url: https://datawire.io/
+  description: Using Kotlin for Datawire Discovery and other back end services.
+  
 - company: Industrial Geodetic Systems
   url: http://hive.geosystems.aero/?locale=en
   description: Using Kotlin for the Front-End Web

--- a/_data/oss-projects.yml
+++ b/_data/oss-projects.yml
@@ -1,3 +1,8 @@
+- name: Discovery
+  description: Eventually consistent service discovery server
+  type: Application
+  link: https://github.com/datawire/discovery
+
 - name: Spek
   description: A Specification Framework
   type: Library


### PR DESCRIPTION
Hello!

Datawire (https://datawire.io) is using Kotlin and has been doing so since the beta releases. We're excited to continue growing our usage over time. I have updated the companies-using-kotlin.yml and oss-projects.yml to include us.

Cheers,
Phil