### PR TITLE
remove contradict suggestion for factory name

### DIFF
--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -65,16 +65,6 @@ fun processDeclarations() { ... }
 var declarationCount = ...
 ``` 
 
-Exception: factory functions used to create instances of classes can have the same name as the class being created:
-
-``` kotlin
-abstract class Foo { ... }
-
-class FooImpl : Foo { ... }
-
-fun Foo(): Foo { return FooImpl(...) }
-```
-
 Names of constants (properties marked with `const`, or top-level or object properties that hold data) 
 should use uppercase underscore-separated names:
 


### PR DESCRIPTION
suggestion to name factory method as the class name contradicts suggestion in another part of the document:
"Exception: factory functions used to create instances of classes can have the same name as the class being created"
contradicts:
"If you declare a factory function for a class, avoid giving it the same name as the class itself. Prefer using a distinct name making it clear why the behaviour of the factory function is special. Example:"

which is here: https://github.com/JetBrains/kotlin-web-site/blob/yole/styleguide/pages/docs/reference/coding-conventions.md#factory-functions