### PR TITLE
Public Review: Procedures around Kotlin Language Evolution

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -174,6 +174,17 @@ reference:
         - url: /docs/reference/compatibility.html
           title: Compatibility
 
+    - title: Language Evolution
+      content:
+        - url: /docs/evolution/language-committee.html
+          title: Language Committee
+        - url: /docs/reference/compatibility.html
+          title: Version Compatibility
+        - url: /docs/evolution/breaking-changes.html
+          title: Breaking Change Policy
+        - url: /docs/evolution/change-review-process.html
+          title: Change Review Process
+
 
     - title: Java Interop
       description: What you need to know about interoperability with Java.

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -207,7 +207,7 @@ we defer to the existing
 ## `7` The scope of this policy
 
 
-## `7.1` In scope
+### `7.1` In scope
 
 `7.1.1` Language: syntax, static checks, execution
     semantics of language constructs.
@@ -232,7 +232,7 @@ we defer to the existing
 `7.1.7` KDoc syntax.
 
 
-## `7.2` Out of scope
+### `7.2` Out of scope
 
 `7.2.1` Build tools and plugins for them (e.g. Gradle
     support).
@@ -264,16 +264,16 @@ we defer to the existing
 
 ## `8` Different requirements for different platforms
 
-## `8.1` Kotlin/JVM
+### `8.1` Kotlin/JVM
 
 No additional requirements on deprecation/breaking changes.
 
-## `8.2` Kotlin/JS
+### `8.2` Kotlin/JS
 
 `8.2.1` Binary compatibility is not guaranteed for the
 JS world, because everything is usually built from sources.
 
-## `8.3` Kotlin/Native
+### `8.3` Kotlin/Native
 
 `8.3.1` Until Kotlin/Native reaches an official
     release, no compatibility guarantees are given for Kotlin/Native.
@@ -289,7 +289,7 @@ JS world, because everything is usually built from sources.
 
 Notation: NC — new compiler, OC — old compiler.
 
-## `9.1` Binary Change, issues
+### `9.1` Binary Change, issues
 
 `9.1.1` A binary produced from unchanged code with NC
     fails where the one produced by OC worked.
@@ -297,7 +297,7 @@ Notation: NC — new compiler, OC — old compiler.
 *Examples of failures*: linkage error, runtime exceptions not
         present in previous versions, deadlocks, race conditions
 
-## `9.2` Binary Change, non-issues
+### `9.2` Binary Change, non-issues
 
 `9.2.1` A binary compiled with NC may be rejected by
     OC, when it relies on new language features unsupported in OC.
@@ -315,7 +315,7 @@ Notation: NC — new compiler, OC — old compiler.
 `9.2.5` Adding supertypes to existing library
 classes/interfaces.
 
-## `9.3` Source Change, issues
+### `9.3` Source Change, issues
 
 `9.3.1` Sources that compiled with OC don't compile
     with NC against the same classpath.
@@ -324,7 +324,7 @@ classes/interfaces.
     behavior changes in a way significant for contract-abiding use
     cases.
 
-## `9.4` Source Change, non-issues
+### `9.4` Source Change, non-issues
 
 `9.4.1` Code compilable with NC fails to compile with
     OC (e.g. due to new language features supported in NC).
@@ -333,12 +333,12 @@ classes/interfaces.
     build configuration or compiler settings explicitly (i.e. in
     addition to advancing the compiler version).
 
-## `9.5` Library Change, issues
+### `9.5` Library Change, issues
 
 `9.5.1` Making a contract on existing API more strict
     than it used to be in a previous version.
 
-## `9.5` Library Change, non-issues
+### `9.5` Library Change, non-issues
 
 `9.5.2` Relaxing a contract on existing APIs.
 
@@ -354,7 +354,7 @@ classes/interfaces.
     stdlib at runtime.
 
 
-## `9.6` Performance changes
+### `9.6` Performance changes
 
 We recognize that runtime performance and bytecode size are important
 metrics, and will make reasonable effort to keep them in a good shape,
@@ -362,7 +362,7 @@ but we don't consider every slowdown (e.g. in edge cases or in very cold
 code) and every extra byte in the classfile a breaking change.
 
 
-# `10` Examples of subtle issues
+## `10` Examples of subtle issues
 
 Banishing the changes listed in this section may pose significant
 problems for language evolution.
@@ -436,7 +436,7 @@ which will likely break source compatibility for many users. We still
 want to do it, but devise a migration mechanism that will first report
 future issues as warnings, and let the users migrate.
 
