### PR TITLE
Update delegation.md

### DIFF
--- a/pages/docs/reference/delegation.md
+++ b/pages/docs/reference/delegation.md
@@ -56,7 +56,7 @@ interface Base {
 
 class BaseImpl(val x: Int) : Base {
     override fun print() { print(x) }
-    override fun print() { println(x) }
+    override fun println() { println(x) }
 }
 
 class Derived(b: Base) : Base by b {


### PR DESCRIPTION
Fix the syntax error: changed function `print` to `println` for the sample code in section "Overriding a member of an interface implemented by delegation".