### PR TITLE
Update Android Studio tutorial to mention plugin

### DIFF
--- a/pages/docs/tutorials/kotlin-android.md
+++ b/pages/docs/tutorials/kotlin-android.md
@@ -42,6 +42,8 @@ you can write it in Java, then copy-paste Java code into Kotlin file, and Intell
 
 #### Converting Java code to Kotlin
 
+First, if using Android Studio, you'll need to install the Kotlin plugin. Go to _File \| Settings \| Plugins \| Install JetBrains plugin..._ and then search for and install *Kotlin*. You'll need to restart the IDE after this completes.
+
 Open MainActivity.java file. Then invoke action **Convert Java File to Kotlin File**. You can do it by several ways.
 The easiest one is to invoke [Find Action](https://www.jetbrains.com/idea/help/navigating-to-action.html) and start typing an action name (like in a screencast below). 
 Alternatively we can call this option via the _Code \| Convert Java File to Kotlin File_  menu entry or by using the corresponding shortcut (we can find it at the menu entry).


### PR DESCRIPTION
Android Studio doesn't come with the Kotlin plugin. It must be manually installed, which the docs will now call out.
