### PR TITLE
Update link to a new version of Yested framework.

### DIFF
--- a/data/oss-projects.yml
+++ b/data/oss-projects.yml
@@ -81,7 +81,7 @@
 - name: Yested
   description: A Web Framework
   type: Framework
-  link: http://www.yested.net
+  link: https://github.com/jean79/yested_fw
 
 - name: Kotlin-Hashids
   description: Library that generates short, unique, non-sequential hashes from numbers.


### PR DESCRIPTION
Original Yested framework is no longer in the development. It has been replaced by a new version which is being actively developed.