### PR TITLE
Correct the type to T, not E

### DIFF
--- a/pages/docs/reference/generics.md
+++ b/pages/docs/reference/generics.md
@@ -71,8 +71,8 @@ That's why the actual signature of `addAll()` is the following:
 
 ``` java
 // Java
-interface Collection<E> ... {
-  void addAll(Collection<? extends E> items);
+interface Collection<T> ... {
+  void addAll(Collection<? extends T> items);
 }
 ```
 


### PR DESCRIPTION
The following text speaks about `T` the whole time, not `E`. So I changed the collection type to `T`