### PR TITLE
Using similar convention for referencing variables

### DIFF
--- a/pages/docs/reference/basic-syntax.md
+++ b/pages/docs/reference/basic-syntax.md
@@ -241,7 +241,7 @@ fun printProduct(arg1: String, arg2: String) {
         println(x * y)
     }
     else {
-        println("either '$arg1' or '$arg2' is not a number")
+        println("either '${arg1}' or '${arg2}' is not a number")
     }    
 }
 //sampleEnd

--- a/pages/docs/reference/basic-syntax.md
+++ b/pages/docs/reference/basic-syntax.md
@@ -241,7 +241,7 @@ fun printProduct(arg1: String, arg2: String) {
         println(x * y)
     }
     else {
-        println("either '${arg1}' or '${arg2}' is not a number")
+        println("either '$arg1' or '$arg2' is not a number")
     }    
 }
 //sampleEnd
@@ -272,11 +272,11 @@ fun printProduct(arg1: String, arg2: String) {
 //sampleStart
     // ...
     if (x == null) {
-        println("Wrong number format in arg1: '${arg1}'")
+        println("Wrong number format in arg1: '$arg1'")
         return
     }
     if (y == null) {
-        println("Wrong number format in arg2: '${arg2}'")
+        println("Wrong number format in arg2: '$arg2'")
         return
     }
 


### PR DESCRIPTION
In some places the value is referenced as it as  $variable while at some places as  ${variable} .
Like in this snippet, in the first part of the code it is referenced as it is without any braces, while below, in the same code it is used with braces. I think it must follow a single convention.