### PR TITLE
Fix for Chrome not respecting negative z-index

### DIFF
--- a/static/js/com/search/search.scss
+++ b/static/js/com/search/search.scss
@@ -42,7 +42,7 @@ body._no-scroll {
 
   &._hidden {
     opacity: 0;
-    z-index: -1;
+    top: 100%;
   }
 
   &:focus {


### PR DESCRIPTION
Hey,

So recently I started to wonder why my mouse scroll (or even touch pad scroll) stopped working on the website. I dig bit more and found out that chrome has problem with negative z-index.

Search popup (when hidden) uses `z-index: -1` to hide its body behind other elements, and remove that property once search icon is clicked.

My Fix is just a proposal, to prevent using negative z-index. I replaced it with `top: 100%` property, which makes search body shop up sliding from the bottom.


Thanks