### PR TITLE
Clarify use of lambda expression outside of function invocation parentheses

### DIFF
--- a/pages/docs/reference/lambdas.md
+++ b/pages/docs/reference/lambdas.md
@@ -48,7 +48,8 @@ Lambda expressions are described in more [detail below](#lambda-expressions-and-
 * Its parameters (if any) are declared before `->` (parameter types may be omitted),
 * The body goes after `->` (when present).
 
-In Kotlin, there is a convention that if the last parameter to a function is a function, that parameter can be specified outside of the parentheses:
+In Kotlin, there is a convention that if the last parameter to a function is a function, that parameter can be specified outside of the parentheses,
+but only if a lambda expression is provided to it:
 
 ``` kotlin
 lock (lock) {


### PR DESCRIPTION
Hi Kotlin website team,

I found an ambiguity regarding the ability to put lambda expressions outside of function invocation parentheses.

The original text read as if the following is possible:

```kotlin
fun fn1(): Int = 1 + 1
fun fn2(x: Int, fn: () -> Int): Int = x + fn()

// This is OK
fn2 (3) { 2 + 2 }

// This is not OK, but original text might make human readers perceive as possible.
fn2 (3) ::fn1
```

I have fixed the ambiguous part, to make it more obvious that only lambda expressions can be allowed outside of such parentheses.