### PR TITLE
added about overriding default parameters

### DIFF
--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -75,7 +75,7 @@ fun read(b: Array<Byte>, off: Int = 0, len: Int = b.size()) {
 }
 ```
 
-Default values are defined using the **=** after type along with the value. Default values can not be changed in an overriging method.
+Default values are defined using the **=** after type along with the value. Default values can not be changed in an overriding method.
 
 ### Named Arguments
 

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -75,7 +75,7 @@ fun read(b: Array<Byte>, off: Int = 0, len: Int = b.size()) {
 }
 ```
 
-Default values are defined using the **=** after type along with the value.
+Default values are defined using the **=** after type along with the value. Default values can not be changed in an overriging method.
 
 ### Named Arguments
 


### PR DESCRIPTION
see http://stackoverflow.com/questions/37700828/why-is-it-possible-to-omit-default-values-in-overridden-member-functions-of-sub/37701185?noredirect=1#comment62876675_37701185