### PR TITLE
Stylistic changes for cos() fixpoint computation

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -310,7 +310,7 @@ class MyStringCollection {
 
 ## Function Scope
 
-In Kotlin functions can be declared at top level in a file, meaning you do not need to create a class to hold a function, like languages such as Java, C# or Scala. In addition
+In Kotlin functions can be declared at top level in a file, meaning you do not need to create a class to hold a function, which you are required to do in languages such as Java, C# or Scala. In addition
 to top level functions, Kotlin functions can also be declared local, as member functions and extension functions.
 
 ### Local Functions
@@ -402,21 +402,25 @@ When a function is marked with the `tailrec` modifier and meets the required for
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only auto-indent="false">
 ``` kotlin
+val eps = 1E-10 // "good enough", could be 10^-15
+
 tailrec fun findFixPoint(x: Double = 1.0): Double
-        = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
+        = if (Math.abs(x - Math.cos(x)) < eps) x else findFixPoint(Math.cos(x))
 ```
 </div>
 
-This code calculates the fixpoint of cosine, which is a mathematical constant. It simply calls Math.cos repeatedly starting at 1.0 until the result doesn't change any more, yielding a result of 0.7390851332151607. The resulting code is equivalent to this more traditional style:
+This code calculates the fixpoint of cosine, which is a mathematical constant. It simply calls Math.cos repeatedly starting at 1.0 until the result doesn't change any more, yielding a result of 0.7390851332151611 for the specified `eps` precision. The resulting code is equivalent to this more traditional style:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ``` kotlin
+val eps = 1E-10 // "good enough", could be 10^-15
+
 private fun findFixPoint(): Double {
     var x = 1.0
     while (true) {
         val y = Math.cos(x)
-        if (x == y) return x
-        x = y
+        if (Math.abs(x - y) < eps) return x
+        x = Math.cos(x)
     }
 }
 ```


### PR DESCRIPTION
Let's keep the example stylistically good: It seems unwise to do exact floating point comparison in an infinite loop as stated. Let's compare against a target precision of 10^-10 instead (machine epsilon of Double is 2^-52 ~ 1.11e-16, and the result is expected to be < 1.0, so 10^-15 sounds safe, but let's just go for 10^-10). 

Additionally, the loop code optimizes by only calling Math.cos(x) once, but the compiler hopefully won't do that, as the language is not purely functional. So I added the second Math.cos(x) code into the loop, for clarity.

Also fixed something that looks like a russianism in the text (apologies)