### PR TITLE
Remove Kotlin formatting from print statements

### DIFF
--- a/pages/docs/reference/delegated-properties.md
+++ b/pages/docs/reference/delegated-properties.md
@@ -50,7 +50,7 @@ println(e.p)
 
 This prints:
 
-``` kotlin
+```
 Example@33a17727, thank you for delegating ‘p’ to me!
 ```
  
@@ -62,7 +62,7 @@ e.p = "NEW"
 
 This prints
  
-``` kotlin
+```
 NEW has been assigned to ‘p’ in Example@33a17727.
 ```
 


### PR DESCRIPTION
Both of these "this prints:" examples had Kotlin keywords in them, so they were displayed in multicolor.