-# `11` Changes to this policy
+## `11` Changes to this policy
 
 `11.1` Changes to this policy need to be approved by
     the Kotlin Language Committee.

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -1,0 +1,447 @@
+---
+type: doc
+layout: reference
+category: "Language Evolution"
+title: "Kotlin Version Compatibility and Breaking Changes"
+toc: true
+---
+
+# Breaking Change Policy 
+
+
+## `1` Intro
+This document contains definitions and policies adhered to by the Kotlin
+language designers & [committee](language-committee.html) with regards to version compatibility and
+languages changes.
+
+
+## `2` Summary of the Policy
+
+This policy is to set the expectations for Kotlin users, what they can
+rely on:
+
+`2.1` Users' binaries and source code won't break on compiler updates (with some caveats in a really small % of the cases)
+
+`2.2` If something is deprecated, there
+will be a migration path:
+
+`2.2.1` Users will be informed in a timely fashion
+ (exact timeline will be defined on a case-by-case basis).
+
+`2.2.2` Users should have enough time to migrate
+    comfortably.
+
+`2.2.3` Users won't have to do much by hand (the
+    tooling will help along).
+
+
+
+
+## `3` Basic principles of this policy
+
+`3.1` We care about pragmatics, not formality.
+
+`3.2` Breaking existing code is generally undesirable
+    and should be avoided.
+
+`3.2.1` Binary incompatibilities for the JVM are
+    generally a lot harder to address on the user side, so the users
+    should never be required to fix them.
+
+`3.2.2` Source incompatibilities are easier to
+    address, especially with the help of automated tools, but they
+    still introduce significant inconvenience and should be generally
+    avoided.
+
+`3.3` Sometimes incompatible changes are needed
+    for the long-term benefit of the language and its users, and we are
+    willing to make those changes, after careful consideration and
+    justification.
+
+`3.3.1` *Example*: bugs and underspecified behaviors
+    in kotlinc and kotlin-stdlib may require incompatible fixes, and it
+    is often better to fix them (formally, breaking compatibility) than
+    carry them around indefinitely.
+
+`3.3.2` *Example*: some language improvements that
+    many users will benefit from may introduce subtle changes that do
+    not harm most of the code out there.
+
+`3.3.2` *Example*: legacy features that are no longer
+    considered a good practice should be phased out (very) gradually.
+
+`3.4` To be pragmatically beneficial, such changes
+    should go through a graceful deprecation cycle, where the user is
+    never stuck with a large number of migration issues to be addressed
+    manually.
+
+`3.5` Those issues that have to be addressed manually
+ should be highlighted for the user by the tooling.
+
+`3.6` Any change that deprecates or breaks
+compatibilty for a feature or API needs to be reviewed by the Kotlin
+Language Committee following the
+[review procedure](/process/index.html).
+
+
+## `4` How breaking changes can be introduced and dealt with
+
+`4.1` Small changes that virtually no users will
+    encounter can normally be made right away (still require committee
+    [review](#3-6)).
+
+`4.1.1` When unsure about the full risk/impact of
+    a change:
+
+*   Implement the change in a preview build.
+*   Try on large bodies of code available to us.
+*   Fall back to [deprecation procedure](#5) if needed.
+
+`4.2` Behavior changing bug fixes in kotlinc:
+
+`4.2.1` Good code did not compile due to a bug can be
+    fixed right away.
+
+`4.2.2` Bad code compiled due to a bug, but always
+    failed at runtime can be fixed right away.
+
+`4.2.3` Bad code compiled due to a bug, and worked
+    reasonably, must follow the deprecation policy spelled out in
+    [Paragraph 5](#5).
+
+
+`4.3` Bug fixes and contract refinement in the
+ kotlin-stdlib require publishing a release note one version in advance.
+
+`4.4` Retiring language features & kotlin-stdlib APIs
+    must follow the deprecation policies spelled out in
+    [Paragraph 5](#5) and [Paragraph 6](#6).
+
+
+
+## `5` Deprecation procedures for language features
+
+Deprecation is closely related to versioning, for versioning scheme
+we defer to the existing
+[versioning policy](https://kotlinlang.org/docs/reference/compatibility.html).
+
+`5.1` Before any changes are made, the upcoming
+    change along with its rationale and the deprecation/migration plan
+    need to be announced to the Kotlin Community.
+
+`5.2` Release a version (call it N.M) that reports
+    deprecation warnings for the feature:
+
+`5.2.1` Provide and describe a replacement for
+    deprecated constructs as part of the warning.
+
+`5.2.3` Allow to disable the warnings in settings,
+    or promote them to errors.
+
+`5.2.4` Along with this version, provide automated
+    migration aids (e.g. in the IDE).
+
+`5.3` Allow a long enough period of time for
+    migration, the exact time will be based on the impact and complexity
+    of the change as discussed during the Kotlin Language Committee
+    [review](/process/index.html).
+
+`5.4` In the version N.M+1 or N+1, report errors for
+ previously deprecated cases.
+
+`5.4.1` In the release notes, repeat the information
+    about the deprecation plan.
+
+`5.4.2` Allow to demote the errors to warnings through
+    settings.
+
+`5.4.3` Keep migration aids available.
+
+`5.4` In the version N.M+2 or N+1, report errors for
+    the deprecated feature.
+
+`5.4.1` In the release notes, declare the feature as
+    discontinued.
+
+`5.4.2` If possible, keep a compatibility mode that
+    does not support new features, but allows the deprecated one as in
+    version N.M+1 or N+1.X.
+
+`5.4.3` Migration aids can be removed from the
+    compiler at this point.
+
+`5.5` A version that supports automated migration
+    must be maintained and kept available for download. Such tools can
+    be retired after support period of a few years, and the retirement
+    must be announced at least 1 year in advance.
+
+`5.6` Backward compatibility modes in the compiler
+    (through -language-version and -api-version) are supported for a few
+    years and their retirement must be announced at least 1 year in
+    advance.
+
+
+
+## `6` Deprecation procedure for the Standard Library
+
+`6.1` Version N: Mark the declarations as
+`@Deprecated(level = WARNING)`
+
+`6.1.1` Provide reasonable ReplaceWith if possible,
+    or custom migration aids if needed.
+
+`6.1.2` Provide an optional support dependency that
+    exposes the same API.
+
+`6.2` Version N+1: Mark the declarations as
+`@Deprecated(level = ERROR)`
+
+`6.3` Version N+2: Mark the declarations as
+`@Deprecated(level = HIDDEN)`
+
+`6.3.1`  *Note*: for inline functions, complete
+     removal is sometimes possible at this point.
+
+
+
+## `7` The scope of this policy
+
+
+## `7.1` In scope
+
+`7.1.1` Language: syntax, static checks, execution
+    semantics of language constructs.
+
+`7.1.2` The interop subsystem of the language: how
+    Java declarations are seen from Kotlin, and how Kotlin declarations
+    are seen from Java.
+
+`7.1.3` Compatibility of binary artifacts produced by
+ kotlinc with one another and with Java binaries
+
+`7.1.4` Standard library: API and contracts of the
+    declarations in kotlin-stdlib (and its  extensions such as for JRE
+    7 & 8).
+
+`7.1.5` CLI parameters of the compiler except for the
+    -X keys.
+
+`7.1.6` Language Feature, Syntax & API Migration
+ tools.
+
+`7.1.7` KDoc syntax.
+
+
+## `7.2` Out of scope
+
+`7.2.1` Build tools and plugins for them (e.g. Gradle
+    support).
+
+`7.2.2` IDE and static analysis tools (other than the
+    compiler).
+
+`7.2.3` Java2Kotlin converter and other source code
+    manipulation tools.
+
+`7.2.4` Experimental language features & APIs.
+
+`7.2.5` APIs and contracts of libraries other than the
+    standard library.
+
+`7.2.6` API of the compiler.
+
+`7.2.7` Scripting support and Compiler REPL loop.
+
+`7.2.8` dokka (docs generation tool).
+
+`7.2.9` Internal packages of the standard library.
+
+`7.2.10` kotlin-reflect - until it graduates from the
+    experimental status.
+
+`7.2.11` kotlin-script-runtime - until it graduates
+    from the experimental status.
+
+## `8` Different requirements for different platforms
+
+## `8.1` Kotlin/JVM
+
+No additional requirements on deprecation/breaking changes.
+
+## `8.2` Kotlin/JS
+
+`8.2.1` Binary compatibility is not guaranteed for the
+JS world, because everything is usually built from sources.
+
+## `8.3` Kotlin/Native
+
+`8.3.1` Until Kotlin/Native reaches an official
+    release, no compatibility guarantees are given for Kotlin/Native.
+
+`8.3.2` After Kotlin/Native reaches the official
+    release, the binary compatibility guarantees should be considered
+    for Kotlin/Native, but as long as it is mostly focused on statically
+    linked programs, the importance of binary compatibility is
+    relatively low (compared to Kotlin/JVM).
+
+
+## `9` Examples: issues & non-issues
+
+Notation: NC — new compiler, OC — old compiler.
+
+## `9.1` Binary Change, issues
+
+`9.1.1` A binary produced from unchanged code with NC
+    fails where the one produced by OC worked.
+
+*Examples of failures*: linkage error, runtime exceptions not
+        present in previous versions, deadlocks, race conditions
+
+## `9.2` Binary Change, non-issues
+
+`9.2.1` A binary compiled with NC may be rejected by
+    OC, when it relies on new language features unsupported in OC.
+
+`9.2.2` A binary compiled against a newer version of
+    kotlin-stdlib fails when an older version of kotlin-stdlib is
+    supplied at runtime.
+
+`9.2.3` Adding generic parameters to existing
+    declarations does not change the ABI on the JVM (due to erasure).
+
+`9.2.4` Changes to signatures of functions marked
+    @InlineOnly are not changing the ABI on the JVM.
+
+`9.2.5` Adding supertypes to existing library
+classes/interfaces.
+
+## `9.3` Source Change, issues
+
+`9.3.1` Sources that compiled with OC don't compile
+    with NC against the same classpath.
+
+`9.3.2` Unchanged sources compile with NC, but their
+    behavior changes in a way significant for contract-abiding use
+    cases.
+
+## `9.4` Source Change, non-issues
+
+`9.4.1` Code compilable with NC fails to compile with
+    OC (e.g. due to new language features supported in NC).
+
+`9.4.2` The code breaks only if the user alters the
+    build configuration or compiler settings explicitly (i.e. in
+    addition to advancing the compiler version).
+
+## `9.5` Library Change, issues
+
+`9.5.1` Making a contract on existing API more strict
+    than it used to be in a previous version.
+
+## `9.5` Library Change, non-issues
+
+`9.5.2` Relaxing a contract on existing APIs.
+
+`9.5.3` Clarification for unspecified behaviors.
+
+`9.5.4` Changes in hashCode() are not breaking
+    changes.
+
+`9.5.5` Changes in toString() on other than Boolean,
+    Numeric, and String types are not breaking changes.
+
+`9.5.6` Improper loading of two different versions of
+    stdlib at runtime.
+
+
+## `9.6` Performance changes
+
+We recognize that runtime performance and bytecode size are important
+metrics, and will make reasonable effort to keep them in a good shape,
+but we don't consider every slowdown (e.g. in edge cases or in very cold
+code) and every extra byte in the classfile a breaking change.
+
+
+# `10` Examples of subtle issues
+
+Banishing the changes listed in this section may pose significant
+problems for language evolution.
+
+`10.1` Changes in type inference and overload
+    resolution algorithms.
+
+`10.1.1` It's reasonable to assume that overloads of
+    the same function are generally intended to do the same thing. So,
+    though undesirable, a change in overload resolution that causes a
+    different overload to be selected, may be acceptable. We encourage
+    our users to follow this principle when defining overloaded
+    functions.
+
+`10.1.2` Some improvements in the language (such as
+    type inference, for example) may result in more precise static types
+    known for some expressions. This may cause changes in overload
+    resolution [as stated above](#10-1-1), or even in type
+    signatures of declarations when return types are inferred from
+    bodies.
+
+`10.1.3` some innocuous-looking changes in the source
+    code, done by the user, may cause similar effects. We encourage our
+    users to specify return types explicitly on public APIs to ensure
+    their stability and binary compatibility.
+
+`10.1.4` Other improvements in type inference may
+    cause edge cases to break or change their results, but it's often
+    tolerable to introduce such changes.
+
+
+`10.2` Changes in private/synthetic JVM signatures
+generated by the compiler.
+
+While generally an implementation detail that we would like to change,
+in exceptional cases when some users may rely heavily on such
+declarations, extra care will be required in introducing the changes.
+
+`10.3` Moving classes from one JAR to another.
+
+This may be required by the platform (e.g. JVM does not allow split
+packages, and the "kotlin" package has historically been split across
+multiple jars) or other circumstances (popular verification tools, like
+ProGuard, rejecting duplicate classes, etc). A reasonable migration
+strategy has to be worked out in each individual case, and some pain on
+the user end may be inevitable.
+
+`10.4` Compatibility with the future.
+
+In the case of unsigned arithmetic and value types for Kotlin, we know
+that Java is going to add them some time in the future, and our present
+version will be incompatible with their version (e.g. the API that
+expects a Kotlin UInt won't take Java UInt, and vice versa). If we
+retarget new libraries against the new JVM types, their old clients will
+break. This is a matter of choosing a trade-off and a reasonable
+deprecation/migration policy.
+
+
+`10.5` Compatibility of mental models.
+
+Kotlin unsigned integers will be signed for Java clients, and the
+programmer that works with the same API in the Java code will be
+surprised by getting different result. While an undesirable situation,
+this is sometimes inevitable, and should not be considered a breaking
+change (it does not fall under the intuitive definition of one anyway).
+
+`10.6` Interop compatibility vs improvements.
+
+*Example*: Android SDK needs to introduce nullability annotations,
+which will likely break source compatibility for many users. We still
+want to do it, but devise a migration mechanism that will first report
+future issues as warnings, and let the users migrate.
+
+# `11` Changes to this policy
+
+`11.1` Changes to this policy need to be approved by
+    the Kotlin Language Committee.
+
+`11.2` Any proposed change needs to be published as
+    a GitHub pull request; providing a reasonable time to allow for
+     comments on the change by the Kotlin Community.
+

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -6,36 +6,38 @@ title: "Kotlin Version Compatibility and Breaking Changes"
 toc: true
 ---
 
-# Breaking Change Policy 
+# Backwards Incompatible Changes and Deprecation Guidelines
 
 
 ## `1` Intro
-This document contains definitions and policies adhered to by the Kotlin
-language designers & [committee](language-committee.html) with regards to version compatibility and
-languages changes.
+This document contains definitions and policies with regards to version compatibility and languages changes. The Kotlin language designers & [committee](language-committee.html) use it as guidelines to consult with when making designd ecisions. 
 
+## `2` Goals
 
-## `2` Summary of the Policy
+We are balancing between two goals: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully. 
 
-This policy is to set the expectations for Kotlin users, what they can
-rely on:
+`2.1` **Legacy cleanup**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up.
 
-`2.1` Users' binaries and source code won't break on compiler updates (with some caveats in a really small % of the cases)
+Examples of such legacy include 
+* mechanisms that become obsolete due to intruduction of better solutions to the same problems,
+* solutions to problems that became irrelevant over time due to some changes in the environment,
+* bugs and underspecified/accidental behaviors that stem from the implementation of the language.
 
-`2.2` If something is deprecated, there
-will be a migration path:
+Obsolete things should be eventually dropped and bugs should be fixed.
 
-`2.2.1` Users will be informed in a timely fashion
- (exact timeline will be defined on a case-by-case basis).
+`2.2` **Users' convenience**. We also recognize that backwards incompatible changes in the language are inconvenient and sometimes blocking for its users. Our goal is to evolve the language in such a manner that minimizes the inconvenience.   
 
-`2.2.2` Users should have enough time to migrate
-    comfortably.
+`2.2.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
 
-`2.2.3` Users won't have to do much by hand (the
-    tooling will help along).
+`2.2.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it. 
 
+`2.2.3` Backwards incompatible changes should be introduced through a deprecation when possible.
 
+`2.2.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis).
 
+`2.2.5` Users should have enough time to migrate comfortably.
+
+`2.2.6` Users shouldn't be required to do much by hand (the tooling will help along).
 
 ## `3` Basic principles of this policy
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -6,6 +6,12 @@ title: "Kotlin Version Compatibility and Breaking Changes"
 toc: true
 ---
 
+<!--
+WHY THIS FILE HAS MANUALLY EDITABLE PARAGRAPH NUMBERS
+
+There will be external links to these paragraphs, and one needs a very good reason to change the numbering. Generally, it's only OK to add paragraphs to this file in such a way that the numbering of the existing paragraphs does not change  
+-->
+
 # Backwards Incompatible Changes and Deprecation Guidelines
 
 
@@ -23,43 +29,6 @@ Examples of such legacy include
 * solutions to problems that became irrelevant over time due to some changes in the environment,
 * bugs and underspecified/accidental behaviors that stem from the implementation of the language.
 
-Obsolete things should be eventually dropped and bugs should be fixed.
-
-`2.2` **Users' convenience**. We also recognize that backwards incompatible changes in the language are inconvenient and sometimes blocking for its users. Our goal is to evolve the language in such a manner that minimizes the inconvenience.   
-
-`2.2.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
-
-`2.2.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it. 
-
-`2.2.3` Backwards incompatible changes should be introduced through a deprecation when possible.
-
-`2.2.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis).
-
-`2.2.5` Users should have enough time to migrate comfortably.
-
-`2.2.6` Users shouldn't be required to do much by hand (the tooling will help along).
-
-## `3` Basic principles of this policy
-
-`3.1` We care about pragmatics, not formality.
-
-`3.2` Breaking existing code is generally undesirable
-    and should be avoided.
-
-`3.2.1` Binary incompatibilities for the JVM are
-    generally a lot harder to address on the user side, so the users
-    should never be required to fix them.
-
-`3.2.2` Source incompatibilities are easier to
-    address, especially with the help of automated tools, but they
-    still introduce significant inconvenience and should be generally
-    avoided.
-
-`3.3` Sometimes incompatible changes are needed
-    for the long-term benefit of the language and its users, and we are
-    willing to make those changes, after careful consideration and
-    justification.
-
 `3.3.1` *Example*: bugs and underspecified behaviors
     in kotlinc and kotlin-stdlib may require incompatible fixes, and it
     is often better to fix them (formally, breaking compatibility) than
@@ -72,18 +41,45 @@ Obsolete things should be eventually dropped and bugs should be fixed.
 `3.3.3` *Example*: legacy features that are no longer
     considered a good practice should be phased out (very) gradually.
 
+Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
+
+`3.1` We care about pragmatics, not formality.
+
+`2.2` **Users' convenience**. We also recognize that backwards incompatible changes in the language are inconvenient and sometimes blocking for its users. Our goal is to evolve the language in such a manner that minimizes the inconvenience. Breaking existing code is generally undesirable and should be avoided.
+
 `3.4` To be pragmatically beneficial, such changes
     should go through a graceful deprecation cycle, where the user is
     never stuck with a large number of migration issues to be addressed
     manually.
 
+`2.2.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
+
+`2.2.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it. 
+
+`2.2.3` Backwards incompatible changes should be introduced through a deprecation when possible.
+
+`2.2.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis).
+
 `3.5` Those issues that have to be addressed manually
  should be highlighted for the user by the tooling.
 
+`2.2.5` Users should have enough time to migrate comfortably.
+
+`2.2.6` Users shouldn't be required to do much by hand (the tooling will help along).
+
+`2.3` Inconvenience is hard to measure, but there are some general guidelines for a number of broad cases
+
+`2.3.1` Binary incompatibilities for the JVM are generally a lot harder to address on the user side, so the users shouldn't be required to fix them.
+
+`2.3.2` Source incompatibilities are easier to address, especially with the help of automated tools, but they still introduce significant inconvenience and should be generally avoided.
+
+ 
 `3.6` Any change that deprecates or breaks
 compatibilty for a feature or API needs to be reviewed by the Kotlin
 Language Committee following the
 [review procedure](/process/index.html).
+
+## `3` Basic principles of these guidelines
 
 
 ## `4` How breaking changes can be introduced and dealt with

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -24,295 +24,296 @@ This document contains definitions and policies with regards to version compatib
 
 `2.1.1` This means that we have to reconcile moving fast (which sometimes requires breaking things) and keeping the design stable enough to be pragmatically usable. We are balancing between two priorities: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully.  
 
-`2.1` **Keeping the language modern**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up. Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
+`2.2` **Keeping the language modern**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up. Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
 
-`2.1.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
+`2.2.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
 
-`2.1.1` *Example*: bugs and underspecified/accidental behaviors
+`2.2.2` *Example*: bugs and underspecified/accidental behaviors
     in `kotlinc` and `kotlin-stdlib` may require incompatible fixes, and it
     is often better to fix them (formally, breaking compatibility) than
     carry them around indefinitely.
 
-`2.1.2` *Example*: some language improvements that
+`2.2.3` *Example*: some language improvements that
     many users will benefit from may introduce subtle changes that do
     not harm most of the code out there.
 
-`2.1.3` *Example*: legacy features that are no longer
+`2.2.4` *Example*: legacy features that are no longer
     considered a good practice should be phased out (very) gradually.
 
-`2.1.4` *Example*: mechanisms that became irrelevant over time due to some changes in the environment should also be phased out.
+`2.2.5` *Example*: mechanisms that became irrelevant over time due to some changes in the environment should also be phased out.
 
 `2.3` **Pragmatic usefulness**. We also recognize that backwards incompatible changes in the language are distracting developers from their primary focus and should be generally avoided. When necessary, to be pragmatically beneficial, such changes should go through a graceful deprecation cycle, where the user is never stuck with a large number of migration issues to be addressed manually. 
 
-`2.4.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
+`2.3.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
 
-`2.4.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it.  
+`2.3.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it.  
 
-`2.4.3` Backwards incompatible changes should be introduced through a deprecation when possible. 
+`2.3.3` Backwards incompatible changes should be introduced through a deprecation when possible. 
 
-`2.4.4` The tooling should provide means of detection and migration: users shouldn't be required to do much by hand.
+`2.3.4` The tooling should provide means of detection and migration: users shouldn't be required to do much by hand.
 
-`2.4.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
+`2.3.5` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
 
-`2.7` Any change that deprecates or breaks
+`2.4` Any change that deprecates or breaks
 compatibility for a language feature or standard API needs to be reviewed by the [Kotlin
 Language Committee](language-committee.html) following the
 [review procedure](/change-review-process.html).
 
-## `7` Changes to this policy
+## `3` Changes to this policy
 
-`7.1` Changes to this policy need to be approved by
+`3.1` Changes to this policy need to be approved by
     the Kotlin Language Committee.
 
-`7.2` Any proposed change needs to be published as
+`3.2` Any proposed change needs to be published as
     a GitHub pull request; providing a reasonable time to allow for
      comments on the change by the Kotlin Community.
 
-## `3` Types of incompatible changes and corresponding guidelines
+## `4` Types of incompatible changes and corresponding guidelines
 
-`3.1` Small fixes that virtually no users will
+`4.1` Small fixes that virtually no users will
     encounter can normally be made right away (still require committee
     [review](#2.4)).
 
-`3.1.1` When unsure about the full risk/impact of
+`4.1.1` When unsure about the full risk/impact of
     a change:
 
 *   Implement the change in a preview build.
 *   Try on large bodies of code available to us.
 *   Fall back to [deprecation procedure](#4) if needed.
 
-`3.2` Behavior-changing bug fixes in `kotlinc`:
+`4.2` Behavior-changing bug fixes in `kotlinc`:
 
-`3.2.1` Good code did not compile due to a bug can be
+`4.2.1` Good code did not compile due to a bug can be
     fixed right away.
 
-`3.2.2` Bad code compiled due to a bug, but always
+`4.2.2` Bad code compiled due to a bug, but always
     failed at runtime can be fixed right away.
 
-`3.2.3` Bad code compiled due to a bug, and worked
+`4.2.3` Bad code compiled due to a bug, and worked
     reasonably, must follow the deprecation policy spelled out in
     [Paragraph 4](#4).
 
 
-`3.3` Bug fixes and contract refinement in the
+`4.3` Bug fixes and contract refinement in the
  `kotlin-stdlib` require publishing a release note one version in advance.
 
-`3.4` Retiring language features & `kotlin-stdlib` APIs
+`4.4` Retiring language features & `kotlin-stdlib` APIs
     must follow the deprecation policies spelled out in
     [Paragraph 4](#4) and [Paragraph 5](#5).
 
 
 
-## `4` Deprecation procedures for language features
+## `5` Deprecation procedures for language features
 
 Deprecation is closely related to versioning, for versioning scheme
 we refer to the existing [versioning policy](../reference/compatibility.html).
 
-`4.1` Before any changes are made, the upcoming
+`5.1` Before any changes are made, the upcoming
     change along with its rationale and the deprecation/migration plan
     need to be announced to the Kotlin community, 
     preview builds of the compiler and standard library should be made available.
 
-`4.2` Release a version (call it N.M) that reports
+`5.2` Release a version (call it N.M) that reports
     deprecation warnings for the feature:
 
-`4.2.1` Provide and describe a replacement for
+`5.2.1` Provide and describe a replacement for
     deprecated constructs as part of the warning.
 
-`4.2.2` Allow to disable the warnings in settings,
+`5.2.2` Allow to disable the warnings in settings,
     or promote them to errors.
 
-`4.2.3` Along with this version, provide automated
+`5.2.3` Along with this version, provide automated
     migration aids (e.g. in the IDE).
 
-`4.3` Allow a long enough period of time for
+`5.3` Allow a long enough period of time for
     migration, the exact time will be based on the impact and complexity
     of the change as discussed during the Kotlin Language Committee
     [review](/process/index.html).
 
-`4.4` In the version N.M+1 or N+1, report errors for
+`5.4` In the version N.M+1 or N+1, report errors for
  previously deprecated cases.
 
-`4.4.1` In the release notes, repeat the information
+`5.4.1` In the release notes, repeat the information
     about the deprecation plan.
 
-`4.4.2` Allow to demote the errors to warnings through
+`5.4.2` Allow to demote the errors to warnings through
     settings.
 
-`4.4.3` Keep migration aids available.
+`5.4.3` Keep migration aids available.
 
-`4.5` In the version N.M+2 or N+1, report errors for
+`5.5` In the version N.M+2 or N+1, report errors for
     the deprecated feature.
 
-`4.5.1` In the release notes, declare the feature as
+`5.5.1` In the release notes, declare the feature as
     discontinued.
 
-`4.5.2` If possible, keep a compatibility mode that
+`5.5.2` If possible, keep a compatibility mode that
     does not support new features, but allows the deprecated one as in
     version N.M+1 or N+1.X.
 
-`4.5.3` Migration aids can be removed from the
+`5.5.3` Migration aids can be removed from the
     compiler at this point.
 
-`4.6` A version that supports automated migration
+`5.6` A version that supports automated migration
     must be maintained and kept available for download. Such tools can
     be retired after support period of a few years, and the retirement
     must be announced at least 1 year in advance.
 
-`4.7` Backward compatibility modes in the compiler
+`5.7` Backward compatibility modes in the compiler
     (through -language-version and -api-version) are supported for a few
     years and their retirement must be announced at least 1 year in
     advance.
 
-## `5` Deprecation procedure for the Standard Library
+## `6` Deprecation procedure for the Standard Library
 
-`5.1` Version N: Mark the declarations as
+`6.1` Version N: Mark the declarations as
 `@Deprecated(level = WARNING)`
 
-`5.1.1` Provide reasonable ReplaceWith if possible,
+`6.1.1` Provide reasonable ReplaceWith if possible,
     or custom migration aids if needed.
 
-`5.1.2` Provide an optional support dependency that
+`6.1.2` Provide an optional support dependency that
     exposes the same API.
 
-`5.2` Version N+1: Mark the declarations as
+`6.2` Version N+1: Mark the declarations as
 `@Deprecated(level = ERROR)`
 
-`5.3` Version N+2: Mark the declarations as
+`6.3` Version N+2: Mark the declarations as
 `@Deprecated(level = HIDDEN)`
 
-`5.3.1`  *Note*: for inline functions, complete
+`6.3.1`  *Note*: for inline functions, complete
      removal is sometimes possible at this point.
 
 
 
-## `6` The scope of this policy
+## `7` The scope of this policy
 
-### `5.5` In scope
+### `7.1` In scope
 
-`5.5.1` Language: syntax, static checks, execution
+`7.1.1` Language: syntax, static checks, execution
     semantics of language constructs.
 
-`5.5.2` The interop subsystem of the language: how
+`7.1.2` The interop subsystem of the language: how
     Java declarations are seen from Kotlin, and how Kotlin declarations
     are seen from Java.
 
-`5.5.3` Compatibility of binary artifacts produced by
+`7.1.3` Compatibility of binary artifacts produced by
  kotlinc with one another and with Java binaries
 
-`5.5.4` Standard library: API and contracts of the
+`7.1.4` Standard library: API and contracts of the
     declarations in kotlin-stdlib (and its  extensions such as for JRE
     7 & 8).
 
-`5.5.5` CLI parameters of the compiler except for the
+`7.1.5` CLI parameters of the compiler except for the
     -X keys.
 
-`5.5.6` Language Feature, Syntax & API Migration
+`7.1.6` Language Feature, Syntax & API Migration
  tools.
 
-`5.5.7` KDoc syntax.
+`7.1.7` KDoc syntax.
 
 
-### `5.6` Out of scope
+### `7.2` Out of scope
 
-`5.6.1` Build tools and plugins for them (e.g. Gradle
+`7.2.1` Build tools and plugins for them (e.g. Gradle
     support).
 
-`5.6.2` IDE and static analysis tools (other than the
+`7.2.2` IDE and static analysis tools (other than the
     compiler).
 
-`5.6.3` Java2Kotlin converter and other source code
+`7.2.3` Java2Kotlin converter and other source code
     manipulation tools.
 
-`5.6.4` Experimental language features & APIs.
+`7.2.4` Experimental language features & APIs.
 
-`5.6.5` APIs and contracts of libraries other than the
+`7.2.5` APIs and contracts of libraries other than the
     standard library.
 
-`5.6.6` API of the compiler.
+`7.2.6` API of the compiler.
 
-`5.6.7` Scripting support and Compiler REPL loop.
+`7.2.7` Scripting support and Compiler REPL loop.
 
-`5.6.8` dokka (docs generation tool).
+`7.2.8` dokka (docs generation tool).
 
-`5.6.9` Internal packages of the standard library.
+`7.2.9` Internal packages of the standard library.
 
-`5.6.10` kotlin-reflect - until it graduates from the
+`7.2.10` kotlin-reflect - until it graduates from the
     experimental status.
 
-`5.6.11` kotlin-script-runtime - until it graduates
+`7.2.11` kotlin-script-runtime - until it graduates
     from the experimental status.
 
-## `5.11` Examples: issues & non-issues
+
+## `8`. Examples: issues & non-issues
 
 Notation: NC — new compiler, OC — old compiler.
 
-### `5.12` Binary Change, issues
+### `8.1` Binary Change, issues
 
-`5.12.1` A binary produced from unchanged code with NC
+`8.1.1` A binary produced from unchanged code with NC
     fails where the one produced by OC worked.
 
 *Examples of failures*: linkage error, runtime exceptions not
         present in previous versions, deadlocks, race conditions
 
-### `5.13` Binary Change, non-issues
+### `8.2` Binary Change, non-issues
 
-`5.13.1` A binary compiled with NC may be rejected by
+`8.2.1` A binary compiled with NC may be rejected by
     OC, when it relies on new language features unsupported in OC.
 
-`5.13.2` A binary compiled against a newer version of
+`8.2.2` A binary compiled against a newer version of
     kotlin-stdlib fails when an older version of kotlin-stdlib is
     supplied at runtime.
 
-`5.13.3` Adding generic parameters to existing
+`8.2.3` Adding generic parameters to existing
     declarations does not change the ABI on the JVM (due to erasure).
 
-`5.13.4` Changes to signatures of functions marked
+`8.2.4` Changes to signatures of functions marked
     @InlineOnly are not changing the ABI on the JVM.
 
-`5.13.5` Adding supertypes to existing library
+`8.2.5` Adding supertypes to existing library
 classes/interfaces.
 
-### `5.14` Source Change, issues
+### `8.3` Source Change, issues
 
-`5.14.1` Sources that compiled with OC don't compile
+`8.3.1` Sources that compiled with OC don't compile
     with NC against the same classpath.
 
-`5.14.2` Unchanged sources compile with NC, but their
+`8.3.2` Unchanged sources compile with NC, but their
     behavior changes in a way significant for contract-abiding use
     cases.
 
-### `5.15` Source Change, non-issues
+### `8.4` Source Change, non-issues
 
-`5.15.1` Code compilable with NC fails to compile with
+`8.4.1` Code compilable with NC fails to compile with
     OC (e.g. due to new language features supported in NC).
 
-`5.15.2` The code breaks only if the user alters the
+`8.4.2` The code breaks only if the user alters the
     build configuration or compiler settings explicitly (i.e. in
     addition to advancing the compiler version).
 
-### `5.16` Library Change, issues
+### `8.5` Library Change, issues
 
-`5.16.1` Making a contract on existing API more strict
+`8.5.1` Making a contract on existing API more strict
     than it used to be in a previous version.
 
-### `5.17` Library Change, non-issues
+### `8.6` Library Change, non-issues
 
-`5.17.1` Relaxing a contract on existing APIs.
+`8.6.1` Relaxing a contract on existing APIs.
 
-`5.17.2` Clarification for unspecified behaviors.
+`8.6.2` Clarification for unspecified behaviors.
 
-`5.17.3` Changes in hashCode() are not breaking
+`8.6.3` Changes in hashCode() are not breaking
     changes.
 
-`5.17.4` Changes in toString() on other than Boolean,
+`8.6.4` Changes in toString() on other than Boolean,
     Numeric, and String types are not breaking changes.
 
-`5.17.5` Improper loading of two different versions of
+`8.6.5` Improper loading of two different versions of
     stdlib at runtime.
 
 
-### `5.18` Performance changes
+### `8.7` Performance changes
 
 We recognize that runtime performance and bytecode size are important
 metrics, and will make reasonable effort to keep them in a good shape,
@@ -320,46 +321,46 @@ but we don't consider every slowdown (e.g. in edge cases or in very cold
 code) and every extra byte in the classfile a breaking change.
 
 
-## `6` Examples of subtle issues
+## Appendix `9` Examples of subtle issues
 
 Banishing the changes listed in this section may pose significant
 problems for language evolution.
 
-`6.1` Changes in type inference and overload
+`9.1` Changes in type inference and overload
     resolution algorithms.
 
-`6.1.1` It's reasonable to assume that overloads of
+`9.1.1` It's reasonable to assume that overloads of
     the same function are generally intended to do the same thing. So,
     though undesirable, a change in overload resolution that causes a
     different overload to be selected, may be acceptable. We encourage
     our users to follow this principle when defining overloaded
     functions.
 
-`6.1.2` Some improvements in the language (such as
+`9.1.2` Some improvements in the language (such as
     type inference, for example) may result in more precise static types
     known for some expressions. This may cause changes in overload
     resolution [as stated above](#10.1.1), or even in type
     signatures of declarations when return types are inferred from
     bodies.
 
-`6.1.3` some innocuous-looking changes in the source
+`9.1.3` some innocuous-looking changes in the source
     code, done by the user, may cause similar effects. We encourage our
     users to specify return types explicitly on public APIs to ensure
     their stability and binary compatibility.
 
-`6.1.4` Other improvements in type inference may
+`9.1.4` Other improvements in type inference may
     cause edge cases to break or change their results, but it's often
     tolerable to introduce such changes.
 
 
-`6.2` Changes in private/synthetic JVM signatures
+`9.2` Changes in private/synthetic JVM signatures
 generated by the compiler.
 
 While generally an implementation detail that we would like to change,
 in exceptional cases when some users may rely heavily on such
 declarations, extra care will be required in introducing the changes.
 
-`6.3` Moving classes from one JAR to another.
+`9.3` Moving classes from one JAR to another.
 
 This may be required by the platform (e.g. JVM does not allow split
 packages, and the "kotlin" package has historically been split across
@@ -368,7 +369,7 @@ ProGuard, rejecting duplicate classes, etc). A reasonable migration
 strategy has to be worked out in each individual case, and some pain on
 the user end may be inevitable.
 
-`6.4` Compatibility with the future.
+`9.4` Compatibility with the future.
 
 In the case of unsigned arithmetic and value types for Kotlin, we know
 that Java is going to add them some time in the future, and our present
@@ -379,7 +380,7 @@ break. This is a matter of choosing a trade-off and a reasonable
 deprecation/migration policy.
 
 
-`6.5` Compatibility of mental models.
+`9.5` Compatibility of mental models.
 
 Kotlin unsigned integers will be signed for Java clients, and the
 programmer that works with the same API in the Java code will be
@@ -387,7 +388,7 @@ surprised by getting different result. While an undesirable situation,
 this is sometimes inevitable, and should not be considered a breaking
 change (it does not fall under the intuitive definition of one anyway).
 
-`6.6` Interop compatibility vs improvements.
+`9.6` Interop compatibility vs improvements.
 
 *Example*: Android SDK needs to introduce nullability annotations,
 which will likely break source compatibility for many users. We still

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -29,7 +29,7 @@ This document contains definitions and policies with regards to version compatib
 `2.1.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
 
 `2.1.1` *Example*: bugs and underspecified/accidental behaviors
-    in kotlinc and kotlin-stdlib may require incompatible fixes, and it
+    in `kotlinc` and `kotlin-stdlib` may require incompatible fixes, and it
     is often better to fix them (formally, breaking compatibility) than
     carry them around indefinitely.
 
@@ -61,20 +61,20 @@ compatibility for a language feature or standard API needs to be reviewed by the
 Language Committee](language-committee.html) following the
 [review procedure](/change-review-process.html).
 
-## `3` How breaking changes can be introduced and dealt with
+## `3` Types of incompatible changes and corresponding guidelines
 
-`3.1` Small changes that virtually no users will
+`3.1` Small fixes that virtually no users will
     encounter can normally be made right away (still require committee
-    [review](#3-6)).
+    [review](#2.4)).
 
 `3.1.1` When unsure about the full risk/impact of
     a change:
 
 *   Implement the change in a preview build.
 *   Try on large bodies of code available to us.
-*   Fall back to [deprecation procedure](#5) if needed.
+*   Fall back to [deprecation procedure](#4) if needed.
 
-`3.2` Behavior changing bug fixes in kotlinc:
+`3.2` Behavior-changing bug fixes in `kotlinc`:
 
 `3.2.1` Good code did not compile due to a bug can be
     fixed right away.
@@ -84,15 +84,15 @@ Language Committee](language-committee.html) following the
 
 `3.2.3` Bad code compiled due to a bug, and worked
     reasonably, must follow the deprecation policy spelled out in
-    [Paragraph 5](#5).
+    [Paragraph 4](#4).
 
 
 `3.3` Bug fixes and contract refinement in the
- kotlin-stdlib require publishing a release note one version in advance.
+ `kotlin-stdlib` require publishing a release note one version in advance.
 
-`3.4` Retiring language features & kotlin-stdlib APIs
+`3.4` Retiring language features & `kotlin-stdlib` APIs
     must follow the deprecation policies spelled out in
-    [Paragraph 5](#5) and [Paragraph 6](#6).
+    [Paragraph 4](#4) and [Paragraph 5](#5).
 
 
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -29,327 +29,324 @@ Examples of such legacy include
 * solutions to problems that became irrelevant over time due to some changes in the environment,
 * bugs and underspecified/accidental behaviors that stem from the implementation of the language.
 
-`3.3.1` *Example*: bugs and underspecified behaviors
+`2.1.1` *Example*: bugs and underspecified behaviors
     in kotlinc and kotlin-stdlib may require incompatible fixes, and it
     is often better to fix them (formally, breaking compatibility) than
     carry them around indefinitely.
 
-`3.3.2` *Example*: some language improvements that
+`2.1.2` *Example*: some language improvements that
     many users will benefit from may introduce subtle changes that do
     not harm most of the code out there.
 
-`3.3.3` *Example*: legacy features that are no longer
+`2.1.3` *Example*: legacy features that are no longer
     considered a good practice should be phased out (very) gradually.
 
 Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
 
-`3.1` We care about pragmatics, not formality.
+`2.2` We care about pragmatics, not formality.
 
-`2.2` **Users' convenience**. We also recognize that backwards incompatible changes in the language are inconvenient and sometimes blocking for its users. Our goal is to evolve the language in such a manner that minimizes the inconvenience. Breaking existing code is generally undesirable and should be avoided.
+`2.3` **Users' convenience**. We also recognize that backwards incompatible changes in the language are inconvenient and sometimes blocking for its users. Our goal is to evolve the language in such a manner that minimizes the inconvenience. Breaking existing code is generally undesirable and should be avoided.
 
-`3.4` To be pragmatically beneficial, such changes
+`2.4` To be pragmatically beneficial, such changes
     should go through a graceful deprecation cycle, where the user is
     never stuck with a large number of migration issues to be addressed
     manually.
 
-`2.2.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
+`2.4.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
 
-`2.2.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it. 
+`2.4.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it. 
 
-`2.2.3` Backwards incompatible changes should be introduced through a deprecation when possible.
+`2.4.3` Backwards incompatible changes should be introduced through a deprecation when possible.
 
-`2.2.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis).
+`2.4.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis).
 
-`3.5` Those issues that have to be addressed manually
+`2.5` Those issues that have to be addressed manually
  should be highlighted for the user by the tooling.
 
-`2.2.5` Users should have enough time to migrate comfortably.
+`2.5.1` Users should have enough time to migrate comfortably.
 
-`2.2.6` Users shouldn't be required to do much by hand (the tooling will help along).
+`2.5.2` Users shouldn't be required to do much by hand (the tooling will help along).
 
-`2.3` Inconvenience is hard to measure, but there are some general guidelines for a number of broad cases
+`2.6` Inconvenience is hard to measure, but there are some general guidelines for a number of broad cases
 
-`2.3.1` Binary incompatibilities for the JVM are generally a lot harder to address on the user side, so the users shouldn't be required to fix them.
+`2.6.1` Binary incompatibilities for the JVM are generally a lot harder to address on the user side, so the users shouldn't be required to fix them.
 
-`2.3.2` Source incompatibilities are easier to address, especially with the help of automated tools, but they still introduce significant inconvenience and should be generally avoided.
+`2.6.2` Source incompatibilities are easier to address, especially with the help of automated tools, but they still introduce significant inconvenience and should be generally avoided.
 
  
-`3.6` Any change that deprecates or breaks
+`2.7` Any change that deprecates or breaks
 compatibilty for a feature or API needs to be reviewed by the Kotlin
 Language Committee following the
 [review procedure](/process/index.html).
 
-## `3` Basic principles of these guidelines
+## `3` How breaking changes can be introduced and dealt with
 
-
-## `4` How breaking changes can be introduced and dealt with
-
-`4.1` Small changes that virtually no users will
+`3.1` Small changes that virtually no users will
     encounter can normally be made right away (still require committee
     [review](#3-6)).
 
-`4.1.1` When unsure about the full risk/impact of
+`3.1.1` When unsure about the full risk/impact of
     a change:
 
 *   Implement the change in a preview build.
 *   Try on large bodies of code available to us.
 *   Fall back to [deprecation procedure](#5) if needed.
 
-`4.2` Behavior changing bug fixes in kotlinc:
+`3.2` Behavior changing bug fixes in kotlinc:
 
-`4.2.1` Good code did not compile due to a bug can be
+`3.2.1` Good code did not compile due to a bug can be
     fixed right away.
 
-`4.2.2` Bad code compiled due to a bug, but always
+`3.2.2` Bad code compiled due to a bug, but always
     failed at runtime can be fixed right away.
 
-`4.2.3` Bad code compiled due to a bug, and worked
+`3.2.3` Bad code compiled due to a bug, and worked
     reasonably, must follow the deprecation policy spelled out in
     [Paragraph 5](#5).
 
 
-`4.3` Bug fixes and contract refinement in the
+`3.3` Bug fixes and contract refinement in the
  kotlin-stdlib require publishing a release note one version in advance.
 
-`4.4` Retiring language features & kotlin-stdlib APIs
+`3.4` Retiring language features & kotlin-stdlib APIs
     must follow the deprecation policies spelled out in
     [Paragraph 5](#5) and [Paragraph 6](#6).
 
 
 
-## `5` Deprecation procedures for language features
+## `4` Deprecation procedures for language features
 
 Deprecation is closely related to versioning, for versioning scheme
 we defer to the existing
 [versioning policy](https://kotlinlang.org/docs/reference/compatibility.html).
 
-`5.1` Before any changes are made, the upcoming
+`4.1` Before any changes are made, the upcoming
     change along with its rationale and the deprecation/migration plan
     need to be announced to the Kotlin Community.
 
-`5.2` Release a version (call it N.M) that reports
+`4.2` Release a version (call it N.M) that reports
     deprecation warnings for the feature:
 
-`5.2.1` Provide and describe a replacement for
+`4.2.1` Provide and describe a replacement for
     deprecated constructs as part of the warning.
 
-`5.2.3` Allow to disable the warnings in settings,
+`4.2.2` Allow to disable the warnings in settings,
     or promote them to errors.
 
-`5.2.4` Along with this version, provide automated
+`4.2.3` Along with this version, provide automated
     migration aids (e.g. in the IDE).
 
-`5.3` Allow a long enough period of time for
+`4.3` Allow a long enough period of time for
     migration, the exact time will be based on the impact and complexity
     of the change as discussed during the Kotlin Language Committee
     [review](/process/index.html).
 
-`5.4` In the version N.M+1 or N+1, report errors for
+`4.4` In the version N.M+1 or N+1, report errors for
  previously deprecated cases.
 
-`5.4.1` In the release notes, repeat the information
+`4.4.1` In the release notes, repeat the information
     about the deprecation plan.
 
-`5.4.2` Allow to demote the errors to warnings through
+`4.4.2` Allow to demote the errors to warnings through
     settings.
 
-`5.4.3` Keep migration aids available.
+`4.4.3` Keep migration aids available.
 
-`5.5` In the version N.M+2 or N+1, report errors for
+`4.5` In the version N.M+2 or N+1, report errors for
     the deprecated feature.
 
-`5.5.1` In the release notes, declare the feature as
+`4.5.1` In the release notes, declare the feature as
     discontinued.
 
-`5.5.2` If possible, keep a compatibility mode that
+`4.5.2` If possible, keep a compatibility mode that
     does not support new features, but allows the deprecated one as in
     version N.M+1 or N+1.X.
 
-`5.5.3` Migration aids can be removed from the
+`4.5.3` Migration aids can be removed from the
     compiler at this point.
 
-`5.6` A version that supports automated migration
+`4.6` A version that supports automated migration
     must be maintained and kept available for download. Such tools can
     be retired after support period of a few years, and the retirement
     must be announced at least 1 year in advance.
 
-`5.7` Backward compatibility modes in the compiler
+`4.7` Backward compatibility modes in the compiler
     (through -language-version and -api-version) are supported for a few
     years and their retirement must be announced at least 1 year in
     advance.
 
-## `6` Deprecation procedure for the Standard Library
+## `5` Deprecation procedure for the Standard Library
 
-`6.1` Version N: Mark the declarations as
+`5.1` Version N: Mark the declarations as
 `@Deprecated(level = WARNING)`
 
-`6.1.1` Provide reasonable ReplaceWith if possible,
+`5.1.1` Provide reasonable ReplaceWith if possible,
     or custom migration aids if needed.
 
-`6.1.2` Provide an optional support dependency that
+`5.1.2` Provide an optional support dependency that
     exposes the same API.
 
-`6.2` Version N+1: Mark the declarations as
+`5.2` Version N+1: Mark the declarations as
 `@Deprecated(level = ERROR)`
 
-`6.3` Version N+2: Mark the declarations as
+`5.3` Version N+2: Mark the declarations as
 `@Deprecated(level = HIDDEN)`
 
-`6.3.1`  *Note*: for inline functions, complete
+`5.3.1`  *Note*: for inline functions, complete
      removal is sometimes possible at this point.
 
 
 
-## `7` The scope of this policy
+## `5.4` The scope of this policy
 
-### `7.1` In scope
+### `5.5` In scope
 
-`7.1.1` Language: syntax, static checks, execution
+`5.5.1` Language: syntax, static checks, execution
     semantics of language constructs.
 
-`7.1.2` The interop subsystem of the language: how
+`5.5.2` The interop subsystem of the language: how
     Java declarations are seen from Kotlin, and how Kotlin declarations
     are seen from Java.
 
-`7.1.3` Compatibility of binary artifacts produced by
+`5.5.3` Compatibility of binary artifacts produced by
  kotlinc with one another and with Java binaries
 
-`7.1.4` Standard library: API and contracts of the
+`5.5.4` Standard library: API and contracts of the
     declarations in kotlin-stdlib (and its  extensions such as for JRE
     7 & 8).
 
-`7.1.5` CLI parameters of the compiler except for the
+`5.5.5` CLI parameters of the compiler except for the
     -X keys.
 
-`7.1.6` Language Feature, Syntax & API Migration
+`5.5.6` Language Feature, Syntax & API Migration
  tools.
 
-`7.1.7` KDoc syntax.
+`5.5.7` KDoc syntax.
 
 
-### `7.2` Out of scope
+### `5.6` Out of scope
 
-`7.2.1` Build tools and plugins for them (e.g. Gradle
+`5.6.1` Build tools and plugins for them (e.g. Gradle
     support).
 
-`7.2.2` IDE and static analysis tools (other than the
+`5.6.2` IDE and static analysis tools (other than the
     compiler).
 
-`7.2.3` Java2Kotlin converter and other source code
+`5.6.3` Java2Kotlin converter and other source code
     manipulation tools.
 
-`7.2.4` Experimental language features & APIs.
+`5.6.4` Experimental language features & APIs.
 
-`7.2.5` APIs and contracts of libraries other than the
+`5.6.5` APIs and contracts of libraries other than the
     standard library.
 
-`7.2.6` API of the compiler.
+`5.6.6` API of the compiler.
 
-`7.2.7` Scripting support and Compiler REPL loop.
+`5.6.7` Scripting support and Compiler REPL loop.
 
-`7.2.8` dokka (docs generation tool).
+`5.6.8` dokka (docs generation tool).
 
-`7.2.9` Internal packages of the standard library.
+`5.6.9` Internal packages of the standard library.
 
-`7.2.10` kotlin-reflect - until it graduates from the
+`5.6.10` kotlin-reflect - until it graduates from the
     experimental status.
 
-`7.2.11` kotlin-script-runtime - until it graduates
+`5.6.11` kotlin-script-runtime - until it graduates
     from the experimental status.
 
-## `8` Different requirements for different platforms
+## `5.7` Different requirements for different platforms
 
-### `8.1` Kotlin/JVM
+### `5.8` Kotlin/JVM
 
 No additional requirements on deprecation/breaking changes.
 
-### `8.2` Kotlin/JS
+### `5.9` Kotlin/JS
 
-`8.2.1` Binary compatibility is not guaranteed for the
+`5.9.1` Binary compatibility is not guaranteed for the
 JS world, because everything is usually built from sources.
 
-### `8.3` Kotlin/Native
+### `5.10` Kotlin/Native
 
-`8.3.1` Until Kotlin/Native reaches an official
+`5.10.1` Until Kotlin/Native reaches an official
     release, no compatibility guarantees are given for Kotlin/Native.
 
-`8.3.2` After Kotlin/Native reaches the official
+`5.10.2` After Kotlin/Native reaches the official
     release, the binary compatibility guarantees should be considered
     for Kotlin/Native, but as long as it is mostly focused on statically
     linked programs, the importance of binary compatibility is
     relatively low (compared to Kotlin/JVM).
 
 
-## `9` Examples: issues & non-issues
+## `5.11` Examples: issues & non-issues
 
 Notation: NC — new compiler, OC — old compiler.
 
-### `9.1` Binary Change, issues
+### `5.12` Binary Change, issues
 
-`9.1.1` A binary produced from unchanged code with NC
+`5.12.1` A binary produced from unchanged code with NC
     fails where the one produced by OC worked.
 
 *Examples of failures*: linkage error, runtime exceptions not
         present in previous versions, deadlocks, race conditions
 
-### `9.2` Binary Change, non-issues
+### `5.13` Binary Change, non-issues
 
-`9.2.1` A binary compiled with NC may be rejected by
+`5.13.1` A binary compiled with NC may be rejected by
     OC, when it relies on new language features unsupported in OC.
 
-`9.2.2` A binary compiled against a newer version of
+`5.13.2` A binary compiled against a newer version of
     kotlin-stdlib fails when an older version of kotlin-stdlib is
     supplied at runtime.
 
-`9.2.3` Adding generic parameters to existing
+`5.13.3` Adding generic parameters to existing
     declarations does not change the ABI on the JVM (due to erasure).
 
-`9.2.4` Changes to signatures of functions marked
+`5.13.4` Changes to signatures of functions marked
     @InlineOnly are not changing the ABI on the JVM.
 
-`9.2.5` Adding supertypes to existing library
+`5.13.5` Adding supertypes to existing library
 classes/interfaces.
 
-### `9.3` Source Change, issues
+### `5.14` Source Change, issues
 
-`9.3.1` Sources that compiled with OC don't compile
+`5.14.1` Sources that compiled with OC don't compile
     with NC against the same classpath.
 
-`9.3.2` Unchanged sources compile with NC, but their
+`5.14.2` Unchanged sources compile with NC, but their
     behavior changes in a way significant for contract-abiding use
     cases.
 
-### `9.4` Source Change, non-issues
+### `5.15` Source Change, non-issues
 
-`9.4.1` Code compilable with NC fails to compile with
+`5.15.1` Code compilable with NC fails to compile with
     OC (e.g. due to new language features supported in NC).
 
-`9.4.2` The code breaks only if the user alters the
+`5.15.2` The code breaks only if the user alters the
     build configuration or compiler settings explicitly (i.e. in
     addition to advancing the compiler version).
 
-### `9.5` Library Change, issues
+### `5.16` Library Change, issues
 
-`9.5.1` Making a contract on existing API more strict
+`5.16.1` Making a contract on existing API more strict
     than it used to be in a previous version.
 
-### `9.6` Library Change, non-issues
+### `5.17` Library Change, non-issues
 
-`9.6.2` Relaxing a contract on existing APIs.
+`5.17.1` Relaxing a contract on existing APIs.
 
-`9.6.3` Clarification for unspecified behaviors.
+`5.17.2` Clarification for unspecified behaviors.
 
-`9.6.4` Changes in hashCode() are not breaking
+`5.17.3` Changes in hashCode() are not breaking
     changes.
 
-`9.6.5` Changes in toString() on other than Boolean,
+`5.17.4` Changes in toString() on other than Boolean,
     Numeric, and String types are not breaking changes.
 
-`9.6.6` Improper loading of two different versions of
+`5.17.5` Improper loading of two different versions of
     stdlib at runtime.
 
 
-### `9.7` Performance changes
+### `5.18` Performance changes
 
 We recognize that runtime performance and bytecode size are important
 metrics, and will make reasonable effort to keep them in a good shape,
@@ -357,46 +354,46 @@ but we don't consider every slowdown (e.g. in edge cases or in very cold
 code) and every extra byte in the classfile a breaking change.
 
 
-## `10` Examples of subtle issues
+## `6` Examples of subtle issues
 
 Banishing the changes listed in this section may pose significant
 problems for language evolution.
 
-`10.1` Changes in type inference and overload
+`6.1` Changes in type inference and overload
     resolution algorithms.
 
-`10.1.1` It's reasonable to assume that overloads of
+`6.1.1` It's reasonable to assume that overloads of
     the same function are generally intended to do the same thing. So,
     though undesirable, a change in overload resolution that causes a
     different overload to be selected, may be acceptable. We encourage
     our users to follow this principle when defining overloaded
     functions.
 
-`10.1.2` Some improvements in the language (such as
+`6.1.2` Some improvements in the language (such as
     type inference, for example) may result in more precise static types
     known for some expressions. This may cause changes in overload
     resolution [as stated above](#10-1-1), or even in type
     signatures of declarations when return types are inferred from
     bodies.
 
-`10.1.3` some innocuous-looking changes in the source
+`6.1.3` some innocuous-looking changes in the source
     code, done by the user, may cause similar effects. We encourage our
     users to specify return types explicitly on public APIs to ensure
     their stability and binary compatibility.
 
-`10.1.4` Other improvements in type inference may
+`6.1.4` Other improvements in type inference may
     cause edge cases to break or change their results, but it's often
     tolerable to introduce such changes.
 
 
-`10.2` Changes in private/synthetic JVM signatures
+`6.2` Changes in private/synthetic JVM signatures
 generated by the compiler.
 
 While generally an implementation detail that we would like to change,
 in exceptional cases when some users may rely heavily on such
 declarations, extra care will be required in introducing the changes.
 
-`10.3` Moving classes from one JAR to another.
+`6.3` Moving classes from one JAR to another.
 
 This may be required by the platform (e.g. JVM does not allow split
 packages, and the "kotlin" package has historically been split across
@@ -405,7 +402,7 @@ ProGuard, rejecting duplicate classes, etc). A reasonable migration
 strategy has to be worked out in each individual case, and some pain on
 the user end may be inevitable.
 
-`10.4` Compatibility with the future.
+`6.4` Compatibility with the future.
 
 In the case of unsigned arithmetic and value types for Kotlin, we know
 that Java is going to add them some time in the future, and our present
@@ -416,7 +413,7 @@ break. This is a matter of choosing a trade-off and a reasonable
 deprecation/migration policy.
 
 
-`10.5` Compatibility of mental models.
+`6.5` Compatibility of mental models.
 
 Kotlin unsigned integers will be signed for Java clients, and the
 programmer that works with the same API in the Java code will be
@@ -424,19 +421,19 @@ surprised by getting different result. While an undesirable situation,
 this is sometimes inevitable, and should not be considered a breaking
 change (it does not fall under the intuitive definition of one anyway).
 
-`10.6` Interop compatibility vs improvements.
+`6.6` Interop compatibility vs improvements.
 
 *Example*: Android SDK needs to introduce nullability annotations,
 which will likely break source compatibility for many users. We still
 want to do it, but devise a migration mechanism that will first report
 future issues as warnings, and let the users migrate.
 
-## `11` Changes to this policy
+## `7` Changes to this policy
 
-`11.1` Changes to this policy need to be approved by
+`7.1` Changes to this policy need to be approved by
     the Kotlin Language Committee.
 
-`11.2` Any proposed change needs to be published as
+`7.2` Any proposed change needs to be published as
     a GitHub pull request; providing a reasonable time to allow for
      comments on the change by the Kotlin Community.
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -69,7 +69,7 @@ Obsolete things should be eventually dropped and bugs should be fixed.
     many users will benefit from may introduce subtle changes that do
     not harm most of the code out there.
 
-`3.3.2` *Example*: legacy features that are no longer
+`3.3.3` *Example*: legacy features that are no longer
     considered a good practice should be phased out (very) gradually.
 
 `3.4` To be pragmatically beneficial, such changes
@@ -159,30 +159,28 @@ we defer to the existing
 
 `5.4.3` Keep migration aids available.
 
-`5.4` In the version N.M+2 or N+1, report errors for
+`5.5` In the version N.M+2 or N+1, report errors for
     the deprecated feature.
 
-`5.4.1` In the release notes, declare the feature as
+`5.5.1` In the release notes, declare the feature as
     discontinued.
 
-`5.4.2` If possible, keep a compatibility mode that
+`5.5.2` If possible, keep a compatibility mode that
     does not support new features, but allows the deprecated one as in
     version N.M+1 or N+1.X.
 
-`5.4.3` Migration aids can be removed from the
+`5.5.3` Migration aids can be removed from the
     compiler at this point.
 
-`5.5` A version that supports automated migration
+`5.6` A version that supports automated migration
     must be maintained and kept available for download. Such tools can
     be retired after support period of a few years, and the retirement
     must be announced at least 1 year in advance.
 
-`5.6` Backward compatibility modes in the compiler
+`5.7` Backward compatibility modes in the compiler
     (through -language-version and -api-version) are supported for a few
     years and their retirement must be announced at least 1 year in
     advance.
-
-
 
 ## `6` Deprecation procedure for the Standard Library
 
@@ -207,7 +205,6 @@ we defer to the existing
 
 
 ## `7` The scope of this policy
-
 
 ### `7.1` In scope
 
@@ -340,23 +337,23 @@ classes/interfaces.
 `9.5.1` Making a contract on existing API more strict
     than it used to be in a previous version.
 
-### `9.5` Library Change, non-issues
+### `9.6` Library Change, non-issues
 
-`9.5.2` Relaxing a contract on existing APIs.
+`9.6.2` Relaxing a contract on existing APIs.
 
-`9.5.3` Clarification for unspecified behaviors.
+`9.6.3` Clarification for unspecified behaviors.
 
-`9.5.4` Changes in hashCode() are not breaking
+`9.6.4` Changes in hashCode() are not breaking
     changes.
 
-`9.5.5` Changes in toString() on other than Boolean,
+`9.6.5` Changes in toString() on other than Boolean,
     Numeric, and String types are not breaking changes.
 
-`9.5.6` Improper loading of two different versions of
+`9.6.6` Improper loading of two different versions of
     stdlib at runtime.
 
 
-### `9.6` Performance changes
+### `9.7` Performance changes
 
 We recognize that runtime performance and bytecode size are important
 metrics, and will make reasonable effort to keep them in a good shape,

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -16,20 +16,19 @@ There will be external links to these paragraphs, and one needs a very good reas
 
 
 ## `1` Intro
-This document contains definitions and policies with regards to version compatibility and languages changes. The Kotlin language designers & [committee](language-committee.html) use it as guidelines to consult with when making designd ecisions. 
+This document contains definitions and policies with regards to version compatibility and languages changes. The Kotlin language designers & [committee](language-committee.html) use it as guidelines to consult with when making design decisions. 
 
-## `2` Goals
+## `2` Kotlin language evolution  
 
-We are balancing between two goals: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully. 
+`2.1` **Our creed**. Kotlin is and should remain a modern language for industry. We care about pragmatics, not formality.
 
-`2.1` **Legacy cleanup**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up.
+`2.1.1` This means that we have to reconcile moving fast (which sometimes requires breaking things) and keeping the design stable enough to be pragmatically usable. We are balancing between two priorities: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully.  
 
-Examples of such legacy include 
-* mechanisms that become obsolete due to intruduction of better solutions to the same problems,
-* solutions to problems that became irrelevant over time due to some changes in the environment,
-* bugs and underspecified/accidental behaviors that stem from the implementation of the language.
+`2.1` **Keeping the language modern**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up. Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
 
-`2.1.1` *Example*: bugs and underspecified behaviors
+`2.1.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
+
+`2.1.1` *Example*: bugs and underspecified/accidental behaviors
     in kotlinc and kotlin-stdlib may require incompatible fixes, and it
     is often better to fix them (formally, breaking compatibility) than
     carry them around indefinitely.
@@ -41,43 +40,26 @@ Examples of such legacy include
 `2.1.3` *Example*: legacy features that are no longer
     considered a good practice should be phased out (very) gradually.
 
-Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
+`2.1.4` *Example*: mechanisms that became irrelevant over time due to some changes in the environment should also be phased out.
 
-`2.2` We care about pragmatics, not formality.
-
-`2.3` **Users' convenience**. We also recognize that backwards incompatible changes in the language are inconvenient and sometimes blocking for its users. Our goal is to evolve the language in such a manner that minimizes the inconvenience. Breaking existing code is generally undesirable and should be avoided.
-
-`2.4` To be pragmatically beneficial, such changes
-    should go through a graceful deprecation cycle, where the user is
-    never stuck with a large number of migration issues to be addressed
-    manually.
+`2.3` **Pragmatic usefulness**. We also recognize that backwards incompatible changes in the language are distracting developers from their primary focus and should be generally avoided. When necessary, to be pragmatically beneficial, such changes should go through a graceful deprecation cycle, where the user is never stuck with a large number of migration issues to be addressed manually. 
 
 `2.4.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
 
-`2.4.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it. 
+`2.4.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it.  
 
-`2.4.3` Backwards incompatible changes should be introduced through a deprecation when possible.
+`2.4.3` Backwards incompatible changes should be introduced through a deprecation when possible. 
 
-`2.4.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis).
+`2.4.4` The tooling should provide means of detection and migration: users shouldn't be required to do much by hand.
 
-`2.5` Those issues that have to be addressed manually
- should be highlighted for the user by the tooling.
+`2.4.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
 
-`2.5.1` Users should have enough time to migrate comfortably.
-
-`2.5.2` Users shouldn't be required to do much by hand (the tooling will help along).
-
-`2.6` Inconvenience is hard to measure, but there are some general guidelines for a number of broad cases
-
-`2.6.1` Binary incompatibilities for the JVM are generally a lot harder to address on the user side, so the users shouldn't be required to fix them.
-
-`2.6.2` Source incompatibilities are easier to address, especially with the help of automated tools, but they still introduce significant inconvenience and should be generally avoided.
-
+`2.6.1` *NOTE*: Binary incompatibilities for the JVM are generally a lot harder to address on the user side, so requiring the  users to fix them should be avoided.
  
 `2.7` Any change that deprecates or breaks
-compatibilty for a feature or API needs to be reviewed by the Kotlin
-Language Committee following the
-[review procedure](/process/index.html).
+compatibility for a language feature or standard API needs to be reviewed by the [Kotlin
+Language Committee](language-committee.html) following the
+[review procedure](/change-review-process.html).
 
 ## `3` How breaking changes can be introduced and dealt with
 
@@ -372,7 +354,7 @@ problems for language evolution.
 `6.1.2` Some improvements in the language (such as
     type inference, for example) may result in more precise static types
     known for some expressions. This may cause changes in overload
-    resolution [as stated above](#10-1-1), or even in type
+    resolution [as stated above](#10.1.1), or even in type
     signatures of declarations when return types are inferred from
     bodies.
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -22,37 +22,37 @@ This document contains definitions and policies with regards to version compatib
 
 `1.1` **Our creed**. Kotlin is and should remain a modern language for industry. We care about pragmatics, not formality.
 
-`1.1.1` This means that we have to reconcile moving fast (which sometimes requires breaking things) and keeping the design stable enough to be pragmatically usable. We are balancing between two priorities: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully.  
+* `1.1.1` This means that we have to reconcile moving fast (which sometimes requires breaking things) and keeping the design stable enough to be pragmatically usable. We are balancing between two priorities: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully.  
 
 `1.2` **Keeping the language modern**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up. Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
 
-`1.2.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
+* `1.2.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
 
-`1.2.2` *Example*: bugs and underspecified/accidental behaviors
+* `1.2.2` *Example*: bugs and underspecified/accidental behaviors
     in `kotlinc` and `kotlin-stdlib` may require incompatible fixes, and it
     is often better to fix them (formally, breaking compatibility) than
     carry them around indefinitely.
 
-`1.2.3` *Example*: some language improvements that
+* `1.2.3` *Example*: some language improvements that
     many users will benefit from may introduce subtle changes that do
     not harm most of the code out there.
 
-`1.2.4` *Example*: legacy features that are no longer
+* `1.2.4` *Example*: legacy features that are no longer
     considered a good practice should be phased out (very) gradually.
 
-`1.2.5` *Example*: mechanisms that became irrelevant over time due to some changes in the environment should also be phased out.
+* `1.2.5` *Example*: mechanisms that became irrelevant over time due to some changes in the environment should also be phased out.
 
 `1.3` **Pragmatic usefulness**. We also recognize that backwards incompatible changes in the language are distracting developers from their primary focus and should be generally avoided. When necessary, to be pragmatically beneficial, such changes should go through a graceful deprecation cycle, where the user is never stuck with a large number of migration issues to be addressed manually. 
 
-`1.3.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
+* `1.3.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
 
-`1.3.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it.  
+* `1.3.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it.  
 
-`1.3.3` Backwards incompatible changes should be introduced through a deprecation when possible. 
+* `1.3.3` Backwards incompatible changes should be introduced through a deprecation when possible. 
 
-`1.3.4` The tooling should provide means of detection and migration: users shouldn't be required to do much by hand.
+* `1.3.4` The tooling should provide means of detection and migration: users shouldn't be required to do much by hand.
 
-`1.3.5` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
+* `1.3.5` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
 
 `1.4` Any change that deprecates or breaks
 compatibility for a language feature or standard API needs to be reviewed by the [Kotlin
@@ -74,7 +74,7 @@ Language Committee](language-committee.html) following the
     encounter can normally be made right away (still require committee
     [review](#1.4)).
 
-`3.1.1` When unsure about the full risk/impact of
+* `3.1.1` When unsure about the full risk/impact of
     a change:
 
 *   Implement the change in a preview build.
@@ -83,13 +83,13 @@ Language Committee](language-committee.html) following the
 
 `3.2` Behavior-changing bug fixes in `kotlinc`:
 
-`3.2.1` Good code did not compile due to a bug can be
+* `3.2.1` Good code did not compile due to a bug can be
     fixed right away.
 
-`3.2.2` Bad code compiled due to a bug, but always
+* `3.2.2` Bad code compiled due to a bug, but always
     failed at runtime can be fixed right away.
 
-`3.2.3` Bad code compiled due to a bug, and worked
+* `3.2.3` Bad code compiled due to a bug, and worked
     reasonably, must follow the deprecation policy spelled out in
     [Paragraph 4](#4).
 
@@ -116,13 +116,13 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
 `4.2` Release a version (call it N.M) that reports
     deprecation warnings for the feature:
 
-`4.2.1` Provide and describe a replacement for
+* `4.2.1` Provide and describe a replacement for
     deprecated constructs as part of the warning.
 
-`4.2.2` Allow to disable the warnings in settings,
+* `4.2.2` Allow to disable the warnings in settings,
     or promote them to errors.
 
-`4.2.3` Along with this version, provide automated
+* `4.2.3` Along with this version, provide automated
     migration aids (e.g. in the IDE).
 
 `4.3` Allow a long enough period of time for
@@ -133,25 +133,25 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
 `4.4` In the version N.M+1 or N+1, report errors for
  previously deprecated cases.
 
-`4.4.1` In the release notes, repeat the information
+* `4.4.1` In the release notes, repeat the information
     about the deprecation plan.
 
-`4.4.2` Allow to demote the errors to warnings through
+* `4.4.2` Allow to demote the errors to warnings through
     settings.
 
-`4.4.3` Keep migration aids available.
+* `4.4.3` Keep migration aids available.
 
 `4.5` In the version N.M+2 or N+1, report errors for
     the deprecated feature.
 
-`4.5.1` In the release notes, declare the feature as
+* `4.5.1` In the release notes, declare the feature as
     discontinued.
 
-`4.5.2` If possible, keep a compatibility mode that
+* `4.5.2` If possible, keep a compatibility mode that
     does not support new features, but allows the deprecated one as in
     version N.M+1 or N+1.X.
 
-`4.5.3` Migration aids can be removed from the
+* `4.5.3` Migration aids can be removed from the
     compiler at this point.
 
 `4.6` A version that supports automated migration
@@ -169,10 +169,10 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
 `5.1` Version N: Mark the declarations as
 `@Deprecated(level = WARNING)`
 
-`5.1.1` Provide reasonable ReplaceWith if possible,
+* `5.1.1` Provide reasonable ReplaceWith if possible,
     or custom migration aids if needed.
 
-`5.1.2` Provide an optional support dependency that
+* `5.1.2` Provide an optional support dependency that
     exposes the same API.
 
 `5.2` Version N+1: Mark the declarations as
@@ -181,66 +181,66 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
 `5.3` Version N+2: Mark the declarations as
 `@Deprecated(level = HIDDEN)`
 
-`5.3.1`  *Note*: for inline functions, complete
+* `5.3.1`  *Note*: for inline functions, complete
      removal is sometimes possible at this point.
 
 
 
 ## `6` The scope of this policy
 
-### `6.1` In scope
+`6.1` In scope
 
-`6.1.1` Language: syntax, static checks, execution
+* `6.1.1` Language: syntax, static checks, execution
     semantics of language constructs.
 
-`6.1.2` The interop subsystem of the language: how
+* `6.1.2` The interop subsystem of the language: how
     Java declarations are seen from Kotlin, and how Kotlin declarations
     are seen from Java.
 
-`6.1.3` Compatibility of binary artifacts produced by
+* `6.1.3` Compatibility of binary artifacts produced by
  kotlinc with one another and with Java binaries
 
-`6.1.4` Standard library: API and contracts of the
+* `6.1.4` Standard library: API and contracts of the
     declarations in kotlin-stdlib (and its  extensions such as for JRE
     7 & 8).
 
-`6.1.5` CLI parameters of the compiler except for the
+* `6.1.5` CLI parameters of the compiler except for the
     -X keys.
 
-`6.1.6` Language Feature, Syntax & API Migration
+* `6.1.6` Language Feature, Syntax & API Migration
  tools.
 
-`6.1.7` KDoc syntax.
+* `6.1.7` KDoc syntax.
 
 
-### `6.2` Out of scope
+`6.2` Out of scope
 
-`6.2.1` Build tools and plugins for them (e.g. Gradle
+* `6.2.1` Build tools and plugins for them (e.g. Gradle
     support).
 
-`6.2.2` IDE and static analysis tools (other than the
+* `6.2.2` IDE and static analysis tools (other than the
     compiler).
 
-`6.2.3` Java2Kotlin converter and other source code
+* `6.2.3` Java2Kotlin converter and other source code
     manipulation tools.
 
-`6.2.4` Experimental language features & APIs.
+* `6.2.4` Experimental language features & APIs.
 
-`6.2.5` APIs and contracts of libraries other than the
+* `6.2.5` APIs and contracts of libraries other than the
     standard library.
 
-`6.2.6` API of the compiler.
+* `6.2.6` API of the compiler.
 
-`6.2.7` Scripting support and Compiler REPL loop.
+* `6.2.7` Scripting support and Compiler REPL loop.
 
-`6.2.8` dokka (docs generation tool).
+* `6.2.8` dokka (docs generation tool).
 
-`6.2.9` Internal packages of the standard library.
+* `6.2.9` Internal packages of the standard library.
 
-`6.2.10` kotlin-reflect - until it graduates from the
+* `6.2.10` kotlin-reflect - until it graduates from the
     experimental status.
 
-`6.2.11` kotlin-script-runtime - until it graduates
+* `6.2.11` kotlin-script-runtime - until it graduates
     from the experimental status.
 
 
@@ -248,72 +248,72 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
 
 Notation: NC — new compiler, OC — old compiler.
 
-### `A.1` Binary Change, issues
+`A.1` Binary Change, issues
 
-`A.1.1` A binary produced from unchanged code with NC
+* `A.1.1` A binary produced from unchanged code with NC
     fails where the one produced by OC worked.
 
 *Examples of failures*: linkage error, runtime exceptions not
         present in previous versions, deadlocks, race conditions
 
-### `A.2` Binary Change, non-issues
+`A.2` Binary Change, non-issues
 
-`A.2.1` A binary compiled with NC may be rejected by
+* `A.2.1` A binary compiled with NC may be rejected by
     OC, when it relies on new language features unsupported in OC.
 
-`A.2.2` A binary compiled against a newer version of
+* `A.2.2` A binary compiled against a newer version of
     kotlin-stdlib fails when an older version of kotlin-stdlib is
     supplied at runtime.
 
-`A.2.3` Adding generic parameters to existing
+* `A.2.3` Adding generic parameters to existing
     declarations does not change the ABI on the JVM (due to erasure).
 
-`A.2.4` Changes to signatures of functions marked
+* `A.2.4` Changes to signatures of functions marked
     @InlineOnly are not changing the ABI on the JVM.
 
-`A.2.5` Adding supertypes to existing library
+* `A.2.5` Adding supertypes to existing library
 classes/interfaces.
 
-### `A.3` Source Change, issues
+`A.3` Source Change, issues
 
-`A.3.1` Sources that compiled with OC don't compile
+* `A.3.1` Sources that compiled with OC don't compile
     with NC against the same classpath.
 
-`A.3.2` Unchanged sources compile with NC, but their
+* `A.3.2` Unchanged sources compile with NC, but their
     behavior changes in a way significant for contract-abiding use
     cases.
 
-### `A.4` Source Change, non-issues
+`A.4` Source Change, non-issues
 
-`A.4.1` Code compilable with NC fails to compile with
+* `A.4.1` Code compilable with NC fails to compile with
     OC (e.g. due to new language features supported in NC).
 
-`A.4.2` The code breaks only if the user alters the
+* `A.4.2` The code breaks only if the user alters the
     build configuration or compiler settings explicitly (i.e. in
     addition to advancing the compiler version).
 
-### `A.5` Library Change, issues
+`A.5` Library Change, issues
 
-`A.5.1` Making a contract on existing API more strict
+* `A.5.1` Making a contract on existing API more strict
     than it used to be in a previous version.
 
-### `A.6` Library Change, non-issues
+`A.6` Library Change, non-issues
 
-`A.6.1` Relaxing a contract on existing APIs.
+* `A.6.1` Relaxing a contract on existing APIs.
 
-`A.6.2` Clarification for unspecified behaviors.
+* `A.6.2` Clarification for unspecified behaviors.
 
-`A.6.3` Changes in hashCode() are not breaking
+* `A.6.3` Changes in hashCode() are not breaking
     changes.
 
-`A.6.4` Changes in toString() on other than Boolean,
+* `A.6.4` Changes in toString() on other than Boolean,
     Numeric, and String types are not breaking changes.
 
-`A.6.5` Improper loading of two different versions of
+* `A.6.5` Improper loading of two different versions of
     stdlib at runtime.
 
 
-### `A.7` Performance changes
+`A.7` Performance changes
 
 We recognize that runtime performance and bytecode size are important
 metrics, and will make reasonable effort to keep them in a good shape,
@@ -329,26 +329,26 @@ problems for language evolution.
 `B.1` Changes in type inference and overload
     resolution algorithms.
 
-`B.1.1` It's reasonable to assume that overloads of
+* `B.1.1` It's reasonable to assume that overloads of
     the same function are generally intended to do the same thing. So,
     though undesirable, a change in overload resolution that causes a
     different overload to be selected, may be acceptable. We encourage
     our users to follow this principle when defining overloaded
     functions.
 
-`B.1.2` Some improvements in the language (such as
+* `B.1.2` Some improvements in the language (such as
     type inference, for example) may result in more precise static types
     known for some expressions. This may cause changes in overload
     resolution [as stated above](#B.1.1), or even in type
     signatures of declarations when return types are inferred from
     bodies.
 
-`B.1.3` some innocuous-looking changes in the source
+* `B.1.3` some innocuous-looking changes in the source
     code, done by the user, may cause similar effects. We encourage our
     users to specify return types explicitly on public APIs to ensure
     their stability and binary compatibility.
 
-`B.1.4` Other improvements in type inference may
+* `B.1.4` Other improvements in type inference may
     cause edge cases to break or change their results, but it's often
     tolerable to introduce such changes.
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -396,6 +396,11 @@ which will likely break source compatibility for many users. We still
 want to do it, but devise a migration mechanism that will first report
 future issues as warnings, and let the users migrate.
 
+
+
+
+<!-- Make sure the numbering is correct, and if not, report the errors -->
+
 <script language="javascript">
 sections = Array.from(document.getElementsByTagName("code"));
 report = document.getElementById("report");
@@ -408,14 +413,21 @@ function reportError(text, lastSecText) {
     
 lastSec = [];
 lastSecText = "";
+appendixBase = 0;
 function checkOrdering(groups) {
     currentSec = [];
     for (j = 1; j < groups.length && groups[j]; j += 2) {        
         level = (j / 2) | 0;              
-        currentValue = Number.parseInt(groups[j]);
+        group = groups[j];
+        currentValue = Number.parseInt(group);
+        if (Number.isNaN(currentValue))
+            currentValue = appendixBase + group.charCodeAt(0) - "A".charCodeAt(0) + 1; 
+          else if (level == 0) {
+              appendixBase = currentValue;
+          }
         currentSec[level] = currentValue;        
     }
-    currentSecText = currentSec.join(".");
+    currentSecText = groups[0];
     
     if (currentSec.length > lastSec.length + 1) {
         reportError(currentSecText, lastSecText)
@@ -453,7 +465,7 @@ for (i = 0; i < sections.length; i++) {
     sec = sections[i];
     text = sec.innerText;
     
-    groups = text.match("^([0-9]+)(\.([0-9]+))?(\.([0-9]+))?(\.([0-9]+))?$");
+    groups = text.match("^([0-9ABC]+)(\.([0-9]+))?(\.([0-9]+))?(\.([0-9]+))?$");
     if (!groups) continue;
     
     correct = checkOrdering(groups);

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -16,7 +16,6 @@ There will be external links to these paragraphs, and one needs a very good reas
 
 <ul id="report" style="color: red"></ul>
 
-## Intro
 This document contains definitions and policies with regards to version compatibility and languages changes. The Kotlin language designers & [committee](language-committee.html) use it as guidelines to consult with when making design decisions. 
 
 ## `1` Kotlin language evolution  
@@ -322,7 +321,7 @@ but we don't consider every slowdown (e.g. in edge cases or in very cold
 code) and every extra byte in the classfile a breaking change.
 
 
-## Appendix `B` Examples of subtle issues
+## Appendix `B`. Examples of subtle issues
 
 Banishing the changes listed in this section may pose significant
 problems for language evolution.

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -245,76 +245,76 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
     from the experimental status.
 
 
-## `8`. Examples: issues & non-issues
+## Appendix `A`. Examples: issues & non-issues
 
 Notation: NC — new compiler, OC — old compiler.
 
-### `8.1` Binary Change, issues
+### `A.1` Binary Change, issues
 
-`8.1.1` A binary produced from unchanged code with NC
+`A.1.1` A binary produced from unchanged code with NC
     fails where the one produced by OC worked.
 
 *Examples of failures*: linkage error, runtime exceptions not
         present in previous versions, deadlocks, race conditions
 
-### `8.2` Binary Change, non-issues
+### `A.2` Binary Change, non-issues
 
-`8.2.1` A binary compiled with NC may be rejected by
+`A.2.1` A binary compiled with NC may be rejected by
     OC, when it relies on new language features unsupported in OC.
 
-`8.2.2` A binary compiled against a newer version of
+`A.2.2` A binary compiled against a newer version of
     kotlin-stdlib fails when an older version of kotlin-stdlib is
     supplied at runtime.
 
-`8.2.3` Adding generic parameters to existing
+`A.2.3` Adding generic parameters to existing
     declarations does not change the ABI on the JVM (due to erasure).
 
-`8.2.4` Changes to signatures of functions marked
+`A.2.4` Changes to signatures of functions marked
     @InlineOnly are not changing the ABI on the JVM.
 
-`8.2.5` Adding supertypes to existing library
+`A.2.5` Adding supertypes to existing library
 classes/interfaces.
 
-### `8.3` Source Change, issues
+### `A.3` Source Change, issues
 
-`8.3.1` Sources that compiled with OC don't compile
+`A.3.1` Sources that compiled with OC don't compile
     with NC against the same classpath.
 
-`8.3.2` Unchanged sources compile with NC, but their
+`A.3.2` Unchanged sources compile with NC, but their
     behavior changes in a way significant for contract-abiding use
     cases.
 
-### `8.4` Source Change, non-issues
+### `A.4` Source Change, non-issues
 
-`8.4.1` Code compilable with NC fails to compile with
+`A.4.1` Code compilable with NC fails to compile with
     OC (e.g. due to new language features supported in NC).
 
-`8.4.2` The code breaks only if the user alters the
+`A.4.2` The code breaks only if the user alters the
     build configuration or compiler settings explicitly (i.e. in
     addition to advancing the compiler version).
 
-### `8.5` Library Change, issues
+### `A.5` Library Change, issues
 
-`8.5.1` Making a contract on existing API more strict
+`A.5.1` Making a contract on existing API more strict
     than it used to be in a previous version.
 
-### `8.6` Library Change, non-issues
+### `A.6` Library Change, non-issues
 
-`8.6.1` Relaxing a contract on existing APIs.
+`A.6.1` Relaxing a contract on existing APIs.
 
-`8.6.2` Clarification for unspecified behaviors.
+`A.6.2` Clarification for unspecified behaviors.
 
-`8.6.3` Changes in hashCode() are not breaking
+`A.6.3` Changes in hashCode() are not breaking
     changes.
 
-`8.6.4` Changes in toString() on other than Boolean,
+`A.6.4` Changes in toString() on other than Boolean,
     Numeric, and String types are not breaking changes.
 
-`8.6.5` Improper loading of two different versions of
+`A.6.5` Improper loading of two different versions of
     stdlib at runtime.
 
 
-### `8.7` Performance changes
+### `A.7` Performance changes
 
 We recognize that runtime performance and bytecode size are important
 metrics, and will make reasonable effort to keep them in a good shape,
@@ -322,46 +322,46 @@ but we don't consider every slowdown (e.g. in edge cases or in very cold
 code) and every extra byte in the classfile a breaking change.
 
 
-## Appendix `9` Examples of subtle issues
+## Appendix `B` Examples of subtle issues
 
 Banishing the changes listed in this section may pose significant
 problems for language evolution.
 
-`9.1` Changes in type inference and overload
+`B.1` Changes in type inference and overload
     resolution algorithms.
 
-`9.1.1` It's reasonable to assume that overloads of
+`B.1.1` It's reasonable to assume that overloads of
     the same function are generally intended to do the same thing. So,
     though undesirable, a change in overload resolution that causes a
     different overload to be selected, may be acceptable. We encourage
     our users to follow this principle when defining overloaded
     functions.
 
-`9.1.2` Some improvements in the language (such as
+`B.1.2` Some improvements in the language (such as
     type inference, for example) may result in more precise static types
     known for some expressions. This may cause changes in overload
     resolution [as stated above](#10.1.1), or even in type
     signatures of declarations when return types are inferred from
     bodies.
 
-`9.1.3` some innocuous-looking changes in the source
+`B.1.3` some innocuous-looking changes in the source
     code, done by the user, may cause similar effects. We encourage our
     users to specify return types explicitly on public APIs to ensure
     their stability and binary compatibility.
 
-`9.1.4` Other improvements in type inference may
+`B.1.4` Other improvements in type inference may
     cause edge cases to break or change their results, but it's often
     tolerable to introduce such changes.
 
 
-`9.2` Changes in private/synthetic JVM signatures
+`B.2` Changes in private/synthetic JVM signatures
 generated by the compiler.
 
 While generally an implementation detail that we would like to change,
 in exceptional cases when some users may rely heavily on such
 declarations, extra care will be required in introducing the changes.
 
-`9.3` Moving classes from one JAR to another.
+`B.3` Moving classes from one JAR to another.
 
 This may be required by the platform (e.g. JVM does not allow split
 packages, and the "kotlin" package has historically been split across
@@ -370,7 +370,7 @@ ProGuard, rejecting duplicate classes, etc). A reasonable migration
 strategy has to be worked out in each individual case, and some pain on
 the user end may be inevitable.
 
-`9.4` Compatibility with the future.
+`B.4` Compatibility with the future.
 
 In the case of unsigned arithmetic and value types for Kotlin, we know
 that Java is going to add them some time in the future, and our present
@@ -381,7 +381,7 @@ break. This is a matter of choosing a trade-off and a reasonable
 deprecation/migration policy.
 
 
-`9.5` Compatibility of mental models.
+`B.5` Compatibility of mental models.
 
 Kotlin unsigned integers will be signed for Java clients, and the
 programmer that works with the same API in the Java code will be
@@ -389,7 +389,7 @@ surprised by getting different result. While an undesirable situation,
 this is sometimes inevitable, and should not be considered a breaking
 change (it does not fall under the intuitive definition of one anyway).
 
-`9.6` Interop compatibility vs improvements.
+`B.6` Interop compatibility vs improvements.
 
 *Example*: Android SDK needs to introduce nullability annotations,
 which will likely break source compatibility for many users. We still

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -54,8 +54,6 @@ This document contains definitions and policies with regards to version compatib
 
 `2.4.4` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
 
-`2.6.1` *NOTE*: Binary incompatibilities for the JVM are generally a lot harder to address on the user side, so requiring the  users to fix them should be avoided.
- 
 `2.7` Any change that deprecates or breaks
 compatibility for a language feature or standard API needs to be reviewed by the [Kotlin
 Language Committee](language-committee.html) following the
@@ -235,29 +233,6 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
 
 `5.6.11` kotlin-script-runtime - until it graduates
     from the experimental status.
-
-## `5.7` Different requirements for different platforms
-
-### `5.8` Kotlin/JVM
-
-No additional requirements on deprecation/breaking changes.
-
-### `5.9` Kotlin/JS
-
-`5.9.1` Binary compatibility is not guaranteed for the
-JS world, because everything is usually built from sources.
-
-### `5.10` Kotlin/Native
-
-`5.10.1` Until Kotlin/Native reaches an official
-    release, no compatibility guarantees are given for Kotlin/Native.
-
-`5.10.2` After Kotlin/Native reaches the official
-    release, the binary compatibility guarantees should be considered
-    for Kotlin/Native, but as long as it is mostly focused on statically
-    linked programs, the importance of binary compatibility is
-    relatively low (compared to Kotlin/JVM).
-
 
 ## `5.11` Examples: issues & non-issues
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -14,6 +14,7 @@ There will be external links to these paragraphs, and one needs a very good reas
 
 # Backwards Incompatible Changes and Deprecation Guidelines
 
+<ul id="report" style="color: red"></ul>
 
 ## Intro
 This document contains definitions and policies with regards to version compatibility and languages changes. The Kotlin language designers & [committee](language-committee.html) use it as guidelines to consult with when making design decisions. 
@@ -395,3 +396,77 @@ which will likely break source compatibility for many users. We still
 want to do it, but devise a migration mechanism that will first report
 future issues as warnings, and let the users migrate.
 
+<script language="javascript">
+sections = Array.from(document.getElementsByTagName("code"));
+report = document.getElementById("report");
+
+function reportError(text, lastSecText) {
+    report.innerHTML += "<li><code><a href=\"#" + text + "\">" + text + "</a>" 
+            + "</code> is out of order with " 
+            + "<code><a href=\"#" + lastSecText + "\">" + lastSecText + "</a></code></li>";
+}
+    
+lastSec = [];
+lastSecText = "";
+function checkOrdering(groups) {
+    currentSec = [];
+    for (j = 1; j < groups.length && groups[j]; j += 2) {        
+        level = (j / 2) | 0;              
+        currentValue = Number.parseInt(groups[j]);
+        currentSec[level] = currentValue;        
+    }
+    currentSecText = currentSec.join(".");
+    
+    if (currentSec.length > lastSec.length + 1) {
+        reportError(currentSecText, lastSecText)
+        result = false;
+    }
+    
+    for (level = 0; level < Math.max(currentSec.length, lastSec.length); level++) {
+        currentSec[level] = currentSec[level] ? currentSec[level] : 0; 
+        lastSec[level] = lastSec[level] ? lastSec[level] : 0; 
+    }
+        
+    result = true;
+        
+    for (level = 0; level < currentSec.length; level++) {
+        if (lastSec[level] < currentSec[level] - 1) {
+            reportError(currentSecText, lastSecText);
+            result = false;
+        }
+        if (lastSec[level] < currentSec[level]) break;
+        if ((lastSec[level] > currentSec[level])) {
+            reportError(currentSecText, lastSecText);
+            result = false;
+        }       
+    }
+    if (lastSec.toString() == currentSec.toString()) {
+        reportError(currentSecText, lastSecText);        
+        result = false;
+    }
+    lastSec = currentSec;
+    lastSecText = currentSecText;
+    return result;
+}
+
+for (i = 0; i < sections.length; i++) {
+    sec = sections[i];
+    text = sec.innerText;
+    
+    groups = text.match("^([0-9]+)(\.([0-9]+))?(\.([0-9]+))?(\.([0-9]+))?$");
+    if (!groups) continue;
+    
+    correct = checkOrdering(groups);
+    
+    anchor = document.createElement("a");
+    anchor.innerText = text;
+    anchor.href = "#" + text;
+    anchor.name = text;
+    if (!correct) {
+        anchor.style.color = "red";
+    }
+    
+    sec.insertAdjacentElement('beforebegin', anchor);
+    sec.remove();
+}
+</script>

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -59,6 +59,15 @@ compatibility for a language feature or standard API needs to be reviewed by the
 Language Committee](language-committee.html) following the
 [review procedure](/change-review-process.html).
 
+## `7` Changes to this policy
+
+`7.1` Changes to this policy need to be approved by
+    the Kotlin Language Committee.
+
+`7.2` Any proposed change needs to be published as
+    a GitHub pull request; providing a reasonable time to allow for
+     comments on the change by the Kotlin Community.
+
 ## `3` Types of incompatible changes and corresponding guidelines
 
 `3.1` Small fixes that virtually no users will
@@ -384,13 +393,4 @@ change (it does not fall under the intuitive definition of one anyway).
 which will likely break source compatibility for many users. We still
 want to do it, but devise a migration mechanism that will first report
 future issues as warnings, and let the users migrate.
-
-## `7` Changes to this policy
-
-`7.1` Changes to this policy need to be approved by
-    the Kotlin Language Committee.
-
-`7.2` Any proposed change needs to be published as
-    a GitHub pull request; providing a reasonable time to allow for
-     comments on the change by the Kotlin Community.
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -99,12 +99,12 @@ Language Committee](language-committee.html) following the
 ## `4` Deprecation procedures for language features
 
 Deprecation is closely related to versioning, for versioning scheme
-we defer to the existing
-[versioning policy](https://kotlinlang.org/docs/reference/compatibility.html).
+we refer to the existing [versioning policy](../reference/compatibility.html).
 
 `4.1` Before any changes are made, the upcoming
     change along with its rationale and the deprecation/migration plan
-    need to be announced to the Kotlin Community.
+    need to be announced to the Kotlin community, 
+    preview builds of the compiler and standard library should be made available.
 
 `4.2` Release a version (call it N.M) that reports
     deprecation warnings for the feature:
@@ -179,7 +179,7 @@ we defer to the existing
 
 
 
-## `5.4` The scope of this policy
+## `6` The scope of this policy
 
 ### `5.5` In scope
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -15,232 +15,232 @@ There will be external links to these paragraphs, and one needs a very good reas
 # Backwards Incompatible Changes and Deprecation Guidelines
 
 
-## `1` Intro
+## Intro
 This document contains definitions and policies with regards to version compatibility and languages changes. The Kotlin language designers & [committee](language-committee.html) use it as guidelines to consult with when making design decisions. 
 
-## `2` Kotlin language evolution  
+## `1` Kotlin language evolution  
 
-`2.1` **Our creed**. Kotlin is and should remain a modern language for industry. We care about pragmatics, not formality.
+`1.1` **Our creed**. Kotlin is and should remain a modern language for industry. We care about pragmatics, not formality.
 
-`2.1.1` This means that we have to reconcile moving fast (which sometimes requires breaking things) and keeping the design stable enough to be pragmatically usable. We are balancing between two priorities: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully.  
+`1.1.1` This means that we have to reconcile moving fast (which sometimes requires breaking things) and keeping the design stable enough to be pragmatically usable. We are balancing between two priorities: **the long-term health of the language** and **the short-term comfort of its users**. Both are very important, and trade-offs are to be made carefully.  
 
-`2.2` **Keeping the language modern**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up. Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
+`1.2` **Keeping the language modern**. We recognize that languages accumulate legacy over time. Our goal is to keep the Kotlin language fit and modern by cleaning this legacy up. Obsolete things should be eventually dropped, and bugs should be fixed. We are willing to make such changes after careful consideration and justification.
 
-`2.2.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
+`1.2.1` *NOTE*: Keeping all the legacy around forever would mean that every language design decision made must be proven to be 100% correct and never require future fixes. In practice, it would hinder language evolution a lot, so we want to be able to move faster knowing that we can make mistakes and fix them in the future. This being said, we recognize that our mistakes cause our users pain, so we try to avoid them to the best of our abilities.   
 
-`2.2.2` *Example*: bugs and underspecified/accidental behaviors
+`1.2.2` *Example*: bugs and underspecified/accidental behaviors
     in `kotlinc` and `kotlin-stdlib` may require incompatible fixes, and it
     is often better to fix them (formally, breaking compatibility) than
     carry them around indefinitely.
 
-`2.2.3` *Example*: some language improvements that
+`1.2.3` *Example*: some language improvements that
     many users will benefit from may introduce subtle changes that do
     not harm most of the code out there.
 
-`2.2.4` *Example*: legacy features that are no longer
+`1.2.4` *Example*: legacy features that are no longer
     considered a good practice should be phased out (very) gradually.
 
-`2.2.5` *Example*: mechanisms that became irrelevant over time due to some changes in the environment should also be phased out.
+`1.2.5` *Example*: mechanisms that became irrelevant over time due to some changes in the environment should also be phased out.
 
-`2.3` **Pragmatic usefulness**. We also recognize that backwards incompatible changes in the language are distracting developers from their primary focus and should be generally avoided. When necessary, to be pragmatically beneficial, such changes should go through a graceful deprecation cycle, where the user is never stuck with a large number of migration issues to be addressed manually. 
+`1.3` **Pragmatic usefulness**. We also recognize that backwards incompatible changes in the language are distracting developers from their primary focus and should be generally avoided. When necessary, to be pragmatically beneficial, such changes should go through a graceful deprecation cycle, where the user is never stuck with a large number of migration issues to be addressed manually. 
 
-`2.3.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
+`1.3.1` Users' binaries and source code shouldn't break unexpectedly or frequently on compiler updates. 
 
-`2.3.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it.  
+`1.3.2` If a backwards incompatible change inconveniences many users of the language considerably, it makes the change highly questionable, so only an exceptional need can justify it.  
 
-`2.3.3` Backwards incompatible changes should be introduced through a deprecation when possible. 
+`1.3.3` Backwards incompatible changes should be introduced through a deprecation when possible. 
 
-`2.3.4` The tooling should provide means of detection and migration: users shouldn't be required to do much by hand.
+`1.3.4` The tooling should provide means of detection and migration: users shouldn't be required to do much by hand.
 
-`2.3.5` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
+`1.3.5` Users should be informed about such changes in a timely fashion (exact timeline is to be defined on a case-by-case basis). In particular, users should have enough time to migrate comfortably.
 
-`2.4` Any change that deprecates or breaks
+`1.4` Any change that deprecates or breaks
 compatibility for a language feature or standard API needs to be reviewed by the [Kotlin
 Language Committee](language-committee.html) following the
 [review procedure](/change-review-process.html).
 
-## `3` Changes to this policy
+## `2` Changes to this policy
 
-`3.1` Changes to this policy need to be approved by
+`2.1` Changes to this policy need to be approved by
     the Kotlin Language Committee.
 
-`3.2` Any proposed change needs to be published as
+`2.2` Any proposed change needs to be published as
     a GitHub pull request; providing a reasonable time to allow for
      comments on the change by the Kotlin Community.
 
-## `4` Types of incompatible changes and corresponding guidelines
+## `3` Types of incompatible changes and corresponding guidelines
 
-`4.1` Small fixes that virtually no users will
+`3.1` Small fixes that virtually no users will
     encounter can normally be made right away (still require committee
     [review](#2.4)).
 
-`4.1.1` When unsure about the full risk/impact of
+`3.1.1` When unsure about the full risk/impact of
     a change:
 
 *   Implement the change in a preview build.
 *   Try on large bodies of code available to us.
 *   Fall back to [deprecation procedure](#4) if needed.
 
-`4.2` Behavior-changing bug fixes in `kotlinc`:
+`3.2` Behavior-changing bug fixes in `kotlinc`:
 
-`4.2.1` Good code did not compile due to a bug can be
+`3.2.1` Good code did not compile due to a bug can be
     fixed right away.
 
-`4.2.2` Bad code compiled due to a bug, but always
+`3.2.2` Bad code compiled due to a bug, but always
     failed at runtime can be fixed right away.
 
-`4.2.3` Bad code compiled due to a bug, and worked
+`3.2.3` Bad code compiled due to a bug, and worked
     reasonably, must follow the deprecation policy spelled out in
     [Paragraph 4](#4).
 
 
-`4.3` Bug fixes and contract refinement in the
+`3.3` Bug fixes and contract refinement in the
  `kotlin-stdlib` require publishing a release note one version in advance.
 
-`4.4` Retiring language features & `kotlin-stdlib` APIs
+`3.4` Retiring language features & `kotlin-stdlib` APIs
     must follow the deprecation policies spelled out in
     [Paragraph 4](#4) and [Paragraph 5](#5).
 
 
 
-## `5` Deprecation procedures for language features
+## `4` Deprecation procedures for language features
 
 Deprecation is closely related to versioning, for versioning scheme
 we refer to the existing [versioning policy](../reference/compatibility.html).
 
-`5.1` Before any changes are made, the upcoming
+`4.1` Before any changes are made, the upcoming
     change along with its rationale and the deprecation/migration plan
     need to be announced to the Kotlin community, 
     preview builds of the compiler and standard library should be made available.
 
-`5.2` Release a version (call it N.M) that reports
+`4.2` Release a version (call it N.M) that reports
     deprecation warnings for the feature:
 
-`5.2.1` Provide and describe a replacement for
+`4.2.1` Provide and describe a replacement for
     deprecated constructs as part of the warning.
 
-`5.2.2` Allow to disable the warnings in settings,
+`4.2.2` Allow to disable the warnings in settings,
     or promote them to errors.
 
-`5.2.3` Along with this version, provide automated
+`4.2.3` Along with this version, provide automated
     migration aids (e.g. in the IDE).
 
-`5.3` Allow a long enough period of time for
+`4.3` Allow a long enough period of time for
     migration, the exact time will be based on the impact and complexity
     of the change as discussed during the Kotlin Language Committee
     [review](/process/index.html).
 
-`5.4` In the version N.M+1 or N+1, report errors for
+`4.4` In the version N.M+1 or N+1, report errors for
  previously deprecated cases.
 
-`5.4.1` In the release notes, repeat the information
+`4.4.1` In the release notes, repeat the information
     about the deprecation plan.
 
-`5.4.2` Allow to demote the errors to warnings through
+`4.4.2` Allow to demote the errors to warnings through
     settings.
 
-`5.4.3` Keep migration aids available.
+`4.4.3` Keep migration aids available.
 
-`5.5` In the version N.M+2 or N+1, report errors for
+`4.5` In the version N.M+2 or N+1, report errors for
     the deprecated feature.
 
-`5.5.1` In the release notes, declare the feature as
+`4.5.1` In the release notes, declare the feature as
     discontinued.
 
-`5.5.2` If possible, keep a compatibility mode that
+`4.5.2` If possible, keep a compatibility mode that
     does not support new features, but allows the deprecated one as in
     version N.M+1 or N+1.X.
 
-`5.5.3` Migration aids can be removed from the
+`4.5.3` Migration aids can be removed from the
     compiler at this point.
 
-`5.6` A version that supports automated migration
+`4.6` A version that supports automated migration
     must be maintained and kept available for download. Such tools can
     be retired after support period of a few years, and the retirement
     must be announced at least 1 year in advance.
 
-`5.7` Backward compatibility modes in the compiler
+`4.7` Backward compatibility modes in the compiler
     (through -language-version and -api-version) are supported for a few
     years and their retirement must be announced at least 1 year in
     advance.
 
-## `6` Deprecation procedure for the Standard Library
+## `5` Deprecation procedure for the Standard Library
 
-`6.1` Version N: Mark the declarations as
+`5.1` Version N: Mark the declarations as
 `@Deprecated(level = WARNING)`
 
-`6.1.1` Provide reasonable ReplaceWith if possible,
+`5.1.1` Provide reasonable ReplaceWith if possible,
     or custom migration aids if needed.
 
-`6.1.2` Provide an optional support dependency that
+`5.1.2` Provide an optional support dependency that
     exposes the same API.
 
-`6.2` Version N+1: Mark the declarations as
+`5.2` Version N+1: Mark the declarations as
 `@Deprecated(level = ERROR)`
 
-`6.3` Version N+2: Mark the declarations as
+`5.3` Version N+2: Mark the declarations as
 `@Deprecated(level = HIDDEN)`
 
-`6.3.1`  *Note*: for inline functions, complete
+`5.3.1`  *Note*: for inline functions, complete
      removal is sometimes possible at this point.
 
 
 
-## `7` The scope of this policy
+## `6` The scope of this policy
 
-### `7.1` In scope
+### `6.1` In scope
 
-`7.1.1` Language: syntax, static checks, execution
+`6.1.1` Language: syntax, static checks, execution
     semantics of language constructs.
 
-`7.1.2` The interop subsystem of the language: how
+`6.1.2` The interop subsystem of the language: how
     Java declarations are seen from Kotlin, and how Kotlin declarations
     are seen from Java.
 
-`7.1.3` Compatibility of binary artifacts produced by
+`6.1.3` Compatibility of binary artifacts produced by
  kotlinc with one another and with Java binaries
 
-`7.1.4` Standard library: API and contracts of the
+`6.1.4` Standard library: API and contracts of the
     declarations in kotlin-stdlib (and its  extensions such as for JRE
     7 & 8).
 
-`7.1.5` CLI parameters of the compiler except for the
+`6.1.5` CLI parameters of the compiler except for the
     -X keys.
 
-`7.1.6` Language Feature, Syntax & API Migration
+`6.1.6` Language Feature, Syntax & API Migration
  tools.
 
-`7.1.7` KDoc syntax.
+`6.1.7` KDoc syntax.
 
 
-### `7.2` Out of scope
+### `6.2` Out of scope
 
-`7.2.1` Build tools and plugins for them (e.g. Gradle
+`6.2.1` Build tools and plugins for them (e.g. Gradle
     support).
 
-`7.2.2` IDE and static analysis tools (other than the
+`6.2.2` IDE and static analysis tools (other than the
     compiler).
 
-`7.2.3` Java2Kotlin converter and other source code
+`6.2.3` Java2Kotlin converter and other source code
     manipulation tools.
 
-`7.2.4` Experimental language features & APIs.
+`6.2.4` Experimental language features & APIs.
 
-`7.2.5` APIs and contracts of libraries other than the
+`6.2.5` APIs and contracts of libraries other than the
     standard library.
 
-`7.2.6` API of the compiler.
+`6.2.6` API of the compiler.
 
-`7.2.7` Scripting support and Compiler REPL loop.
+`6.2.7` Scripting support and Compiler REPL loop.
 
-`7.2.8` dokka (docs generation tool).
+`6.2.8` dokka (docs generation tool).
 
-`7.2.9` Internal packages of the standard library.
+`6.2.9` Internal packages of the standard library.
 
-`7.2.10` kotlin-reflect - until it graduates from the
+`6.2.10` kotlin-reflect - until it graduates from the
     experimental status.
 
-`7.2.11` kotlin-script-runtime - until it graduates
+`6.2.11` kotlin-script-runtime - until it graduates
     from the experimental status.
 
 

--- a/pages/docs/evolution/breaking-changes.md
+++ b/pages/docs/evolution/breaking-changes.md
@@ -58,7 +58,7 @@ This document contains definitions and policies with regards to version compatib
 `1.4` Any change that deprecates or breaks
 compatibility for a language feature or standard API needs to be reviewed by the [Kotlin
 Language Committee](language-committee.html) following the
-[review procedure](/change-review-process.html).
+[review procedure](change-review-process.html).
 
 ## `2` Changes to this policy
 
@@ -73,7 +73,7 @@ Language Committee](language-committee.html) following the
 
 `3.1` Small fixes that virtually no users will
     encounter can normally be made right away (still require committee
-    [review](#2.4)).
+    [review](#1.4)).
 
 `3.1.1` When unsure about the full risk/impact of
     a change:
@@ -129,7 +129,7 @@ we refer to the existing [versioning policy](../reference/compatibility.html).
 `4.3` Allow a long enough period of time for
     migration, the exact time will be based on the impact and complexity
     of the change as discussed during the Kotlin Language Committee
-    [review](/process/index.html).
+    [review](change-review-process.html).
 
 `4.4` In the version N.M+1 or N+1, report errors for
  previously deprecated cases.
@@ -340,7 +340,7 @@ problems for language evolution.
 `B.1.2` Some improvements in the language (such as
     type inference, for example) may result in more precise static types
     known for some expressions. This may cause changes in overload
-    resolution [as stated above](#10.1.1), or even in type
+    resolution [as stated above](#B.1.1), or even in type
     signatures of declarations when return types are inferred from
     bodies.
 

--- a/pages/docs/evolution/change-review-process.md
+++ b/pages/docs/evolution/change-review-process.md
@@ -1,0 +1,49 @@
+---
+type: doc
+layout: reference
+category: "Language Evolution"
+title: "Change Review Process"
+toc: true
+---
+
+# Scheduling a proposed change for review
+
+The committee meets every few weeks to review any upcoming changes.
+
+To get a change scheduled for review:
+
+*   Ensure there is a bug tracking the change in the
+    [Kotlin Issue Tracker](https://youtrack.jetbrains.com/issues/KT)
+*   Include the following information in the bug:
+    *   Concrete sample of the existing behavior/pattern/bug
+    *   Concrete sample of the proposed behavior/pattern
+    *   If possible an indication of the impact of this change
+        (# impacted users, how common this pattern is, etc..)
+    *   Description what part of the above deprecation policy this
+        change should fall
+    *   Proposed compiler versions where this change will land
+        (e.g. when will the warning show up, when will it become an
+        error)
+*   Add the tag
+'[for-language-committee](https://youtrack.jetbrains.com/issues/KT?q=project:%20Kotlin%20tag:%20for-language-committee%20%23Unresolved)'
+to make the bug show up on the committee's radar.
+
+
+# Committee review & response
+
+*   The committee members preview bugs in the queue a couple of days
+    before the committee meets and might post additional questions on
+    the bugs.
+*   At the committee meeting, members review the bugs in the queue
+    together and try to make a decision.
+*   The committee will post their notes to the bug, this can be a
+    request for more information or a decision.
+*   When the committee approves the change, they will mark the bug
+    with 'language-committee-approved'
+
+# Urgent Reviews
+
+Reviews that need a decision before the next committee meeting (e.g.
+because of a release deadline) can be done by the committee in
+email/chat. These type of reviews need to be requested by the Lead
+Kotlin Language Designer (currently Andrey Breslav).

--- a/pages/docs/evolution/change-review-process.md
+++ b/pages/docs/evolution/change-review-process.md
@@ -14,20 +14,10 @@ To get a change scheduled for review:
 
 *   Ensure there is a bug tracking the change in the
     [Kotlin Issue Tracker](https://youtrack.jetbrains.com/issues/KT)
-*   Include the following information in the bug:
-    *   Concrete sample of the existing behavior/pattern/bug
-    *   Concrete sample of the proposed behavior/pattern
-    *   If possible an indication of the impact of this change
-        (# impacted users, how common this pattern is, etc..)
-    *   Description what part of the above deprecation policy this
-        change should fall
-    *   Proposed compiler versions where this change will land
-        (e.g. when will the warning show up, when will it become an
-        error)
+  * Use the template [below](#issue-template)
 *   Add the tag
 '[for-language-committee](https://youtrack.jetbrains.com/issues/KT?q=project:%20Kotlin%20tag:%20for-language-committee%20%23Unresolved)'
 to make the bug show up on the committee's radar.
-
 
 # Committee review & response
 
@@ -47,3 +37,42 @@ Reviews that need a decision before the next committee meeting (e.g.
 because of a release deadline) can be done by the committee in
 email/chat. These type of reviews need to be requested by the Lead
 Kotlin Language Designer (currently Andrey Breslav).
+
+# Issue Template
+
+``` java
+# Summary
+> This section is optional, may contain some motivation and background  
+
+# Existing behavior/pattern/bug
+> 1. (Minimal) code example
+> 2. What's wrong with it
+> 3. Detailed explanation of why and how this happens
+> 4. Any known reasoning behind such behavior 
+
+# Proposed behavior/pattern
+> 1. How it fixes the issue?
+> 2. Describe automated migration, if possible
+
+# Impact of this change
+> If possible: 
+> * number of impacted users
+> * how common this pattern is
+> * if we believe it's a rare case, why
+> * is automated migration possible
+
+# Applicable policies 
+> Quotes of relevant sections of the policies 
+> from http://kotlinlang.org/docs/evolution/breaking-changes.html
+
+# Affected versions 
+> * Provide a detailed step-by-step migration plan
+> * Refer to relevant policy sections to justify the proposed changes
+> Example:
+> * Alter signatures of `MutableMap.getValue` and `setValue`
+>   * 1.2.20: add new declarations, deprecate old ones warning 
+>     and `ReplaceWith` per section 5.1
+>   * 1.3: elevate warning to error per section 5.2
+>   * 1.4: remove old declarations (section 5.3: HIDDEN is not needed, because of 
+>     `@InlineOnly`)
+```

--- a/pages/docs/evolution/language-committee.md
+++ b/pages/docs/evolution/language-committee.md
@@ -1,0 +1,28 @@
+---
+type: doc
+layout: reference
+category: "Language Evolution"
+title: "About the Kotlin Language Committee"
+---
+
+# About the Kotlin Language Committee 
+
+As part of the efforts to move Kotlin into a non-profit entity, the Kotlin
+Language Committee was created to oversee changes to the Kotlin
+language.
+
+This committee is in charge of ensuring the Kotlin language ages well
+over time; to ensure that any work done in new versions of the language
+does not put an undue burden on users trying to migrate from older
+versions to the newer version.
+
+The committee achieves this goal by maintaining this deprecation policy
+and reviewing proposed changes to the language and determining what
+parts of the deprecation procedures apply.
+
+Current members of this committee:
+
+*   [William Cook, University of Texas at Austin](https://github.com/w7cook)
+*   [Andrey Breslav, JetBrains](https://github.com/abreslav)
+*   [Jeffrey van Gogh, Google](https://github.com/jvgogh)
+

--- a/pages/docs/evolution/language-committee.md
+++ b/pages/docs/evolution/language-committee.md
@@ -5,20 +5,26 @@ category: "Language Evolution"
 title: "About the Kotlin Language Committee"
 ---
 
-# About the Kotlin Language Committee 
+# Kotlin Language Evolution 
 
-As part of the efforts to move Kotlin into a non-profit entity, the Kotlin
-Language Committee was created to oversee changes to the Kotlin
-language.
+Evolving a language in a consistent and healthy way is challenging due to a number of trade-offs, biggest of which are adding useful features vs keeping the complexity down and getting rid of legacy vs maintaining compatibility. In both cases, the balance is not immediately obvious. Growing a language must be done very cautiously to avoid both "feature creep" and stagnation. It's much easier to build a modern language from scratch than to keep it modern over the course of many years. Kotlin aims at the sweet spot of evolving continuously and pragmatically.
 
+This document outlines the governance model of language evolution for Kotlin.
+
+## Lead Language Designer 
+
+In Kotlin, the job of finding the right balance in these trade-offs and directing the language evolution belongs to the Lead Language Designer (currently Andrey Breslav). The Lead Designer, while consulting extensively with many other people including the community, holds the ultimate decision power in all matters concerning evolving the language (some people call this "benevolent dictatorship"), limited only in the case of backwards incompatible changes (see next section).
+
+## Language Committee
+
+As part of the efforts to move Kotlin into a non-profit entity, the Kotlin Language Committee was created to oversee changes to the Kotlin language. 
+ 
 This committee is in charge of ensuring the Kotlin language ages well
 over time; to ensure that any work done in new versions of the language
 does not put an undue burden on users trying to migrate from older
 versions to the newer version.
 
-The committee achieves this goal by maintaining this deprecation policy
-and reviewing proposed changes to the language and determining what
-parts of the deprecation procedures apply.
+If the Lead Language Designer decides to introduce a backwards incompatible change to the language, this decision must be approved by the Kotlin Language Committee. For each proposed change the committee also decides which deprecation procedures are to be applied. The committee maintains a set of [guidelines]() that are being consulted with when making such decisions.  
 
 Current members of this committee:
 

--- a/pages/docs/evolution/language-committee.md
+++ b/pages/docs/evolution/language-committee.md
@@ -32,3 +32,6 @@ Current members of this committee:
 *   [Andrey Breslav, JetBrains](https://github.com/abreslav)
 *   [Jeffrey van Gogh, Google](https://github.com/jvgogh)
 
+### Open Process 
+
+Meeting minutes of the Language Committee are public and can be viewed live in [this document](https://docs.google.com/document/d/1ReH84Cw_ZhGOUM_MdMQbLjzB0edXIeaFuBUF5molsuI/preview). 

--- a/pages/docs/reference/compatibility.md
+++ b/pages/docs/reference/compatibility.md
@@ -33,7 +33,7 @@ Compatibility means answering the question: for given two versions of Kotlin (fo
   - API (`kotlin-stdlib-*`, `kotlin-reflect-*`)
     - new APIs may be added
     - deprecations with level `WARNING` may be added/removed
-    - deprecations with level `WARNING` may be elevated to level `ERROR` or `HIDDEN` in NV
+    - deprecations with level `WARNING` in OV may be elevated to level `ERROR` or `HIDDEN` in NV
 - **BCB** - **B**ackward **C**ompatibility for **B**inaries
   - Binaries (ABI)
     - runtime: NV-binaries can be used  everywhere where OV binaries worked

--- a/pages/docs/reference/compatibility.md
+++ b/pages/docs/reference/compatibility.md
@@ -49,7 +49,7 @@ Compatibility means answering the question: for given two versions of Kotlin (fo
 
 ---
 
-\* No changes *modulo bugs* means that if an important bug is found (e.g. in the compiler diagnostics or elsewhere), a fix for it may introduce a breaking change, but we are always very careful with such changes.
+\* No changes *modulo bugs* means that if an important bug is found (e.g. in the compiler diagnostics or elsewhere), a fix for it may introduce [a breaking change](../evolution/breaking-changes.html), but we are always very careful with such changes.
 
 ## Compatibility guarantees for Kotlin releases
 

--- a/pages/docs/reference/compatibility.md
+++ b/pages/docs/reference/compatibility.md
@@ -53,7 +53,7 @@ Compatibility means answering the question: for given two versions of Kotlin (fo
 
 ## Compatibility guarantees for Kotlin releases
 
-**Kotlin for JVM**:
+**Kotlin/JVM**:
   - patch version updates (e.g. 1.1.X) are fully compatible;
   - minor version updates (e.g. 1.X) are backwards compatible.
 
@@ -66,7 +66,7 @@ Compatibility means answering the question: for given two versions of Kotlin (fo
 | **...**   | ... | ...   | ... | ...   | ... | ... |
 | **2.0**   | ?   | ?     | ?   | ?     | ... | - 
 
-**Kotlin for JS**: starting with Kotlin 1.1, both patch and minor version updates provide backward compatibility for the language and API (BCLA), but no BCB.  
+**Kotlin/JS**: starting with Kotlin 1.1, both patch and minor version updates provide backward compatibility for the language and API (BCLA), but no BCB.  
 
 | Kotlin    | 1.0.X | 1.1  | 1.1.X | ... | 2.0 |
 |----------:|:-----:|:----:|:-----:|:---:|:---:|
@@ -77,6 +77,8 @@ Compatibility means answering the question: for given two versions of Kotlin (fo
 | **2.0**   | EXP   | ?    | ?     | ... | - 
 
 **Kotlin Scripts**: both patch and minor version updates provide backward compatibility for the language and API (BCLA), but no BCB.
+
+**Kotlin/Native**: no guarantees until 1.0 is released.
 
 ## Compatibility across platforms
  


### PR DESCRIPTION
This PR contains the initial version of the documents describing how Kotlin's evolution is governed. These documents describe the general guidelines on how decisions about language and core library changes are made.

To understand the context, please read the [langauge-committee.md](https://github.com/JetBrains/kotlin-web-site/blob/5688f9cd1ee14283423417b0b6f3a7bb1b5d5582/pages/docs/evolution/language-committee.md) file first.

These documents have been prepared by the Kotlin Language Committee, and are now offered here to gather feedback from the community. Your comments are very welcome