### PR TITLE
Add Sydney to user groups

### DIFF
--- a/pages/community/user-groups.md
+++ b/pages/community/user-groups.md
@@ -68,6 +68,7 @@
 ### Australia/Oceania
 
 * [Brisbane Kotlin User Group](https://www.meetup.com/Brisbane-Kotlin-User-Group/), Australia
+* [Sydney Kotlin User Group](https://www.meetup.com/sydney-kotlin/), Australia
 * [Wellington Kotlin User Group](https://www.meetup.com/Wellington-kt/), New Zealand
 
 ### Africa


### PR DESCRIPTION
We're starting Sydney Kotlin User Group, adding a link to our Meetup.com page to the community/user-groups page.