### PR TITLE
Code Example: replace call to nonexistent Array.size() with Array.size

### DIFF
--- a/templates/inc/pages/index/code-examples.html
+++ b/templates/inc/pages/index/code-examples.html
@@ -70,7 +70,7 @@
         <!-- code example -->
         <div class="kotlin-overview-code-example is_hidden" id="kotlin-code-example-name-reading">
             <div class="code-line"><div class="code"><span class="keyword">fun</span> <span class="func-name">main</span>(<span class="var-name">args</span>: Array&lt;String&gt;) {
-   <span class="keyword">if</span> (<span class="var-name">args</span>.size() == <span class="number">0</span>) {
+   <span class="keyword">if</span> (<span class="var-name">args</span>.size == <span class="number">0</span>) {
       println(<span class="string-literal">"Provide a name"</span>)
       <span class="keyword">return</span>
    }</div></div>


### PR DESCRIPTION
`Array.size()` has not existed for some time and makes this example confusing.