### PR TITLE
Minor grammatic correction in functions.md

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -29,7 +29,7 @@ val result = double(2)
 Calling member functions uses the dot notation
 
 ``` kotlin
-Sample().foo() // create instance of class Sample and calls foo
+Sample().foo() // create instance of class Sample and call foo
 ```
 
 ### Infix notation


### PR DESCRIPTION
A code snippet in the page about functions had a grammatic error. Correcting it. 