### PR TITLE
Fixed example code typo error

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -265,7 +265,7 @@ open class Foo {
 class Bar : Foo() {
     override fun f() { 
         super.f()
-        println("Bar.f()"} 
+        println("Bar.f()") 
     }
     
     override val x: Int get() = super.x + 1


### PR DESCRIPTION
Typo error: Closing bracket should by parentheses.