### PR TITLE
typo

### DIFF
--- a/docs/reference/type-safe-builders.md
+++ b/docs/reference/type-safe-builders.md
@@ -98,7 +98,7 @@ html {
 }
 ```
 
-(`head` and `body` are member functions of `html`.)
+(`head` and `body` are member functions of `HTML`.)
 
 Now, *this*{: .keyword } can be omitted, as usual, and we get something that looks very much like a builder already:
 


### PR DESCRIPTION
head and body are members of the HTML class, not the html function, obviously... (see here: https://kotlinlang.org/docs/reference/type-safe-builders.html#declarations)