### PR TITLE
Fixed small error in the first example's comment

### DIFF
--- a/pages/docs/reference/ranges.md
+++ b/pages/docs/reference/ranges.md
@@ -11,7 +11,7 @@ Range expressions are formed with `rangeTo` functions that have the operator for
 Range is defined for any comparable type, but for integral primitive types it has an optimized implementation. Here are some examples of using ranges
 
 ``` kotlin
-if (i in 1..10) { // equivalent of 1 <= i && i <= 10
+if (i in 1..10) { // equivalent of 1 >= i && i <= 10
     println(i)
 }
 ```


### PR DESCRIPTION
The range `i in 1..10` validates from 1 to 10, however the comment gives the wrong idea.