### PR TITLE
correct kiwi -> kiwifruit

### DIFF
--- a/pages/docs/reference/basic-syntax.md
+++ b/pages/docs/reference/basic-syntax.md
@@ -413,7 +413,7 @@ See [Classes](classes.html) and [Type casts](typecasts.html).
 ``` kotlin
 fun main(args: Array<String>) {
 //sampleStart
-    val items = listOf("apple", "banana", "kiwi")
+    val items = listOf("apple", "banana", "kiwifruit")
     for (item in items) {
         println(item)
     }
@@ -429,7 +429,7 @@ or
 ``` kotlin
 fun main(args: Array<String>) {
 //sampleStart
-    val items = listOf("apple", "banana", "kiwi")
+    val items = listOf("apple", "banana", "kiwifruit")
     for (index in items.indices) {
         println("item at $index is ${items[index]}")
     }
@@ -448,7 +448,7 @@ See [for loop](control-flow.html#for-loops).
 ``` kotlin
 fun main(args: Array<String>) {
 //sampleStart
-    val items = listOf("apple", "banana", "kiwi")
+    val items = listOf("apple", "banana", "kiwifruit")
     var index = 0
     while (index < items.size) {
         println("item at $index is ${items[index]}")
@@ -576,7 +576,7 @@ Iterating over a collection:
 
 ``` kotlin
 fun main(args: Array<String>) {
-    val items = listOf("apple", "banana", "kiwi")
+    val items = listOf("apple", "banana", "kiwifruit")
 //sampleStart
     for (item in items) {
         println(item)
@@ -593,7 +593,7 @@ Checking if a collection contains an object using *in*{: .keyword } operator:
 
 ``` kotlin
 fun main(args: Array<String>) {
-    val items = setOf("apple", "banana", "kiwi")
+    val items = setOf("apple", "banana", "kiwifruit")
 //sampleStart
     when {
         "orange" in items -> println("juicy")
@@ -612,7 +612,7 @@ Using lambda expressions to filter and map collections:
 
 ``` kotlin
 fun main(args: Array<String>) {
-    val fruits = listOf("banana", "avocado", "apple", "kiwi")
+    val fruits = listOf("banana", "avocado", "apple", "kiwifruit")
 //sampleStart
     fruits
         .filter { it.startsWith("a") }


### PR DESCRIPTION
'kiwi' is a bird, or a person that normally does fly, but for some reason does not (eg: grounded wing commander), or someone from New Zealand, or, sometimes, the nzd/usd currency pair.  just as grapefruit are not called grape (a grape is something else entirely), neither should the kiwifruit be called a kiwi.  yeah, I understand that in many people's minds, kiwi is also the fruit, but, it's just not right.  Have a look at this: https://medium.com/new-zealand-thoughts/kiwi-kiwi-or-kiwifruit-8ac0b30ac447