### PR TITLE
Fix colon spacing on "Constructor References" example

### DIFF
--- a/pages/docs/reference/reflection.md
+++ b/pages/docs/reference/reflection.md
@@ -188,8 +188,8 @@ that expects a function parameter with no parameters and return type `Foo`:
 ``` kotlin
 class Foo
 
-fun function(factory : () -> Foo) {
-    val x : Foo = factory()
+fun function(factory: () -> Foo) {
+    val x: Foo = factory()
 }
 ```
 


### PR DESCRIPTION
So it corresponds to the rest of this file and https://kotlinlang.org/docs/reference/coding-conventions.html#colon