### PR TITLE
Fix tailrec example

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -340,7 +340,7 @@ private fun findFixPoint(): Double {
     var x = 1.0
     while (true) {
         val y = Math.cos(x)
-        if (x == y) return y
+        if (x == y) return x
         x = y
     }
 }


### PR DESCRIPTION
Tailrec part of `if (x == Math.cos(x)) x` is equivalent of `if (x == y) return x` not `if (x == y) return y`, if I get it right...