### PR TITLE
Fix code highlighting

### DIFF
--- a/docs/tutorials/android-plugin.md
+++ b/docs/tutorials/android-plugin.md
@@ -45,7 +45,7 @@ Android Extensions is a part of the Kotlin IDEA plugin. You do not need to insta
 
 All you need is to enable the Android Extensions Gradle plugin in your project-local `build.gradle` file:
 
-```
+``` groovy
 apply plugin: 'kotlin-android-extensions'
 ```
 


### PR DESCRIPTION
Code block to config plugin don't have the background on https://kotlinlang.org/docs/tutorials/android-plugin.html. But it has background on github preview. So I hope that specifying language can solve the issue.