### PR TITLE
Add Glimpse Framework

### DIFF
--- a/_data/oss-projects.yml
+++ b/_data/oss-projects.yml
@@ -227,3 +227,8 @@
   description: REST framework in pure Kotlin
   type: Library
   link: https://github.com/gimlet2/kottpd
+
+- name: Glimpse Framework
+  description: An OpenGL framework written in Kotlin
+  type: Framework
+  link: https://github.com/GlimpseFramework/glimpse-framework


### PR DESCRIPTION
I added another OSS project – Glimpse Framework.
Basic idea behind this project is to make OpenGL easy – for both desktop and Android.
