### PR TITLE
Add public modifier and final keyword for clarity

### DIFF
--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -125,7 +125,7 @@ class C(id: String) {
 
 ``` java
 // Java
-class JavaClient {
+public final class JavaClient {
     public String getID(C c) {
         return c.ID;
     }


### PR DESCRIPTION
For the sample Java source codes written on `Instance Fields` section to indicate how generated source code from `@JvmField` annotation looks like, I have added `public` visibility modifier and `final` keyword. This is to explicitly indicate that

> The field will have the same visibility as the underlying property.

and also how visibility modifiers in Kotlin work.
https://kotlinlang.org/docs/reference/visibility-modifiers.html#visibility-modifiers