### PR TITLE
Update getting-started-with-gradle.md

### DIFF
--- a/pages/docs/tutorials/javascript/getting-started-gradle/getting-started-with-gradle.md
+++ b/pages/docs/tutorials/javascript/getting-started-gradle/getting-started-with-gradle.md
@@ -78,11 +78,11 @@ In order to specify the module kind, we can add a configuration to our plugin as
 
 ```groovy
 compileKotlin2Js {
-    kotlinOptions.outputFile = "{projectDir}/web/output.js"
+    kotlinOptions.outputFile = "${projectDir}/web/output.js"
     kotlinOptions.moduleKind = "amd"
     kotlinOptions.sourceMap = true
 }
- ```
+```
 
 where `moduleKind` can be
 


### PR DESCRIPTION
Minor issues, but on the website right now, the `compileKotlin2Js` block is not formatted well, and the $ is missing from the `outputFile` path. When I preview the change to the `compileKotlin2Js` block on github, it seems to render fine (before I made my change removing the space before the triple-backtick on line 85) but maybe whatever rendering engine you use doesn't detect it properly, because it looks like this:

<img width="731" alt="screen shot 2017-03-21 at 8 37 06 pm" src="https://cloud.githubusercontent.com/assets/6582067/24177110/a372c5b6-0e76-11e7-827f-1c553c7aacac.png">

At any rate, some friends and I were trying this out at work today, and noticed it so I figured I'd fix it.