### PR TITLE
Fix incorrect property declaration

### DIFF
--- a/pages/docs/reference/delegated-properties.md
+++ b/pages/docs/reference/delegated-properties.md
@@ -332,8 +332,9 @@ class C {
 class C {
     // calling "provideDelegate" to create the additional "delegate" property
     private val prop$delegate = MyDelegate().provideDelegate(this, this::prop)
-    val prop: Type
+    var prop: Type
         get() = prop$delegate.getValue(this, this::prop)
+        set(value: Type) = prop$delegate.setValue(this, this::prop, value)
 }
 ```
 


### PR DESCRIPTION
prop declaration in code is generated by compiler should use var keyword instead of val keyword, as it was used var keyword in original Also I add set method.