### PR TITLE
Rework externals support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ package-lock.json
 pages/api/
 external/
 pages/docs/reference/native/
+pages/docs/reference/coroutines/
 _teamcity

--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -212,6 +212,15 @@ reference:
         repo: https://github.com/JetBrains/kotlin-native
         branch: master
 
+    - title: Coroutines
+      description: Kotlin Coroutines Library
+      external:
+        path: kotlinx.coroutines/docs
+        nav: _nav.yml
+        base: /docs/reference/coroutines
+        repo: https://github.com/kotlin/kotlinx.coroutines
+        branch: master
+
     - title: Tools
       description:
       content:

--- a/data/releases.yml
+++ b/data/releases.yml
@@ -1,7 +1,7 @@
 url: https://github.com/JetBrains/kotlin/releases
 
 latest:
-  version: 1.2.70
-  url: https://github.com/JetBrains/kotlin/releases/tag/v1.2.70
+  version: 1.2.71
+  url: https://github.com/JetBrains/kotlin/releases/tag/v1.2.71
   runtime_size: 964KB
-  date: September 12, 2018
+  date: September 24, 2018

--- a/kotlin-website.py
+++ b/kotlin-website.py
@@ -15,6 +15,7 @@ from flask.helpers import url_for, send_file, make_response
 from flask_frozen import Freezer, walk_directory
 
 from src.Feature import Feature
+from src.github import assert_valid_git_hub_url
 from src.navigation import process_video_nav, process_nav
 from src.api import get_api_page
 from src.encoder import DateAwareEncoder
@@ -230,8 +231,7 @@ def process_page(page_path):
         edit_on_github_url = app.config['EDIT_ON_GITHUB_URL'] + app.config['FLATPAGES_ROOT'] + "/" + page_path + \
                              app.config['FLATPAGES_EXTENSION']
 
-    assert edit_on_github_url.startswith(
-        'https://github.com/JetBrains/kotlin'), 'Check edit_on_github_url for ' + page_path
+    assert_valid_git_hub_url(edit_on_github_url, page_path)
 
     template = page.meta["layout"] if 'layout' in page.meta else 'default.html'
     if not template.endswith(".html"):

--- a/kotlin-website.py
+++ b/kotlin-website.py
@@ -180,7 +180,10 @@ def books_page():
 
 @app.route('/docs/kotlin-docs.pdf')
 def pdf():
-    return send_file(generate_pdf(build_mode, pages, get_nav()['reference']))
+    if build_mode:
+        return send_file(generate_pdf(build_mode, pages, get_nav()['reference']))
+    else:
+        return "Not supported in the dev mode, ask in #kotlin-web-site, if you need it"
 
 
 @app.route('/docs/resources.html')

--- a/src/externals.py
+++ b/src/externals.py
@@ -24,6 +24,8 @@ class ExternalMount:
 
         self.target_external_path = path.join(root_folder, 'pages', self.external_base.lstrip("/"))
         self.source_external_path = path.join(root_folder, 'external', self.external_path.lstrip("/"))
+        # assuming external folder contains only sub repositories
+        self.source_checkout_root = path.join(root_folder, 'external', self.external_path.split("/")[0])
 
         self.nav_file = path.join(self.source_external_path, self.external_nav.lstrip("/"))
 
@@ -31,6 +33,9 @@ class ExternalMount:
         print("External nav file:   ", self.nav_file)
         print("External source dir: ", self.source_external_path)
         print("External target dir: ", self.target_external_path)
+
+    def github_view_url(self, file: str) -> str:
+        return self.external_repo + "/blob/" + self.external_branch + "/" + file.lstrip("/")
 
 
 def _rant_if_external_nav_is_not_found(self: ExternalMount):
@@ -106,9 +111,7 @@ def _process_external_entry(self: ExternalMount, url_mappers, entry: dict):
         source_text = file.read()
 
     # TODO: check `---` headers at the beginning of the original file and WARN or MERGE
-
-    for mapper in url_mappers:
-        source_text = mapper(source_text)
+    source_text = url_mappers(source_text, item.source_item)
 
     template = item.generate_header()
 
@@ -123,13 +126,29 @@ def _process_external_entry(self: ExternalMount, url_mappers, entry: dict):
     }
 
 
-def _build_url_mappers(external_yml):
-    def _url_replace_function(source_url, target_url):
-        pattern = "\\]\\("        "(" + re.escape(source_url) + ")"           "(#[^\\)]+)?"     "\\)"
-        return lambda text: re.compile(pattern).sub("](" + target_url + "\\2)", text)
+def _build_url_mappers(external_yml, mount: ExternalMount):
+    r = re.compile("\\]\\("        "([^#)]+)?"           "(#[^)]+)?"     "\\)")
 
