### PR TITLE
Update compiler-plugins.md

### DIFF
--- a/pages/docs/reference/compiler-plugins.md
+++ b/pages/docs/reference/compiler-plugins.md
@@ -171,7 +171,7 @@ The *no-arg* compiler plugin generates an additional zero-argument constructor f
 
 The generated constructor is synthetic so it can’t be directly called from Java or Kotlin, but it can be called using reflection.
 
-This allows the Java Persistence API (JPA) to instantiate the `data` class although it doesn't have the zero-parameter constructor from Kotlin or Java point of view (see the description of `kotlin-jpa` plugin [below](compiler-plugins.html#jpa-support)).
+This allows the Java Persistence API (JPA) to instantiate a class although it doesn't have the zero-parameter constructor from Kotlin or Java point of view (see the description of `kotlin-jpa` plugin [below](compiler-plugins.html#jpa-support)).
 
 ### Using in Gradle
 


### PR DESCRIPTION
Changed wording. I recommend to not specifically say "data class" in that case, because actually using data classes for JPA entities might be a bad practice (equals/hashCode dilemma).