### PR TITLE
First range example had a backwards chevron

### DIFF
--- a/pages/docs/reference/ranges.md
+++ b/pages/docs/reference/ranges.md
@@ -11,7 +11,7 @@ Range expressions are formed with `rangeTo` functions that have the operator for
 Range is defined for any comparable type, but for integral primitive types it has an optimized implementation. Here are some examples of using ranges
 
 ``` kotlin
-if (i in 1..10) { // equivalent of 1 <= i && i <= 10
+if (i in 1..10) { // equivalent of 1 >= i && i <= 10
     println(i)
 }
 ```


### PR DESCRIPTION
In the first example, it read "i less than or equal to one" instead of "i greater than or equal to one", just flipped it.