### PR TITLE
Object expressions example code does not compile

### DIFF
--- a/docs/reference/object-declarations.md
+++ b/docs/reference/object-declarations.md
@@ -38,7 +38,7 @@ open class A(x: Int) {
 
 interface B {...}
 
-val ab = object : A(1), B {
+val ab: A = object : A(1), B {
   override val y = 15
 }
 ```


### PR DESCRIPTION
I'm using Intellij 2016.1.2, kotlin plugin 1.0.3-release-IJ2016.1-103
The example code on this site did not compile. I got "Error:(11, 1) Kotlin: Right-hand side has anonymous type. Please specify type explicitly".

The type of "val ab" could not be deferred automatically, so a type for it had to be declared.