### PR TITLE
Updated usage of sealed classes with when.

### DIFF
--- a/pages/docs/reference/sealed-classes.md
+++ b/pages/docs/reference/sealed-classes.md
@@ -36,7 +36,7 @@ Note that classes which extend subclasses of a sealed class (indirect inheritors
 the same file.
 
 The key benefit of using sealed classes comes into play when you use them in a [`when` expression](control-flow.html#when-expression). If it's possible
-to verify that the statement covers all cases, you don't need to add an `else` clause to the statement. However, this works only if you use `when` as an expression (using the result) and not as a statement.
+to verify that the statement covers all cases, you don't need to add an `else` clause to the statement.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ``` kotlin


### PR DESCRIPTION
You don't need an `else` clause even if `when` is used as a statement. A somewhat ugly and artificial example from [Kotlin Koans](https://try.kotlinlang.org/#/Kotlin%20Koans/Introduction/Smart%20casts/Task.kt)
```
fun eval(expr: Expr): Int {
    when (expr) {
        is Num -> {
            return expr.value
        }
        is Sum -> {
            return eval(expr.left) + eval(expr.right)
        }
    }
}
```