### PR TITLE
Add Mindorks Blog to the list of Tutorials

### DIFF
--- a/pages/docs/tutorials/index.md
+++ b/pages/docs/tutorials/index.md
@@ -9,4 +9,5 @@ If you have a tutorial you'd like featured here, please let us know. We'll be ha
 * If you like a “hands-on” learning, try [Kotlin Koans online](http://try.kotlinlang.org/koans) to get familiar with Kotlin;
 * If you are using the command line compiler, start with [Working with the Command Line Compiler](command-line.html) and then work your way through the [Kotlin Koans](koans.html);
 * If you are using IntelliJ IDEA, start with [Getting Started](getting-started.html) and then work your way through the [Kotlin Koans](koans.html).
+* You can follow [Mindorkd Blog - Kotlin](https://blog.mindorks.com/tagged/kotlin), as it regularly posts Kotlin Tutorials  
 


### PR DESCRIPTION
As developers intersted in Kotlin will always check here for tutorials, we should keep all the best resources available over the web here for them, not only the official ones.
https://blog.mindorks.com/tagged/kotlin This blog always keeps posting on Kotlin, so thought it would be a great addition here.