### PR TITLE
Remove the example due to empty range.

### DIFF
--- a/pages/docs/reference/ranges.md
+++ b/pages/docs/reference/ranges.md
@@ -26,8 +26,6 @@ The compiler takes care of converting this analogously to Java's indexed *for*{:
 fun main(args: Array<String>) {
 //sampleStart
 for (i in 1..4) print(i)
-
-for (i in 4..1) print(i)
 //sampleEnd
 }
 ```


### PR DESCRIPTION
4..1 is an empty range. If we want to iterate from 4 to 1, we should use 4 downTo 1 instead of 4..1