### PR TITLE
Follow convention of using it in lambdas

### DIFF
--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -211,7 +211,7 @@ of each array element given its index:
 
 ``` kotlin
 // Creates an Array<String> with values ["0", "1", "4", "9", "16"]
-val asc = Array(5, { i -> (i * i).toString() })
+val asc = Array(5, { (it * it).toString() })
 ```
 
 As we said above, the `[]` operation stands for calls to member functions `get()` and `set()`.


### PR DESCRIPTION
The convention is to use `it` for lambdas that are short and not nested. The Kotlin docs aren't following this convention though and explicitly declaring them. I propose that we change them according to the convention.

This is only one example, but if you agree I'll update with the others I find when reading through the docs.