### PR TITLE
Fix confusing wrapping on backing properties example.

### DIFF
--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -102,7 +102,7 @@ var setterWithAnnotation: Any? = null
 Fields cannot be declared directly in Kotlin classes. However, when a property needs a backing field, Kotlin provides it automatically. This backing field can be referenced in the accessors using the `field` identifier:
 
 ``` kotlin
-var counter = 0 // initializer value is written directly to the backing field
+var counter = 0 // Note: the initializer assigns the backing field directly
     set(value) {
         if (value >= 0) field = value
     }

--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -102,7 +102,7 @@ var setterWithAnnotation: Any? = null
 Fields cannot be declared directly in Kotlin classes. However, when a property needs a backing field, Kotlin provides it automatically. This backing field can be referenced in the accessors using the `field` identifier:
 
 ``` kotlin
-var counter = 0 // the initializer value is written directly to the backing field
+var counter = 0 // initializer value is written directly to the backing field
     set(value) {
         if (value >= 0) field = value
     }


### PR DESCRIPTION
The last word, field, is wrapped to the next line and can be a bit confusing.  This prevents wrapping on standard zoom.