### PR TITLE
added github-edit-link to docs-page

### DIFF
--- a/_layouts/docs-page.html
+++ b/_layouts/docs-page.html
@@ -5,4 +5,6 @@ main_nav_id: docs
 
 {% include nav/docs-nav.html active=page.docs_nav_id %}
 
+{% include edit-on-github-link.html %}
+
 {{ content }}


### PR DESCRIPTION
This should add a link to **Edit** on github to pages like https://kotlinlang.org/docs/events.html>
I suppose it will go to https://github.com/JetBrains/kotlin-web-site/blob/master/_data/events.yml

I need this link every time I want to add a video to the page :(