### PR TITLE
Remove built-in XML

### DIFF
--- a/docs/reference/comparison-to-scala.md
+++ b/docs/reference/comparison-to-scala.md
@@ -24,8 +24,6 @@ Taking this into account, if you are happy with Scala, you most likely do not ne
     * See [Classes and Inheritance](classes.html)
 * Custom symbolic operations
     * See [Operator overloading](operator-overloading.html)
-* Built-in XML
-    * See [Type-safe Groovy-style builders](type-safe-builders.html)
 * Structural types
 * Value types
     * We plan to support [Project Valhalla](http://openjdk.java.net/projects/valhalla/) once it is released as part of the JDK


### PR DESCRIPTION
XML support has been removed from the core and was made optional, pending deprecation and replacement with string interpolation.