### PR TITLE
Update Effective Java citation in classes.md

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -223,8 +223,8 @@ class Derived(p: Int) : Base(p)
 
 > The *open*{: .keyword } annotation on a class is the opposite of Java's *final*{: .keyword }: it allows others
 to inherit from this class. By default, all classes in Kotlin are final, which
-corresponds to [Effective Java](http://www.oracle.com/technetwork/java/effectivejava-136174.html),
-Item 17: *Design and document for inheritance or else prohibit it*.
+corresponds to [Effective Java, 3rd Editon](http://www.oracle.com/technetwork/java/effectivejava-136174.html),
+Item 19: *Design and document for inheritance or else prohibit it*.
 
 If the derived class has a primary constructor, the base class can (and must) be initialized right there,
 using the parameters of the primary constructor.


### PR DESCRIPTION
The page lists the *Design and document for inheritance or else prohibit it* Effective Java entry as being item 17 in "Effective Java".  This is technically an incorrect reference since listing the book as "Effective Java" implies the first edition, in which the mentioned item is #15. The citation should therefore be "Effective Java, 2nd Edition, Item #17". But given that the third edition was released in this past December, I think it, as the latest edition. should be cited. In the third edition it's item #19. Thus I recommend chaining the cite to  "Effective Java, 3rd Edition, Item #19".