### PR TITLE
Fix to example for setting jvmTarget in a Kotlin-DSL

### DIFF
--- a/pages/docs/reference/using-gradle.md
+++ b/pages/docs/reference/using-gradle.md
@@ -359,7 +359,7 @@ It is also possible to configure all Kotlin compilation tasks in the project:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ``` groovy
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).all {
     kotlinOptions { ... }
 }
 ```


### PR DESCRIPTION
Fix to example for setting jvmTarget in a Kotlin-DSL
Example given does not compile/parse.  Working example appends "::class.java" to correspond to the parameter type for 'withType'