### PR TITLE
fix example usage of trimIndent

### DIFF
--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -803,8 +803,11 @@ To maintain indentation in multiline strings, use `trimIndent` when the resultin
 indentation, or `trimMargin` when internal indentation is required:
 
 ``` kotlin
-assertEquals("""Foo
-                Bar""".trimIndent(), value)
+assertEquals(
+    """
+    Foo
+    Bar""".trimIndent(), value
+)
 
 val a = """if(a > 1) {
           |    return a

--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -806,7 +806,9 @@ indentation, or `trimMargin` when internal indentation is required:
 assertEquals(
     """
     Foo
-    Bar""".trimIndent(), value
+    Bar
+    """.trimIndent(), 
+    value
 )
 
 val a = """if(a > 1) {


### PR DESCRIPTION
the previous example didn't trim anything, as noted in the documentation:
"In case if there are non-blank lines with no leading whitespace characters (no indent at all) then the common indent is 0, and therefore this function doesn't change the indentation."

The new snippet formatting is the one applied by IntelliJ when choosing formatting based on the Kotlin style guide