### PR TITLE
Add note on visibility for extensions

### DIFF
--- a/pages/docs/reference/extensions.md
+++ b/pages/docs/reference/extensions.md
@@ -260,9 +260,10 @@ C().caller(D1())  // prints "D.foo in C" - extension receiver is resolved static
 
 ## Note on visibility
 
-Extensions utilize the same [visibility of other entities](visibility-modifiers.html) as a regular function declared in the same scope would.
-E.g. if an extension is declared outside of its receiver such an extension cannot access the receiver's private members;
-or an extension declared on the top level of a package does have access to entities of `internal` visibility.
+Extensions utilize the same [visibility of other entities](visibility-modifiers.html) as regular functions declared in the same scope would. For example:
+
+* An extension declared on top level of a file has access to the other `private` top-level declarations in the same file;
+* If an extension is declared outside its receiver type, such an extension cannot access the receiver's `private` members.
 
 ## Motivation
 

--- a/pages/docs/reference/extensions.md
+++ b/pages/docs/reference/extensions.md
@@ -258,7 +258,12 @@ C1().caller(D())  // prints "D.foo in C1" - dispatch receiver is resolved virtua
 C().caller(D1())  // prints "D.foo in C" - extension receiver is resolved statically
 ```
 
- 
+## Note on visibility
+
+Extensions utilize the same [visibility of other entities](visibility-modifiers.html) as a regular function declared in the same scope would.
+E.g. if an extension is declared outside of its receiver such an extension cannot access the receiver's private members;
+or an extension declared on the top level of a package does have access to entities of `internal` visibility.
+
 ## Motivation
 
 In Java, we are used to classes named "\*Utils": `FileUtils`, `StringUtils` and so on. The famous `java.util.Collections` belongs to the same breed.


### PR DESCRIPTION
I don't have prior experience of Java, C#, or Gosu, I'm also not familiar with a concept of extensions and it was **not** obvious to me that an extension declared outside of a class' scope does not have an access to the class' private (and protected?) members.

I was able to deduce an answer to my question about visibility from the following paragraph, though:

> Extensions do not actually modify classes they extend. By defining an extension, you do not insert new members into a class, but merely make new functions callable with the dot-notation on variables of this type.

However, I believe that the documentation would benefit by adding this information explicitly. 
Not sure how to formulate it better -- I'm open to any suggestions.