### PR TITLE
Update formatting to match Kotlin style

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -13,7 +13,7 @@ Functions in Kotlin are declared using the *fun*{: .keyword } keyword:
 
 ``` kotlin
 fun double(x: Int): Int {
-    return 2*x
+    return 2 * x
 }
 ```
 


### PR DESCRIPTION
The expression `2*x` should be formatted as `2 * x`.