### PR TITLE
Minor fix for _nav.yml

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -156,6 +156,7 @@ reference:
 
 
     - title: Core Libraries
+      items:
         - url: /api/latest/jvm/stdlib/index.html
           title: Standard Library
         - url: /api/latest/kotlin.test/index.html


### PR DESCRIPTION
It also need a `description` under `- title: Core Libraries` compared to others.