### PR TITLE
Add snap install instructions

### DIFF
--- a/pages/docs/tutorials/command-line.md
+++ b/pages/docs/tutorials/command-line.md
@@ -15,6 +15,14 @@ Every release ships with a standalone version of the compiler. We can download i
 #### Manual Install
 Unzip the standalone compiler into a directory and optionally add the `bin` directory to the system path. The `bin` directory contains the scripts needed to compile and run Kotlin on Windows, OS X and Linux.
 
+#### Linux
+
+You can install the auto-updating snap of the Kotlin compiler on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+```
+   $ snap install kotlin --classic
+```
+
 #### SDKMAN!
 An easier way to install Kotlin on UNIX based systems such as OS X, Linux, Cygwin, FreeBSD and Solaris is by using [SDKMAN!](http://sdkman.io).
 Simply run the following in a terminal and follow any instructions:


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install).