### PR TITLE
(for 1.1.50, don't merge yet) Add section about module names

### DIFF
--- a/pages/docs/reference/using-gradle.md
+++ b/pages/docs/reference/using-gradle.md
@@ -207,6 +207,16 @@ kotlin {
 }
 ```
 
+## Module names
+
+The Kotlin modules that the build produces are named accordingly to the `archivesBaseName` property of the project. If a project has a broad name like `lib` or `jvm`, which is common for subprojects, the Kotlin output files related to the module (`*.kotlin_module`) might clash with those from third-party modules with the same name. This causes problems when a project is packaged into a single archive (e.g. APK).
+
+To avoid this, consider setting a unique `archivesBaseName` manually:
+
+``` groovy
+archivesBaseName = 'myExampleProject_lib'
+```
+
 ## Compiler Options
 
 To specify additional compilation options, use the `kotlinOptions` property of a Kotlin compilation task.


### PR DESCRIPTION
Add section about module names that can clash and the way to resolve it with `archivesBaseName`.