### PR TITLE
Addition of the word interfaces.

### DIFF
--- a/pages/docs/reference/interfaces.md
+++ b/pages/docs/reference/interfaces.md
@@ -7,7 +7,7 @@ title: "Interfaces"
 
 # Interfaces
 
-Interfaces in Kotlin are very similar to Java 8. They can contain declarations of abstract methods, as well as method
+Interfaces in Kotlin are very similar to Java 8 Interfaces. They can contain declarations of abstract methods, as well as method
 implementations. What makes them different from abstract classes is that interfaces cannot store state. They can have
 properties but these need to be abstract or to provide accessor implementations.
 


### PR DESCRIPTION
To make it read well it should be "Interfaces in Kotlin are very similar to Java 8 Interfaces" . leaving it as it is before makes it not clear what Java 8 it is similar to . Is it Classes ? Generic classes ?