### PR TITLE
"import static" now hyperlink to Java 8 doc

### DIFF
--- a/pages/docs/reference/packages.md
+++ b/pages/docs/reference/packages.md
@@ -76,7 +76,7 @@ The `import` keyword is not restricted to importing classes; you can also use it
   * functions and properties declared in [object declarations](object-declarations.html#object-declarations);
   * [enum constants](enum-classes.html)
 
-Unlike Java, Kotlin does not have a separate "import static" syntax; all of these declarations are imported using the regular `import` keyword.
+Unlike Java, Kotlin does not have a separate ["import static"](https://docs.oracle.com/javase/8/docs/technotes/guides/language/static-import.html) syntax; all of these declarations are imported using the regular `import` keyword.
 
 ## Visibility of Top-level Declarations
 


### PR DESCRIPTION
Added a link to the Oracle Java 8 documentation to be able to look up "import static" quickly. Not sure whether this is desired in the Kotlin documentation.