### PR TITLE
Add a three-letter acronym

### DIFF
--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -175,7 +175,7 @@ The names should make it clear what the purpose of the entity is, so it's best t
 (`Manager`, `Wrapper` etc.) in names.
 
 When using an acronym as part of a declaration name, capitalize it if it consists of two letters (`IOStream`);
-capitalize only the first letter if it is longer (`HttpInputStream`).
+capitalize only the first letter if it is longer (`XmlFormatter`, `HttpInputStream`).
 
 
 ## Formatting


### PR DESCRIPTION
It is stated in the description, that only two letter acronyms are capitalized. 
But when scanning over the text, this can be overlooked. 
Therefore a  three-letter-acronym is added to make it clear with the examples, that 
two letters are capitalized, and three ore more are just with capitalized first letter.