### PR TITLE
Update comparison-to-java.md Ternary-Operator

### DIFF
--- a/pages/docs/reference/comparison-to-java.md
+++ b/pages/docs/reference/comparison-to-java.md
@@ -25,6 +25,7 @@ Kotlin fixes a series of issues that Java suffers from:
 * [Static members](classes.html)
 * [Non-private fields](properties.html)
 * [Wildcard-types](generics.html)
+* Instead of the Ternary-operator(`a ? b : c`) [if-expressions](control-flow.html#if-expression) can be used
 
 ## What Kotlin has that Java does not
 

--- a/pages/docs/reference/comparison-to-java.md
+++ b/pages/docs/reference/comparison-to-java.md
@@ -25,7 +25,7 @@ Kotlin fixes a series of issues that Java suffers from:
 * [Static members](classes.html)
 * [Non-private fields](properties.html)
 * [Wildcard-types](generics.html)
-* Instead of the Ternary-operator(`a ? b : c`) [if-expressions](control-flow.html#if-expression) can be used
+* [Ternary-operator `a ? b : c`](control-flow.html#if-expression)
 
 ## What Kotlin has that Java does not
 


### PR DESCRIPTION
There is this endless discussion about whether or not to add the ternary operator to Kotlin https://discuss.kotlinlang.org/t/ternary-operator/2116/122 and someone pointed out, that the docs don't list this as a difference to java. 
It seems like the ternary operator wont be added so I think it is a good idea to state this here, as it makes changing from java easier.