-    return [_url_replace_function(item['md'], item['url']) for item in external_yml]
+    known_urls = {item['md']: item['url'] for item in external_yml}
 
+    def patch_the_text(text, source_item):
+        def handle_match(m):
+            url = m.group(1) or ''
+            anchor = m.group(2) or ''
+
+            if url in known_urls:
+                url = known_urls[url]
+            elif not url.startswith("http://") and not url.startswith("https://"):
+                real_path = path.normpath(path.join(path.dirname(source_item), url))
+                if path.isfile(real_path):
+                    rel_path = path.relpath(real_path, mount.source_checkout_root)
+                    url = mount.github_view_url(rel_path)
+
+            return "](" + url + anchor + ")"
+
+        return r.sub(handle_match, text)
+
+    return patch_the_text
 
 def _process_external_key(build_mode, data):
     if 'external' not in data: return
@@ -144,7 +163,7 @@ def _process_external_key(build_mode, data):
         external_yml = yaml.load(stream)
         assert isinstance(external_yml, list)
 
-    url_mappers = _build_url_mappers(external_yml)
+    url_mappers = _build_url_mappers(external_yml, mount)
     data['content'] = [_process_external_entry(mount, url_mappers, item) for item in external_yml]
 
 

--- a/src/externals.py
+++ b/src/externals.py
@@ -3,6 +3,8 @@ import re
 from os import path
 import yaml
 
+from src.github import assert_valid_git_hub_url
+
 root_folder = path.normpath(path.join(os.path.dirname(__file__), '..'))
 
 
@@ -18,7 +20,7 @@ class ExternalMount:
         self.external_repo: str = external_spec['repo']
         self.external_branch: str = external_spec['branch']
 
-        assert self.external_repo.startswith("https://github.com/JetBrains")
+        assert_valid_git_hub_url(self.external_repo, 'EXTERNAL MODULE: %s' % self.external_path)
 
         self.target_external_path = path.join(root_folder, 'pages', self.external_base.lstrip("/"))
         self.source_external_path = path.join(root_folder, 'external', self.external_path.lstrip("/"))

--- a/src/externals.py
+++ b/src/externals.py
@@ -132,8 +132,10 @@ def _build_url_mappers(external_yml):
 def _process_external_key(build_mode, data):
     if 'external' not in data: return
     mount = ExternalMount(build_mode, data['external'])
+    del data['external']
 
     if not _rant_if_external_nav_is_not_found(mount):
+        data['content'] = [{ 'url': '/', 'title': 'external "%s" is it included' % mount.external_path}]
         return
 
     with open(mount.nav_file) as stream:
@@ -142,7 +144,6 @@ def _process_external_key(build_mode, data):
 
     url_mappers = _build_url_mappers(external_yml)
     data['content'] = [_process_external_entry(mount, url_mappers, item) for item in external_yml]
-    del data['external']
 
 
 def process_nav_includes(build_mode, data):

--- a/src/github.py
+++ b/src/github.py
@@ -1,0 +1,10 @@
+def assert_valid_git_hub_url(edit_on_github_url: str, page_path: str):
+    # Do you like to include yet another organization? Thing twice :)
+
+    url_lower = edit_on_github_url.lower()
+
+    assert \
+        url_lower.startswith('https://github.com/JetBrains/'.lower()) \
+        or \
+        url_lower.startswith('https://github.com/kotlin/'.lower()), \
+        'Check `edit_on_github_url` for `' + page_path + "` to be either `JetBrains` or `kotlin` "

--- a/src/processors/processors.py
+++ b/src/processors/processors.py
@@ -14,7 +14,8 @@ languageMimeTypeMap = {
     "javascript": "text/javascript",
     "json": "application/json",
     "js": "text/javascript",
-    "c": "text/x-csrc"
+    "c": "text/x-csrc",
+    "text": "text/plain"
 }
 
 


### PR DESCRIPTION
**DO NOT MERGE IT TO MASTER**

In the branch I have
 - fix to make kotlin-web-site work without external folders included
 - disabled PDF generation in local development mode
 - supported links hacking for included .md files - I resolve relative references and generate GitHub links (it is not possible to have kotlinx coroutines generated documentation included)
 - add coroutines section to the web site (THAT CHANGE SHOULD NOT GO TO MASTER)

Please review python changes just in case. I'd like to merge my changes, but not the _nav.yml back to master if everything is ok