### PR TITLE
Fix typo: @Parcelize, instead of @Parcelable

### DIFF
--- a/pages/docs/tutorials/android-plugin.md
+++ b/pages/docs/tutorials/android-plugin.md
@@ -264,15 +264,15 @@ External parcelers can be applied using `@TypeParceler` or `@WriteWith` annotati
 
 ```kotlin
 // Class-local parceler
-@Parcelable
+@Parcelize
 @TypeParceler<ExternalClass, ExternalClassParceler>()
 class MyClass(val external: ExternalClass)
 
 // Property-local parceler
-@Parcelable
+@Parcelize
 class MyClass(@TypeParceler<ExternalClass, ExternalClassParceler>() val external: ExternalClass)
 
 // Type-local parceler
-@Parcelable
+@Parcelize
 class MyClass(val external: @WriteWith<ExternalClassParceler>() ExternalClass)
 ```


### PR DESCRIPTION
There is no such thing as the `@Parcelable` annotation, so it's rather a typo. This PR fixes the typo.