### PR TITLE
Add required parens for == translation.

### DIFF
--- a/pages/docs/reference/operator-overloading.md
+++ b/pages/docs/reference/operator-overloading.md
@@ -127,8 +127,8 @@ For the assignment operations, e.g. `a += b`, the compiler performs the followin
 
 | Expression | Translated to |
 |------------|---------------|
-| `a == b` | `a?.equals(b) ?: b === null` |
-| `a != b` | `!(a?.equals(b) ?: b === null)` |
+| `a == b` | `a?.equals(b) ?: (b === null)` |
+| `a != b` | `!(a?.equals(b) ?: (b === null))` |
 
 *Note*: `===` and `!==` (identity checks) are not overloadable, so no conventions exist for them
 


### PR DESCRIPTION
Otherwise this fails.
```
    fun eq(a: Any?, b: Any?): Boolean {
        return a?.equals(b) ?: b === null
    }

    @Test fun testEquals() {
        assertTrue(eq("a", "a"))
    }
```