### PR TITLE
Call compile method for Gradle Kotlin DSL

### DIFF
--- a/pages/docs/reference/using-gradle.md
+++ b/pages/docs/reference/using-gradle.md
@@ -170,10 +170,10 @@ With Gradle Kotlin DSL, the following notation for the dependencies is equivalen
 
 ``` kotlin
 dependencies {
-    compile kotlin("stdlib")
+    compile(kotlin("stdlib"))
     // or one of:
-    compile kotlin("stdlib-jdk7")
-    compile kotlin("stdlib-jdk8") 
+    compile(kotlin("stdlib-jdk7"))
+    compile(kotlin("stdlib-jdk8"))
 }
 ```
 


### PR DESCRIPTION
In Gradle Kotlin DSL all configurations are methods.
Means the current documentation is just wrong and lead to issues.
This will fix it 👍 