### PR TITLE
support for includes in the _nav.yml

### DIFF
--- a/kotlin-website.py
+++ b/kotlin-website.py
@@ -222,8 +222,13 @@ def process_page(page_path):
         if page.meta['formatted_date'].startswith('0'):
             page.meta['formatted_date'] = page.meta['formatted_date'][1:]
 
-    edit_on_github_url = app.config['EDIT_ON_GITHUB_URL'] + app.config['FLATPAGES_ROOT'] + "/" + page_path + app.config[
-        'FLATPAGES_EXTENSION']
+    if 'github_edit_url' in page.meta:
+        edit_on_github_url = page.meta['github_edit_url']
+    else:
+        edit_on_github_url = app.config['EDIT_ON_GITHUB_URL'] + app.config['FLATPAGES_ROOT'] + "/" + page_path + app.config['FLATPAGES_EXTENSION']
+
+    assert edit_on_github_url.startswith('https://github.com/JetBrains/kotlin'), 'Check edit_on_github_url for ' + page_path
+
     template = page.meta["layout"] if 'layout' in page.meta else 'default.html'
     if not template.endswith(".html"):
         template += ".html"


### PR DESCRIPTION
We need to split the global `_nav.yml` into parts to share site sources between repositories. We assume the site is included under the `pages/` folder, thus there is no need to change the way `.md` files are rendered.

Right now the following is supported in the root _nav.yml:
```
    - title: Native
      description: Kotlin Native and iOS
      '@include': /docs/reference/native/_nav.yml
      '@prefix': /docs/reference/native/

```
The `@include` and `@prefix` elements will be replaced with the `content` element, the included yml file contents are placed under the created `content` element. We assume the imported yml is list.

`.yml` file to import:
```
- url: INTEROP.html
  title: C Interop
- url: OBJC_INTEROP.md
  title: Objective-C/Swift Interop
```

The `@prefix` parameter helps to fix `url` elements of the imported `.yml` to include prefix paths, e.g., `url: foo` will be imported as `url: /docs/reference/native/foo`.