### PR TITLE
fix heading levels of generics.md

### DIFF
--- a/pages/docs/reference/generics.md
+++ b/pages/docs/reference/generics.md
@@ -242,7 +242,7 @@ For example, if the type is declared as `interface Function<in T, out U>` we can
 
 *Note*: star-projections are very much like Java's raw types, but safe.
 
-# Generic functions
+## Generic functions
 
 Not only classes can have type parameters. Functions can, too. Type parameters are placed before the name of the function:
 
@@ -262,11 +262,11 @@ To call a generic function, specify the type arguments at the call site **after*
 val l = singletonList<Int>(1)
 ```
 
-# Generic constraints
+## Generic constraints
 
 The set of all possible types that can be substituted for a given type parameter may be restricted by **generic constraints**.
 
-## Upper bounds
+### Upper bounds
 
 The most common type of constraint is an **upper bound** that corresponds to Java's *extends* keyword:
 


### PR DESCRIPTION
Fix issue as the followed snapshot that "Generic functions" & "Generic constraints" should be sub-headings of "Generic" in the TOC of the PDF. While currently they are in same level.

![headinglevels-generic](https://cloud.githubusercontent.com/assets/3896345/21668635/b77879fc-d33e-11e6-91b3-39a768a26678.png)
