### PR TITLE
Include Windows Subsystem for Linux as environment

### DIFF
--- a/pages/docs/tutorials/native/targeting-multiple-platforms.md
+++ b/pages/docs/tutorials/native/targeting-multiple-platforms.md
@@ -53,7 +53,7 @@ wasm32:
 zephyr_stm32f4_disco:
 ```
 
-For Linux with Kotlin/Native v0.8 we have:
+For Linux and Windows Subsystem for Linux (WSL) with Kotlin/Native v0.8 we have:
 
 ```
 > kotlinc -list_targets


### PR DESCRIPTION
Tested like below:
```
joel@JOEL-LAPTOP C:\users\joel\code
$ kotlinc -list_targets
mingw_x64:                    (default) mingw
wasm32:
zephyr_stm32f4_disco:

joel@JOEL-LAPTOP C:\users\joel\code
$ bash
joel@JOEL-LAPTOP:/mnt/c/Users/joel/code$ ~/.konan/kotlin-native-linux-0.8.1/bin/kotlinc -list_targets
linux_x64:                    (default) linux
linux_arm32_hfp:                        raspberrypi
linux_mips32:
linux_mipsel32:
android_arm32:
android_arm64:
wasm32:
zephyr_stm32f4_disco:
```