### PR TITLE
Fix Java syntax

### DIFF
--- a/pages/docs/reference/extensions.md
+++ b/pages/docs/reference/extensions.md
@@ -266,21 +266,21 @@ And the unpleasant part about these Utils-classes is that the code that uses the
 
 ``` java
 // Java
-Collections.swap(list, Collections.binarySearch(list, Collections.max(otherList)), Collections.max(list))
+Collections.swap(list, Collections.binarySearch(list, Collections.max(otherList)), Collections.max(list));
 ```
 
 Those class names are always getting in the way. We can use static imports and get this:
 
 ``` java
 // Java
-swap(list, binarySearch(list, max(otherList)), max(list))
+swap(list, binarySearch(list, max(otherList)), max(list));
 ```
 
 This is a little better, but we have no or little help from the powerful code completion of the IDE. It would be so much better if we could say
 
 ``` java
 // Java
-list.swap(list.binarySearch(otherList.max()), list.max())
+list.swap(list.binarySearch(otherList.max()), list.max());
 ```
 
 But we don't want to implement all the possible methods inside the class `List`, right? This is where extensions help us.


### PR DESCRIPTION
Semicolons are missing in the Java examples on the extensions page.