### PR TITLE
Additional explaination of overriding properties

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -195,7 +195,7 @@ to inherit from this class. By default, all classes in Kotlin are final, which
 corresponds to [Effective Java](http://www.oracle.com/technetwork/java/effectivejava-136174.html),
 Item 17: *Design and document for inheritance or else prohibit it*.
 
-### Overriding Members
+### Overriding Methods
 
 As we mentioned before, we stick to making things explicit in Kotlin. And unlike Java, Kotlin requires explicit
 annotations for overridable members (we call them *open*) and for overrides:
@@ -222,21 +222,34 @@ open class AnotherDerived() : Base() {
 }
 ```
 
-Overriding properties works in a similar way to overriding methods.
-Note that you can use the `override` keyword as part of the property declaration in a primary constructor:
+### Overriding Properties 
+
+Overriding properties works in a similar way to overriding methods; properties declared on a superclass that are then redeclared on a derived class must be prefaced with *override*{: .keyword }, and they must have a compatible type. Each declared property can be overridden by a property with an initializer or by a property with a getter method.
 
 ``` kotlin
 open class Foo {
     open val x: Int get { ... }
 }
 
-class Bar1(override val x: Int) : Foo() {
-
+class Bar1: Foo {
+    override val x: Int = ...
 }
 ```
 
-You can also override a `val` property with a `var` property, but not vice versa.
-This is allowed because a `val` property essentially declares a getter method, and overriding it as a `var` additionally declares a setter method in the derived class.
+You can also override a `val` property with a `var` property, but not vice versa. This is allowed because a `val` property essentially declares a getter method, and overriding it as a `var` additionally declares a setter method in the derived class.
+
+Note that you can use the override keyword as part of the property declaration in a primary constructor.
+
+``` kotlin 
+interface Foo {
+    val count: Int
+}
+
+class Bar1(override val count: Int) : Foo()
+class Bar2: Foo() {
+    override var count: Int = 0.0
+}
+```
 
 ### Overriding Rules
 


### PR DESCRIPTION
I feel that the properties section could use expansion. I understand its syntactic sugar to us but to many kotlin users it is likely to be an important feature.

My use-case was in trying to explain to a colleague why creating a kotlin interface with `fun getThingies(): Thingies` was a bad idea, and that he should instead put `val thingies: Thingies` on his interface. I wanted to refer him to the kotlin lang docs, but was a little disappointed with what is here right now, so I figured I would suggest these changes.

My main goal was to explain how properties can be overriden, and some of the specifics around syntax for it. I think this syntax is fairly intuitive, but was not intuitive enough for my afforementioned collegue. In this sense, a few extra words elaborating on the subject I think are warrented. 

My phrase `compatible type` is in reference to covariance on getters. I'm not sure this is a topic worth even mentioning here, but I thought the phrase `same type` would simply incorrect. 

please note: several links will probably need updating,
- this breaks all links to `overriding members`. I think this is worth it because trying to differentiate between methods and properties is likely a disservice. If backwards compatibility is hotly desired it would not be hard to create a 3-# section `overriding members` with two 4-# sections `overriding methods` and `overriding properties`
- https://kotlinlang.org/docs/reference/properties.html#overriding-properties should point to this new section.