### PR TITLE
Update preamble of type-safe builders to say DSL

### DIFF
--- a/pages/docs/reference/type-safe-builders.md
+++ b/pages/docs/reference/type-safe-builders.md
@@ -2,20 +2,18 @@
 type: doc
 layout: reference
 category: "Syntax"
-title: "Type-Safe Groovy-Style Builders"
+title: "Type-Safe Builders"
 ---
 
 # Type-Safe Builders
 
-The concept of [builders](http://www.groovy-lang.org/dsls.html#_nodebuilder) is rather popular in the *Groovy* community.
-Builders allow for defining data in a semi-declarative way. Builders are good for [generating XML](http://www.groovy-lang.org/processing-xml.html#_creating_xml), 
+By using well-named functions as builders in combination with extension lambdas it is possible to create static type safe builders in Kotlin. Type-safe builders are also known as domain specific languages (DSLs).
+
+Builders, or domain specific languages, are a good solution for often-repeated code that builds complex data structures in a semi-declarative way. Builders are good for [generating XML](http://www.groovy-lang.org/processing-xml.html#_creating_xml), 
 [laying out UI components](http://www.groovy-lang.org/swing.html), 
-[describing 3D scenes](http://www.artima.com/weblogs/viewpost.jsp?thread=296081) and more...
+[describing 3D scenes](http://www.artima.com/weblogs/viewpost.jsp?thread=296081), and more...
 
-For many use cases, Kotlin allows to *type-check* builders, which makes them even more attractive than the 
-dynamically-typed implementation made in Groovy itself.
-
-For the rest of the cases, Kotlin supports Dynamic types builders.
+To support builders that can't be statically typed, Kotlin supports also supports [Dynamic types](/docs/reference/dynamic-type.html) builders.
 
 ## A type-safe builder example
 

--- a/pages/docs/reference/type-safe-builders.md
+++ b/pages/docs/reference/type-safe-builders.md
@@ -7,13 +7,13 @@ title: "Type-Safe Builders"
 
 # Type-Safe Builders
 
-By using well-named functions as builders in combination with extension lambdas it is possible to create static type safe builders in Kotlin. Type-safe builders are also known as domain specific languages (DSLs).
+By using well-named functions as builders in combination with [function literals with receiver](lambdas.html#function-literals-with-receiver) it is possible to create type-safe, statically-typed builders in Kotlin.
 
-Builders, or domain specific languages, are a good solution for often-repeated code that builds complex data structures in a semi-declarative way. Builders are good for [generating XML](http://www.groovy-lang.org/processing-xml.html#_creating_xml), 
-[laying out UI components](http://www.groovy-lang.org/swing.html), 
-[describing 3D scenes](http://www.artima.com/weblogs/viewpost.jsp?thread=296081), and more...
+Type-safe builders allow for creating Kotlin-based domain-specific languages (DSLs) suitable for building complex hierarchical data structures in a semi-declarative way. Some of the example use cases for the builders are:
 
-To support builders that can't be statically typed, Kotlin supports also supports [Dynamic types](/docs/reference/dynamic-type.html) builders.
+* Generating markup with Kotlin code, such as [HTML](https://github.com/Kotlin/kotlinx.html) or XML;
+* Programmatically laying out UI components: [Anko](https://github.com/Kotlin/anko/wiki/Anko-Layouts)
+* Configuring routes for a web server: [Ktor](http://ktor.io/features/routing.html#routing-tree).
 
 ## A type-safe builder example
 


### PR DESCRIPTION
- Update to add callout out to the concept of DSL (popular phrasing in Ruby etc).
- Remove explicit callout to Groovy in header, this page stands on it's own without referencing Groovy content.