### PR TITLE
Fixing the name of organizer user group for one event.

### DIFF
--- a/data/events.xml
+++ b/data/events.xml
@@ -4336,7 +4336,7 @@ So would you like to taste kotlin with Android with us?</p>
         <endDate>2017-10-05</endDate>
         <location>Banja Luka, Bosnia-Herzegovina</location>
         <speaker>Dusko Bajic</speaker>
-        <title>Kotlin User Group Serbia</title>
+        <title>Kotlin User Group Bosnia</title>
         <subject>Introduction to Kotlin</subject>
         <url>https://www.meetup.com/Kotlin-User-Group-Bosnia/events/242956306/</url>
         <description>


### PR DESCRIPTION
Organizer UG name fix for the event in Banja Luka form 5th October.