### PR TITLE
Add clarifying explanation for computed properties

### DIFF
--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -115,6 +115,28 @@ var setterWithAnnotation: Any? = null
 ```
 </div>
 
+
+### Computed Properties
+
+When using a custom getter for a property (`get()`) the value is computed once and stored. However, when omitting the `get()`, the value is computed on every access.
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+``` kotlin
+val isEmpty get() = this.size == 0 // Computed once and stored.
+val isEmpty = this.size == 0 // Computed on every access.
+```
+</div>
+
+When using a `var` the behavior is the same in both cases. The value is computed on every access.
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+``` kotlin
+var isEmpty get() = this.size == 0  // Computed on every access.
+var isEmpty = this.size == 0 // Computed on every access.
+```
+</div>
+
+
 ### Backing Fields
 
 Fields cannot be declared directly in Kotlin classes. However, when a property needs a backing field, Kotlin provides it automatically. This backing field can be referenced in the accessors using the `field` identifier:

--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -118,12 +118,12 @@ var setterWithAnnotation: Any? = null
 
 ### Computed Properties
 
-When using a custom getter for a property (`get()`) the value is computed once and stored. However, when omitting the `get()`, the value is computed on every access.
+When using a custom getter for a `val` property (`get()`) the value is computed on every access. However, when omitting the `get()`, the value is calculated once and stored.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ``` kotlin
-val isEmpty get() = this.size == 0 // Computed once and stored.
-val isEmpty = this.size == 0 // Computed on every access.
+val isEmpty get() = this.size == 0 // Computed on every access.
+val isEmpty = this.size == 0 // Computed once and stored.
 ```
 </div>
 

--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -131,7 +131,8 @@ When using a `var` the behavior is almost the same except that the computed valu
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ``` kotlin
-var isEmpty get() = this.size == 0  // Computed on every access.
+var isEmpty = false
+    get() = this.size == 0 // Computed on every access.
 var isEmpty = this.size == 0 // Computed at time of assignment and stored (until overwritten).
 ```
 </div>

--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -118,7 +118,7 @@ var setterWithAnnotation: Any? = null
 
 ### Computed Properties
 
-When using a custom getter for a `val` property (`get()`) the value is computed on every access. However, when omitting the `get()`, the value is calculated once and stored.
+When using a computed property, the value is computed once and stored. This behavior changes when using adding `get()`. The `get()` causes the value to be computed on every access.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ``` kotlin
@@ -127,12 +127,12 @@ val isEmpty = this.size == 0 // Computed once and stored.
 ```
 </div>
 
-When using a `var` the behavior is the same in both cases. The value is computed on every access.
+When using a `var` the behavior is almost the same except that the computed value is stored until it changes or is overwritten.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ``` kotlin
 var isEmpty get() = this.size == 0  // Computed on every access.
-var isEmpty = this.size == 0 // Computed on every access.
+var isEmpty = this.size == 0 // Computed at time of assignment and stored (until overwritten).
 ```
 </div>
 


### PR DESCRIPTION
When using a computed property with a `get()` the behavior will be different than without using `get()` so add some explanation for this.

Feel free to help me out with the wording and syntax. :)