### PR TITLE
Update Chicago Kotlin Users Group URL

### DIFF
--- a/pages/community/user-groups.md
+++ b/pages/community/user-groups.md
@@ -34,7 +34,7 @@
 
 * [Bay Area Kotlin User Group](http://www.meetup.com/Bay-Area-Kotlin-User-Group/), USA
 * [Boulder Kotlin Group](http://www.meetup.com/Kotlin-Group-Boulder/), USA
-* [Chicago Kotlin Users Group](http://www.meetup.com/Chicago-Kotlin-Users-Group/), USA
+* [Chicago Kotlin Users Group](http://www.meetup.com/Chicago-Kotlin/), USA
 * [New York Kotlin Meetup](http://www.meetup.com/New-York-Kotlin-Meetup/), USA
 * [Toronto Kotlin](https://www.meetup.com/Kotlin-Toronto/events/235740293/), Canada
 * [San Paolo Kotlin Meetup](https://www.meetup.com/kotlin-meetup-sp/), Brazil 


### PR DESCRIPTION
We had to recreate the Chicago Kotlin Users Group, since, while I was out on vacation, the meetup group expired. Unfortunately, Meetup support has not been responsive, so I created a new Meetup and will be re-inviting all the old members. So, I had to update the url for the meetup group.