### PR TITLE
show how to map nullable values if not null

### DIFF
--- a/pages/docs/reference/idioms.md
+++ b/pages/docs/reference/idioms.md
@@ -155,6 +155,14 @@ data?.let {
 }
 ```
 
+### Map nullable value if not null
+
+``` kotlin
+val data = ...
+
+val mapped = data?.let { transformData(it) } ?: defaultValueIfDataIsNull
+```
+
 ### Return on when statement
 
 ``` kotlin


### PR DESCRIPTION
An example how to do equivalent of Java’s 
``` java
Mapped mapped = Optional.of(data)
    .map(d -> transformData(d)))
    .orElse(defaultValue);
```
with Kotlin’s nullable reference for chaining.

I had hard time finding how to do this. I believe more examples of what can be achieved using the `let` method would be helpful.