### PR TITLE
Fix hash references in all articles

### DIFF
--- a/pages/docs/reference/comparison-to-java.md
+++ b/pages/docs/reference/comparison-to-java.md
@@ -13,7 +13,7 @@ Kotlin fixes a series of issues that Java suffers from
 
 * Null references are [controlled by the type system](null-safety.html).
 * [No raw types](java-interop.html)
-* Arrays in Kotlin are [invariant](basic-types.html#Arrays)
+* Arrays in Kotlin are [invariant](basic-types.html#arrays)
 * Kotlin has proper [function types](lambdas.html#function-types), as opposed to Java's SAM-conversions
 * [Use-site variance](generics.html#use-site-variance-type-projections) without wildcards
 * Kotlin does not have checked [exceptions](exceptions.html)

--- a/pages/docs/reference/java-interop.md
+++ b/pages/docs/reference/java-interop.md
@@ -128,7 +128,7 @@ You can find the full list in the [Kotlin compiler source code](https://github.c
 
 Kotlin treats some Java types specially. Such types are not loaded from Java "as is", but are _mapped_ to corresponding Kotlin types.
 The mapping only matters at compile time, the runtime representation remains unchanged.
- Java's primitive types are mapped to corresponding Kotlin types (keeping [platform types](#platform-types) in mind):
+ Java's primitive types are mapped to corresponding Kotlin types (keeping [platform types](#null-safety-and-platform-types) in mind):
 
 | **Java type** | **Kotlin type**  |
 |---------------|------------------|
@@ -208,7 +208,7 @@ if (a is List<*>) // OK: no guarantees about the contents of the list
 
 Arrays in Kotlin are invariant, unlike Java. This means that Kotlin does not let us assign an `Array<String>` to an `Array<Any>`,
 which prevents a possible runtime failure. Passing an array of a subclass as an array of superclass to a Kotlin method is also prohibited,
-but for Java methods this is allowed (through [platform types](#platform-types) of the form `Array<(out) String>!`).
+but for Java methods this is allowed (through [platform types](#null-safety-and-platform-types) of the form `Array<(out) String>!`).
 
 Arrays are used with primitive datatypes on the Java platform to avoid the cost of boxing/unboxing operations.
 As Kotlin hides those implementation details, a workaround is required to interface with Java code.

--- a/pages/docs/reference/lambdas.md
+++ b/pages/docs/reference/lambdas.md
@@ -179,7 +179,7 @@ ints.filter {
 
 Note that if a function takes another function as the last parameter, the lambda expression argument can be passed
 outside the parenthesized argument list.
-See the grammar for [callSuffix](grammar.html#call-suffix).
+See the grammar for [callSuffix](grammar.html#callSuffix).
 
 ### Anonymous Functions
 

--- a/pages/docs/reference/returns.md
+++ b/pages/docs/reference/returns.md
@@ -16,7 +16,7 @@ Kotlin has three structural jump operators
 ## Break and Continue Labels
 
 Any expression in Kotlin may be marked with a *label*{: .keyword }.
-Labels have the form of an identifier followed by the `@` sign, for example: `abc@`, `fooBar@` are valid labels (see the [grammar](grammar.html#label)).
+Labels have the form of an identifier followed by the `@` sign, for example: `abc@`, `fooBar@` are valid labels (see the [grammar](grammar.html#labelReference)).
 To label an expression, we just put a label in front of it
 
 ``` kotlin

--- a/pages/docs/reference/typecasts.md
+++ b/pages/docs/reference/typecasts.md
@@ -57,7 +57,7 @@ or in the right-hand side of `&&` and `||`:
 ```
 
 
-Such _smart casts_ work for [*when*{: .keyword }-expressions](control-flow.html#when-expressions)
+Such _smart casts_ work for [*when*{: .keyword }-expressions](control-flow.html#when-expression)
 and [*while*{: .keyword }-loops](control-flow.html#while-loops) as well:
 
 ``` kotlin
@@ -80,7 +80,7 @@ More specifically, smart casts are applicable according to the following rules:
 ## "Unsafe" cast operator
 
 Usually, the cast operator throws an exception if the cast is not possible. Thus, we call it *unsafe*.
-The unsafe cast in Kotlin is done by the infix operator *as*{: .keyword } (see [operator precedence](grammar.html#operator-precedence)):
+The unsafe cast in Kotlin is done by the infix operator *as*{: .keyword } (see [operator precedence](grammar.html#precedence)):
 
 ``` kotlin
 val x: String = y as String


### PR DESCRIPTION
I have written a tool to find all missed hash references in all markdown files and then I fixed them after manually verified.
Here are all the fixes.

I will publish the tool as a opensource project a few days later (and post a comment here too).