### PR TITLE
(WIP) Update MPP docs for 1.3

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -130,6 +130,16 @@ reference:
         - url: /docs/reference/inline-functions.html
           title: Inline Functions
 
+    - title: Multiplatform Programming
+      description: Reusing code across JVM, JS, and Native
+      content:
+        - url: /docs/reference/multiplatform.html
+          title: Introduction
+        - url: /docs/reference/platform-specific-declarations.html
+          title: Platform-Specific Declarations
+        - url: /docs/reference/building-mpp-with-gradle.html
+          title: Multiplatform Projects with Gradle
+
     - title: Other
       description: Various bits and bobs
       content:
@@ -159,9 +169,6 @@ reference:
           title: Type-Safe Builders
         - url: /docs/reference/type-aliases.html
           title: Type Aliases
-        - url: /docs/reference/multiplatform.html
-          title: Multiplatform Projects
-
 
     - title: Core Libraries
       content:

--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -60,7 +60,9 @@ reference:
         - url: /docs/reference/native-overview.html
           title: Kotlin/Native
         - url: /docs/reference/coroutines-overview.html
-          title: Coroutines Overview
+          title: Coroutines
+        - url: /docs/reference/multiplatform.html
+          title: Multiplatform
         - url: /docs/reference/whatsnew11.html
           title: What's New in 1.1
         - url: /docs/reference/whatsnew12.html
@@ -133,12 +135,10 @@ reference:
     - title: Multiplatform Programming
       description: Reusing code across JVM, JS, and Native
       content:
-        - url: /docs/reference/multiplatform.html
-          title: Introduction
         - url: /docs/reference/platform-specific-declarations.html
           title: Platform-Specific Declarations
         - url: /docs/reference/building-mpp-with-gradle.html
-          title: Multiplatform Projects with Gradle
+          title: Building with Gradle
 
     - title: Other
       description: Various bits and bobs

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -1,0 +1,481 @@
+---
+type: doc
+layout: reference
+title: "Building Multiplatform Projects with Gradle"
+---
+
+# Building Multiplatform Projects with Gradle
+
+> Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
+and tooling features described in this document are subject to change in future Kotlin versions.
+{:.note}
+
+This document describes how [Kotlin multiplatform projects](multiplatform.html) are configured and built using 
+Gradle. Only Gradle versions 4.7 and above can be used, older Gradle versions are not supported.
+
+Gradle Kotlin DSL support has not been implemented yet for multiplatform projects, it will be added in the future 
+updates. Please use the Groovy DSL in the build scripts.
+
+## Gradle Plugin
+
+First, apply the `kotlin-multiplatform` plugin to the project by adding the following to the
+`build.gradle` file:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform' version '{{ site.data.releases.latest.version }}'
+}
+```
+</div>
+
+This creates the `kotlin` extension at the top level. You can then access it in the build script for:
+
+* [setting up the targets](#setting-up-targets) for multiple platforms (no targets are created by default);
+* [configuring the source sets](#configuring-source-sets) and their [dependencies](#adding-dependencies);
+
+## Setting up Targets
+
+A target is a part of the build responsible for compiling, testing, and packaging a piece of software aimed for
+one of the [supported platforms](#supported-platforms).
+
+As the platforms are different, the targets are built in different ways and have various platform-specific 
+settings. The Gradle plugin bundles a number of presets for the supported platforms, which allow you to 
+create the targets by just providing a name as follows:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+``` groovy
+kotlin {
+    targets {
+        fromPreset(presets.jvm, 'jvm6') // Create a JVM target by the name 'jvm6'
+        
+        fromPreset(presets.linuxX64, 'linux') { 
+            /* You can specify additional settings for the 'linux' target here */
+        } 
+    }
+}
+``` 
+</div>
+
+Building a target requires compiling Kotlin one or more times. Each Kotlin compilation of a target may serve a 
+different purpose (e.g. production code, tests) and incorporate different [source sets](#configuring-source-sets). The compilations
+of a target may be acccessed in the DSL, for example, to get the task names:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin {
+    targets {
+        fromPreset(presets.jvm, 'jvm6') { 
+            def mainKotlinTaskName = compilations.main.compileKotlinTaskName
+            def testKotlinTaskName = compilations.test.compileKotlinTaskName
+            /* ... */
+        }
+    }
+}
+```
+</div>
+
+All of the targets may share some of the sources and may have platform-specific sources in their compilations as well. 
+See [Configuring Source Sets](#configuring-source-sets) for details.
+
+### Supported platforms
+
+There are target presets that one can apply using `fromPreset(presets.<presetName>, '<targetName>')`, as described above, for the
+following target platforms:
+
+* `jvm` for Kotlin/JVM. Note: `jvm` targets do not compile Java;
+* `js` for Kotlin/JS;
+* `android` for Android applications and libraries. Note that one of the Android Gradle 
+   plugins should be applied as well;
+  
+*  Kotlin/Native target presets (see the [notes](#using-kotlinnative-targets) below):
+  
+    * `androidNativeArm32` and `androidNativeArm64` for Android NDK;
+    * `iosArm32`, `iosArm64`, `iosX64` for iOS;
+    * `linuxArm32Hfp`, `linuxMips32`, `linuxMipsel32`, `linuxX64` for Linux
+    * `macosX64` for MacOS
+    * `mingwX64` for Windows
+    
+    Note that some of the Kotlin/Native targets require an [appropriate host machine](#using-kotlinnative-targets) to build on.
+    
+## Configuring source sets
+
+A Kotlin source set is a collection of Kotlin sources, along with their resources, dependencies, and language settings, 
+which may take part in Kotlin compilations of one or more [targets](#setting-up-targets).
+
+If you apply a target preset, some source sets are created and configured by default. See [Default Project Layout](#default-project-layout).
+
+The source sets are configured within a `sourceSets { ... }` block of the `kotlin { ... }` extension.
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin { 
+    targets { /* ... */ }
+    
+    sourceSets { 
+        foo { /* ... */ } // create or configure a source set by the name 'foo' 
+        bar { /* ... */ }
+    }
+}
+``` 
+</div
+
+A source set by itself is platform-agnostic, but
+it can be considered platform-specific if it is only compiled for a single platform. A source set can, therefore, contain either
+common code shared between the platforms or platform-specific code.
+
+To add Kotlin source directories and resources to a source set, use its `kotlin` and `resources` `SourceDirectorySet`s:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin { 
+    sourceSets { 
+        commonMain {
+            kotlin.srcDir('src')
+            resources.srcDir('res')
+        } 
+    }
+}
+``` 
+</div
+
+Kotlin source sets are interconnected with the 'depends on' relation, so that if a source set `foo`  depends on` a source set `bar` then:
+
+* whenever `foo` is compiled for a certain target, `bar` takes part in that compilation as well and is also compiled 
+into the same target binary form, such as JVM class files or JS code;
+
+* the resources of `bar` are always processed along with the resources of `foo`;
+
+* sources of `foo` 'see' the declarations of `bar`, including the `internal` ones, and the [dependencies](#adding-dependencies) of `bar`, even those
+ specified as `implementation` dependencies;
+  
+* `foo` may contain [platform-specific implementations](platform-specific-declarations.html) for the expected declarations of `bar`;
+
+* the [language settings](#language-settings) of `foo` and `bar` should be consistent;
+
+The source sets DSL can be used to define these dependencies between source sets:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+ kotlin { 
+     sourceSets { 
+         commonMain { /* ... */ }
+         allJvm {
+             dependsOn commonMain
+             /* ... */
+         } 
+     }
+ }
+```
+</div>
+
+Custom source sets created in addition the [default ones](#default-project-layout) should be explicitly included into the dependencies hierarchy. 
+Most often, they need a `dependsOn commonMain` or `dependsOn commonTest` statement, and some platform-specific source sets should
+depend on the custom ones. Circular source set dependencies are prohibited. 
+
+### Adding Dependencies
+
+To add a dependency to a source set, use a `dependencies { ... }` block of the source sets DSL. Four kinds of dependencies
+are supported:
+
+* `api` dependencies are used both during compilation and at runtime and are exported to a library consumers. If any types 
+  from a dependency are used in the public API, then it should be an `api` dependency;
+  
+* `implementation` dependencies are used during compilation and at runtime for the current module, but are not exposed for compilation 
+  of other modules depending on the one with the `implementation` dependency. The`implementation` dependency kind should be used for 
+  dependencies needed for the internal logic of a module. If a module is an endpoint application which is not published, it may
+  use `implementation` dependencies instead of `api` ones.
+
+* `compileOnly` dependencies are only used for compilation of the current module and are available neither at runtime nor during compilation
+  of other modules. These dependencies should be used for APIs which have a third-party implementation available at runtime.
+  
+* `runtimeOnly` dependencies are available at runtime but are not visible during compilation of any module.
+
+They are specified per source set as follows: 
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api 'com.example:foo-metadata:1.0'
+            }
+        }
+        jvm6Main {
+            dependencies {
+                api 'com.example:foo-jvm6:1.0'
+            }
+        }
+    }
+}
+```
+</div>
+
+Note that for the IDE to correctly analyze the dependencies of the common sources, the common source sets need to have corresponding dependencies on the Kotlin 
+metadata packages in addition to the platform-specific artifact dependencies of the platform-specific source set. Usually, an artifact with a suffix 
+`-common` (as in `kotlin-stdlib-common`) or `-metadata` is required.
+
+If a multiplatform library is published in the experimental [metadata publishing mode](#experimental-metadata-publishing-mode) and the project 
+is set up to consume it, then 
+it is enough to specify the corresponding dependency once for the common source set. Otherwise, each platform-specific source set should be 
+provided with a corresponding platform module of the library, in addition to the common module, as shown above. A `project('...')` dependency
+on another multiplatform project is likewise resolved to an appropriate target, even with experimental metadata disabled.
+
+An alternative way to specify the dependencies is to use the Gradle built-in DSL at the top level with the configuration names following the 
+pattern `<sourceSetName><DependencyKind>`:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+dependencies {
+    commonMainApi 'com.example:foo-common:1.0'
+    jvm6MainApi 'com.example:foo-jvm6:1.0'
+}
+```
+</div>
+
+### Language settings
+
+The language settings for a source set can be specified as follows:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin {
+    sourceSets {
+        commonMain {
+            languageSettings {
+                languageVersion = '1.3' // possible values: '1.0', '1.1', '1.2', '1.3'
+                apiVersion = '1.3' // possible values: '1.0', '1.1', '1.2', '1.3'
+                enableLanguageFeatures('InlineClasses') 
+                progressiveMode = true // false by default
+            }
+        }
+    }
+}
+```
+</div> 
+
+Language settings of a source set affect how the sources are analyzed in the IDE. Due to the current limitations, in a Gradle build, only the language settings 
+of the compilation's default source set are used.
+
+The language settings are checked for consistency between source sets depending on each other. Namely, if `foo` depends on `bar`:
+
+* `foo` should set `languageVersion` that is greater or equal to that of `bar`;
+* `foo` should enable all unstable language features that `bar` enabled (there's no such requirement for bugfix features);
+* `apiVersion`, bugfix language features, and `progressiveMode` can be set arbitrarily; 
+
+## Publishing a Multiplatform Library
+
+> The set of target platforms is defined by a multiplatform library author, and they should provide all of the platform-specific implementations for the library. 
+  Adding new targets for a multiplatform library at the consumer side is not supported. {:.note} 
+
+A library built from a multiplatform project may be published to a Maven repository with the Gradle `maven-publish` plugin, which can be applied as follows:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+plugins {
+    /* ... */
+    id 'maven-publish'
+}
+```
+</div>
+
+Once this plugin is applied, default publications are created for each of the targets that can be built on the current host. This requires `group` and 
+`version` to be set in the project. The default artifact IDs follow the pattern `<projectName>-<targetNameToLowerCase>`, for example `sample-lib-nodejs` for a target named `nodeJs` in a project 
+`sample-lib`. 
+
+Also, an additional publication is added by default which contains serialized Kotlin declarations and is used by the IDE to analyze multiplatform libraries.
+
+By default, a sources JAR is added to each publication in addition to its main artifact. The sources JAR contains the sources used by the `main` compilation
+of the target.
+
+The Maven coordinates can be altered and additional artifact files may be added to the publication within the `targets { ... }` block:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin {
+    targets {
+        fromPreset(presets.jvm, 'jvm6') {
+            /* ... */
+            mavenPublication { 
+                artifactId = 'sample-lib-jvm'
+                artifact(jvmJavadocJar)
+            }
+        }
+    }
+}
+```
+</div>
+
+### Experimental metadata publishing mode
+
+An experimental publishing and dependency consumption mode can be enabled by adding 
+`enableFeaturePreview('GRADLE_METADATA)` to the `settings.gradle` file. With Gradle metadata enabled,
+ an additional publication is added which references the target publications as its variants. The artifact ID of this publication
+ matches the project name.
+ 
+> Gradle metadata publishing is an experimental Gradle feature which is not guaranteed to be backward-compatible. 
+Future Gradle versions may fail to resolve a dependency to a library published with current versions of Gradle metadata.
+Library authors are recommended to use it to publish experimental versions of the library alongside with the stable publishing mechanism. 
+{:note} 
+ 
+If a library is published with Gradle metadata enabled and a consumer enables the metadata as well, the consumer may specify a
+ single dependency on the library in a common source set, and a corresponding platform-specific variant will be chosen, if available, 
+ for each of the compilations. Consider a `sample-lib` library built for the JVM and JS and published with experimental Gradle metadata.
+ Then it is enough for the consumers to add `enableFeaturePreview('GRADLE_METADATA)` and specify a single dependency:
+ 
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin {
+    targets {
+        fromPreset(presets.jvm, 'jvm6')
+        fromPreset(presets.js, 'nodeJs')
+    }
+    sourceSets {
+        commonMain {
+            dependencies {
+                api 'com.example:sample-lib:1.0' 
+                // is resolved to `sample-lib-jvm` for JVM, `sample-lib-js` for JS 
+            }
+        }
+    }
+}
+```
+</div>    
+
+### Disambiguating Targets
+
+It is possible to have more than one target for a single platform in a multiplatform library. For example, these targets
+provide the same API and differ in the libraries they use at runtime, such as testing frameworks or logging solutions. 
+
+However, dependencies on such a library may be ambiguous and thus may thus fail to resolve under certain conditions:
+
+* a `project('...')` dependency on the multiplatform library's project: use a `project(path: '...', configuration: '...')` dependency instead. 
+  Use the appropriate target's runtime elements configuration, such as `jvm6RuntimeElements`. Due to current limitations, this dependency should
+  be placed in a top-level `dependencies { ... }` block rather than in a source set's dependencies.
+  
+* a published library dependency: if a library is published with experimental Gradle metadata, one can still replace the single dependency with
+  unambiguous dependencies on its separate target modules;   
+  
+* in both of the cases above, another solution is to mark the targets with a custom attribute. This, however, must be done on both the library author
+ and the consumer sides, and it's the library author's responsibility to communicate the attribute and its values to the consumers;
+ 
+     This is done as follows, symmetrically, in both the library and the consumer projects, but the consumer may only need to mark 
+     a single target with the attribute:
+     
+     <div class="sample" markdown="1" theme="idea" mode='groovy'>
+     
+     ```groovy
+     def testFrameworkAttribte = Attribute.of('com.example.testFramework', String)
+      
+     kotlin {
+         targets {
+             fromPreset(presets.jvm, 'junit') {
+                 attributes {
+                     attribute(testingFrameworkAttribte, 'junit')
+                 }
+             }
+             fromPreset(presets.jvm, 'testng') {
+                 attributes {
+                     attribute(testingFrameworkAttribte, 'testng')
+                 }
+             }
+         }
+     }
+     ```
+     </div>
+     
+## Running Tests
+
+A test task is created under the name `<targetName>Test` for each target that is suitable for testing, for example. 
+Run the `check` task to run the tests for all targets.
+
+As the `commonTest` [default source set](#default-project-layout) is added to all test compilations, tests and test tools that are needed
+on all target platforms may be placed there.
+
+The `kotlin.test` API is availble for multiplatform tests. Add the `kotlin-test-common` and `kotlin-test-annotations-common`
+dependencies to `commonTest` to use `DefaultAsserter` and `@Test`/`@Ignore`/`@BeforeTest`/`@AfterTest` annotations in the common tests.
+
+For JVM targets, use `kotlin-test-junit`, or `kotlin-test-junit5`, or `kotlin-test-testng` for the corresponding asserter implementation and
+annotations mapping.
+
+For Kotlin/JS targets, add `kotlin-test-js` as a test dependency. At this point, test tasks for Kotlin/JS do not run tests by default 
+and should be manually configured to do so. 
+
+Kotlin/Native targets do not require additional test dependencies, and the `kotlin.test` API implementations are built-in.
+ 
+## Default Project Layout
+
+By default, each project contains two source sets, `commonMain` and `commonTest`, where one can place all the code that should be 
+shared between all of the target platforms. These source sets are added to each production and test compilation, respectively.
+
+Then, once a target is added, default compilations are created for it:
+
+* `main` and `test` compilations for JVM, JS, and Native targets;
+* a compilation per Android variant, for Android targets;
+
+For each compilation, there is a default source set under the name composed as `<targetName><CompilationName>`. This default source
+set participates in the compilation, and thus it should be used for the platform-specific code and dependencies, and for adding other source
+ sets to the compilation be the means of 'depends on'. For example, a project with
+targets `jvm6` (JVM) and `nodeJs` (JS) will have source sets: `jvm6Main`, `jvm6Test`, `nodeJsMain`, `nodeJsTest`.
+
+Numerous use cases are covered by just the default source sets and don't require custom source sets.
+ 
+Each source set by default has its Kotlin sources under `src/<sourceSetName>/kotlin` directory and the resources under `src/<sourceSetName>/resources`.
+
+In Android projects, additional Kotlin source sets are created for each Android source set. These Kotlin source sets can consume Kotlin sources
+from the `src/.../java` directory of the Android source set or its neighbor `src/.../kotlin` directory.
+
+## Using Kotlin/Native Targets
+
+It is important to note that some of the [Kotlin/Native targets](#supported-platforms) may only be built with an appropriate host machine:
+
+* Linux targets may only be built on a Linux host;
+* Windows targets require a Windows host;
+* macOS and iOS targets can only be built on a macOS host;
+* Android Native targets require a Linux or macOS host; 
+
+A target that is not supported by the current host is ignored during build and therefore not published. A library author may want to set up
+builds and publishing from different hosts as required by the library target platforms.
+
+### Kotlin/Native output kinds
+
+By default, a Kotlin/Native target is compiled down to a `*.klib` library artifact, which can be consumed by Kotlin/Native itself as a dependency but
+cannot be run or used as a native library.
+
+To link a binary in addition to the Kotlin/Native library, add an one or more of the `outputKinds`, which can be:
+
+* `executable` for an executable program;
+* `dynamic` for a dynamic library;
+* `static` for a static library;
+* `framework` for an Objective-C framework (only supported for macOS and iOS targets)
+
+This can be done as follows:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin {
+    targets {
+        fromPreset(presets.linuxX64, 'linux') {
+            compilations.main.outputKinds 'executable' // could be 'static', 'dynamic'
+        }
+    }
+}
+```
+</div>
+
+This creates additional link tasks for the debug and release binaries. The tasks can be accessed from the compilation as, for example, 
+`getLinkTask('executable', 'release')` or `getLinkTaskName('static', 'debug')`. To get the binary file, use the `outputFile` property of the link task.

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -122,7 +122,7 @@ kotlin {
     }
 }
 ``` 
-</div
+</div>
 
 A source set by itself is platform-agnostic, but
 it can be considered platform-specific if it is only compiled for a single platform. A source set can, therefore, contain either
@@ -262,7 +262,7 @@ kotlin {
     }
 }
 ```
-</div> 
+</div>
 
 Language settings of a source set affect how the sources are analyzed in the IDE. Due to the current limitations, in a Gradle build, only the language settings 
 of the compilation's default source set are used.

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -276,9 +276,8 @@ The source sets DSL can be used to define these connections between the source s
 
 </div>
 
-Custom source sets created in addition the [default ones](#default-project-layout) should be explicitly included into the dependencies hierarchy. 
-Most often, they need a `dependsOn commonMain` or `dependsOn commonTest` statement, and some platform-specific source sets should
-depend on the custom ones:
+Custom source sets created in addition to the [default ones](#default-project-layout) should be explicitly included into the dependencies hierarchy to be able to use declarations from other source sets and, most importantly, to take part in compilations. 
+Most often, they need a `dependsOn commonMain` or `dependsOn commonTest` statement, and some of the default platform-specific source sets should depend on the custom ones, directly or indirectly:
 
 <div class="sample" markdown="1" theme="idea" mode='groovy'>
 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -542,10 +542,10 @@ the tests for all targets.
 As the `commonTest` [default source set](#default-project-layout) is added to all test compilations, tests and test tools that are needed
 on all target platforms may be placed there.
 
-The `kotlin.test` API is availble for multiplatform tests. Add the `kotlin-test-common` and `kotlin-test-annotations-common`
+The [`kotlin.test` API](https://kotlinlang.org/api/latest/kotlin.test/index.html) is availble for multiplatform tests. Add the `kotlin-test-common` and `kotlin-test-annotations-common`
 dependencies to `commonTest` to use `DefaultAsserter` and `@Test`/`@Ignore`/`@BeforeTest`/`@AfterTest` annotations in the common tests.
 
-For JVM targets, use `kotlin-test-junit`, or `kotlin-test-junit5`, or `kotlin-test-testng` for the corresponding asserter implementation and
+For JVM targets, use `kotlin-test-junit` or `kotlin-test-testng` for the corresponding asserter implementation and
 annotations mapping.
 
 For Kotlin/JS targets, add `kotlin-test-js` as a test dependency. At this point, test tasks for Kotlin/JS do not run tests by default 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -169,7 +169,7 @@ kotlin {
 All of the targets may share some of the sources and may have platform-specific sources in their compilations as well. 
 See [Configuring source sets](#configuring-source-sets) for details.
 
-Some targets may require additional configuration. For Android and iOS examples, see the [Multiplatform Project: iOS and Android](/docs/tutorials/native/mpp-ios-android.html) tutorial.
+Some targets may require additional configuration. For Android and iOS examples, see the [Multiplatform Project: iOS and Android] TODO /docs/tutorials/native/mpp-ios-android.html tutorial.
 
 ### Supported platforms
 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -216,7 +216,8 @@ kotlin {
 
 > Note: creating a source set does not link it to any target. Some source sets are [predefined](#default-project-layout) 
 and thus compiled by default. However, custom source sets always need to be explicitly directed to the compilations. 
-See: [Depending on source sets](#depending-on-source-sets). {:.note}
+See: [Depending on source sets](#depending-on-source-sets). 
+{:.note}
 
 A source set by itself is platform-agnostic, but
 it can be considered platform-specific if it is only compiled for a single platform. A source set can, therefore, contain either
@@ -255,6 +256,8 @@ into the same target binary form, such as JVM class files or JS code;
 
 * the [language settings](#language-settings) of `foo` and `bar` should be consistent;
 
+Circular source set dependencies are prohibited.
+
 The source sets DSL can be used to define these connections between the source sets:
 
 <div class="sample" markdown="1" theme="idea" mode='groovy'>
@@ -275,7 +278,35 @@ The source sets DSL can be used to define these connections between the source s
 
 Custom source sets created in addition the [default ones](#default-project-layout) should be explicitly included into the dependencies hierarchy. 
 Most often, they need a `dependsOn commonMain` or `dependsOn commonTest` statement, and some platform-specific source sets should
-depend on the custom ones. Circular source set dependencies are prohibited. 
+depend on the custom ones:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+kotlin { 
+    targets {
+        fromPreset(presets.mingwX64, 'windows')
+        fromPreset(presets.linuxX64, 'linux')
+        /* ... */
+    }
+    sourceSets {
+        desktopTest { // custom source set with tests for the two targets
+            dependsOn commonTest
+            /* ... */
+        }
+        windowsTest { // default test source set for target 'windows'
+            dependsOn desktopTest
+            /* ... */
+        }
+        linuxTest { // default test source et for target 'linux'
+            dependsOn desktopTest
+        }
+        /* ... */
+    }
+}
+```
+
+</div>
 
 ### Adding Dependencies
 
@@ -377,7 +408,8 @@ The language settings are checked for consistency between source sets depending 
 ## Publishing a Multiplatform Library
 
 > The set of target platforms is defined by a multiplatform library author, and they should provide all of the platform-specific implementations for the library. 
-  Adding new targets for a multiplatform library at the consumer's side is not supported. {:.note} 
+> Adding new targets for a multiplatform library at the consumer's side is not supported. 
+{:.note} 
 
 A library built from a multiplatform project may be published to a Maven repository with the Gradle `maven-publish` plugin, which can be applied as follows:
 
@@ -432,7 +464,7 @@ An experimental publishing and dependency consumption mode can be enabled by add
 Future Gradle versions may fail to resolve a dependency to a library published with current versions of Gradle metadata.
 Library authors are recommended to use it to publish experimental versions of the library alongside with the stable publishing mechanism
 until the feature is considered stable. 
-{:note} 
+{:.note}
  
 If a library is published with Gradle metadata enabled and a consumer enables the metadata as well, the consumer may specify a
  single dependency on the library in a common source set, and a corresponding platform-specific variant will be chosen, if available, 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -358,7 +358,7 @@ kotlin {
 ### Disambiguating Targets
 
 It is possible to have more than one target for a single platform in a multiplatform library. For example, these targets
-provide the same API and differ in the libraries they use at runtime, such as testing frameworks or logging solutions. 
+may provide the same API and differ in the libraries they use at runtime, such as testing frameworks or logging solutions. 
 
 However, dependencies on such a library may be ambiguous and thus may thus fail to resolve under certain conditions:
 
@@ -428,8 +428,8 @@ Then, once a target is added, default compilations are created for it:
 
 For each compilation, there is a default source set under the name composed as `<targetName><CompilationName>`. This default source
 set participates in the compilation, and thus it should be used for the platform-specific code and dependencies, and for adding other source
- sets to the compilation be the means of 'depends on'. For example, a project with
-targets `jvm6` (JVM) and `nodeJs` (JS) will have source sets: `jvm6Main`, `jvm6Test`, `nodeJsMain`, `nodeJsTest`.
+ sets to the compilation by the means of 'depends on'. For example, a project with
+targets `jvm6` (JVM) and `nodeJs` (JS) will have source sets: `commonMain`, `commonTest`, `jvm6Main`, `jvm6Test`, `nodeJsMain`, `nodeJsTest`.
 
 Numerous use cases are covered by just the default source sets and don't require custom source sets.
  

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -404,6 +404,46 @@ The language settings are checked for consistency between source sets depending 
 * `foo` should enable all unstable language features that `bar` enabled (there's no such requirement for bugfix features);
 * `apiVersion`, bugfix language features, and `progressiveMode` can be set arbitrarily; 
 
+## Default Project Layout
+
+By default, each project contains two source sets, `commonMain` and `commonTest`, where one can place all the code that should be 
+shared between all of the target platforms. These source sets are added to each production and test compilation, respectively.
+
+Then, once a target is added, default compilations are created for it:
+
+* `main` and `test` compilations for JVM, JS, and Native targets;
+* a compilation per Android variant, for Android targets;
+
+For each compilation, there is a default source set under the name composed as `<targetName><CompilationName>`. This default source
+set participates in the compilation, and thus it should be used for the platform-specific code and dependencies, and for adding other source
+ sets to the compilation by the means of 'depends on'. For example, a project with
+targets `jvm6` (JVM) and `nodeJs` (JS) will have source sets: `commonMain`, `commonTest`, `jvm6Main`, `jvm6Test`, `nodeJsMain`, `nodeJsTest`.
+
+Numerous use cases are covered by just the default source sets and don't require custom source sets.
+ 
+Each source set by default has its Kotlin sources under `src/<sourceSetName>/kotlin` directory and the resources under `src/<sourceSetName>/resources`.
+
+In Android projects, additional Kotlin source sets are created for each Android source set. If the Android target has a name `foo`, the Android source set `bar` gets a Kotlin source set counterpart `fooBar`. The Kotlin compilations, however, are able to consume Kotlin sources from all of the directories `src/bar/java`, `src/bar/kotlin`, and `src/fooBar/kotlin`. Java sources are only read from the first of these directories.
+
+## Running Tests
+
+A test task is created under the name `<targetName>Test` for each target that is suitable for testing.  Run the `check` task to run 
+the tests for all targets.
+
+As the `commonTest` [default source set](#default-project-layout) is added to all test compilations, tests and test tools that are needed
+on all target platforms may be placed there.
+
+The [`kotlin.test` API](https://kotlinlang.org/api/latest/kotlin.test/index.html) is availble for multiplatform tests. Add the `kotlin-test-common` and `kotlin-test-annotations-common`
+dependencies to `commonTest` to use `DefaultAsserter` and `@Test`/`@Ignore`/`@BeforeTest`/`@AfterTest` annotations in the common tests.
+
+For JVM targets, use `kotlin-test-junit` or `kotlin-test-testng` for the corresponding asserter implementation and
+annotations mapping.
+
+For Kotlin/JS targets, add `kotlin-test-js` as a test dependency. At this point, test tasks for Kotlin/JS do not run tests by default 
+and should be manually configured to do so. 
+
+Kotlin/Native targets do not require additional test dependencies, and the `kotlin.test` API implementations are built-in.
+
 ## Publishing a Multiplatform Library
 
 > The set of target platforms is defined by a multiplatform library author, and they should provide all of the platform-specific implementations for the library. 
@@ -533,47 +573,6 @@ However, dependencies on such a multiplatform library may be ambiguous and may t
      ```
      
      </div>
-     
-## Running Tests
-
-A test task is created under the name `<targetName>Test` for each target that is suitable for testing.  Run the `check` task to run 
-the tests for all targets.
-
-As the `commonTest` [default source set](#default-project-layout) is added to all test compilations, tests and test tools that are needed
-on all target platforms may be placed there.
-
-The [`kotlin.test` API](https://kotlinlang.org/api/latest/kotlin.test/index.html) is availble for multiplatform tests. Add the `kotlin-test-common` and `kotlin-test-annotations-common`
-dependencies to `commonTest` to use `DefaultAsserter` and `@Test`/`@Ignore`/`@BeforeTest`/`@AfterTest` annotations in the common tests.
-
-For JVM targets, use `kotlin-test-junit` or `kotlin-test-testng` for the corresponding asserter implementation and
-annotations mapping.
-
-For Kotlin/JS targets, add `kotlin-test-js` as a test dependency. At this point, test tasks for Kotlin/JS do not run tests by default 
-and should be manually configured to do so. 
-
-Kotlin/Native targets do not require additional test dependencies, and the `kotlin.test` API implementations are built-in.
- 
-## Default Project Layout
-
-By default, each project contains two source sets, `commonMain` and `commonTest`, where one can place all the code that should be 
-shared between all of the target platforms. These source sets are added to each production and test compilation, respectively.
-
-Then, once a target is added, default compilations are created for it:
-
-* `main` and `test` compilations for JVM, JS, and Native targets;
-* a compilation per Android variant, for Android targets;
-
-For each compilation, there is a default source set under the name composed as `<targetName><CompilationName>`. This default source
-set participates in the compilation, and thus it should be used for the platform-specific code and dependencies, and for adding other source
- sets to the compilation by the means of 'depends on'. For example, a project with
-targets `jvm6` (JVM) and `nodeJs` (JS) will have source sets: `commonMain`, `commonTest`, `jvm6Main`, `jvm6Test`, `nodeJsMain`, `nodeJsTest`.
-
-Numerous use cases are covered by just the default source sets and don't require custom source sets.
- 
-Each source set by default has its Kotlin sources under `src/<sourceSetName>/kotlin` directory and the resources under `src/<sourceSetName>/resources`.
-
-In Android projects, additional Kotlin source sets are created for each Android source set. These Kotlin source sets can consume Kotlin sources
-from the `src/.../java` directory of the Android source set or its neighbor `src/.../kotlin` directory.
 
 ## Using Kotlin/Native Targets
 

--- a/pages/docs/reference/multiplatform.md
+++ b/pages/docs/reference/multiplatform.md
@@ -7,223 +7,138 @@ title: "Multiplatform Projects"
 
 # Multiplatform Projects
 
-> Multiplatform projects are a new experimental feature in Kotlin 1.2. All of the language
+> Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
 and tooling features described in this document are subject to change in future Kotlin versions.
 {:.note}
 
-A Kotlin multiplatform project allows you to compile the same code to multiple target
-platforms. At this time supported target platforms are the JVM and JS, with Native to be added later.
+A Kotlin multiplatform project allows you to compile your codebases to multiple target
+platforms. This allows for code reuse between all of the Kotlin target platforms: the JVM, JS, and Native.
 
-## Multiplatform Project Structure
+## Basic Concepts
 
-A multiplatform project consists of three types of modules:
+Multiplatform projects are not just about compiling all the code for all target platforms, instead a project may 
+contain platform-specific code, such as GUI logic, along with the common part shared between the platforms. 
 
-  * A _common_ module contains code that is not specific to any platform, as well as declarations
-    without implementation of platform-dependent APIs. Those declarations allow common code to depend on 
-    platform-specific implementations.
-  * A _platform_ module contains implementations of platform-dependent declarations in the common module
-    for a specific platform, as well as other platform-dependent code. A platform module is always
-    an implementation of a single common module.
-  * A regular module. Such modules target a specific platform and can either be dependencies of
-    platform modules or depend on platform modules.
-    
-A common module can depend only on other common modules and libraries, including the common
-version of the Kotlin standard library (`kotlin-stdlib-common`). Common modules contain only Kotlin
-code, and not code in any other languages.
+To define the API for platform-specific logic and provide the implementations for certain target platforms, you can use 
+[`expect` and `actual` declarations](platform-specific-declarations.html).
 
-A platform module can depend on any modules and libraries available on the given platform
-(including Java libraries in case of Kotlin/JVM and JS libraries for Kotlin/JS). Platform modules
-targeting Kotlin/JVM can also contain code in Java and other JVM languages.
-
-Compiling a common module produces a special _metadata_ file containing all the declarations in the
-module. Compiling a platform module produces target-specific code (JVM bytecode or JS source code)
-for the code in the platform module as well as the common module that it implements.
-
-Therefore, each multiplatform library needs to be distributed as a set of artifacts - a common
-.jar containing the metadata for common code, as well as platform specific .jars containing the
-compiled implementation code for each platform.
-
-
-## Setting Up a Multiplatform Project
-
-As of Kotlin 1.2, multiplatform projects have to be built with Gradle; other build systems
-are not supported. If you work with a multiplatform project in IDE, make sure that `Delegate IDE build/run actions to gradle` option is enabled and `Gradle Test Runner` is set for `Run tests using` option. Both options may be found here: _Settings > Build, execution, Deployment > Build Tools > Gradle > Runner_
-
-To create a new multiplatform project in the IDE, select the "Kotlin (Multiplatform)" option
-under "Kotlin" in the New Project dialog. This will create a project with three modules, a common one
-and two platform ones for JVM and JS. To add additional modules, select one of the "Kotlin (Multiplatform)"
-options under "Gradle" in the New Module dialog.
-
-If you need to configure the project manually, use the following steps:
-
-  * Add the Kotlin Gradle plugin to the buildscript classpath: `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"`
-  * Apply the `kotlin-platform-common` plugin to the common module
-  * Add the `kotlin-stdlib-common` dependency to the common module
-  * Apply the `kotlin-platform-jvm`, `kotlin-platform-android`, and `kotlin-platform-js` plugins to the platform modules for JVM, Android, and JS, respectively
-  * Add dependencies with `expectedBy` scope from the platform modules to the common module
+* an `expect` declaration does not require an implementation and is placed in the common code, communicating that
+ its platform-specific implementations are *expected*; it can then be used in other `expect` declarations and the 
+ common code;
   
-The following example demonstrates a complete `build.gradle` file for a common module with Kotlin 1.2:
+* an `actual` declaration specifies a platform-specific implementation of a certain `expect` declaration for one or more
+  of the target platforms; each `expect` declaration must have an actual counterpart on all of the target platforms.
+  
+Kotlin multiplatform projects support flexible code reuse between the target platforms by grouping the sources within 
+source sets and directing them to certain targets. There is a set of building blocks that are used to define the 
+structure of a multiplatform project:
 
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
-``` groovy
-buildscript {
-    ext.kotlin_version = '{{ site.data.releases.latest.version }}'
-
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-apply plugin: 'kotlin-platform-common'
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
-    testCompile "org.jetbrains.kotlin:kotlin-test-common:$kotlin_version"
-}
-```
-</div>
-
-And the example below shows a complete `build.gradle` for a JVM module. Pay special
-attention to the `expectedBy` line in the `dependencies` block:
-
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
-``` groovy
-buildscript {
-    ext.kotlin_version = '{{ site.data.releases.latest.version }}'
-
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-apply plugin: 'kotlin-platform-jvm'
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    expectedBy project(":")
-    testCompile "junit:junit:4.12"
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-}
-```
-</div>
-
-
-## Platform-Specific Declarations
-
-One of the key capabilities of Kotlin's multiplatform code is a way for common code to
-depend on platform-specific declarations. In other languages, this can often be accomplished
-by building a set of interfaces in the common code and implementing these interfaces in platform-specific
-modules. However, this approach is not ideal in cases when you have a library on one of the platforms
-that implements the functionality you need, and you'd like to use the API of this library directly
-without extra wrappers. Also, it requires common declarations to be expressed as interfaces, which
-doesn't cover all possible cases.
-
-As an alternative, Kotlin provides a mechanism of _expected and actual declarations_.
-With this mechanism, a common module can define _expected declarations_, and a platform module
-can provide _actual declarations_ corresponding to the expected ones. 
-To see how this works, let's look at an example first. This code is part of a common module:
-
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
-``` kotlin
-package org.jetbrains.foo
-
-expect class Foo(bar: String) {
-    fun frob()
-}
-
-fun main(args: Array<String>) {
-    Foo("Hello").frob()
-}
-```
-</div>
-
-And this is the corresponding JVM module:
-
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
-``` kotlin
-package org.jetbrains.foo
-
-actual class Foo actual constructor(val bar: String) {
-    actual fun frob() {
-        println("Frobbing the $bar")
-    }
-}
-```
-</div>
-
-This illustrates several important points:
-
-  * An expected declaration in the common module and its actual counterparts always
-    have exactly the same fully qualified name.
-  * An expected declaration is marked with the `expect` keyword; the actual declaration
-    is marked with the `actual` keyword.
-  * All actual declarations that match any part of an expected declaration need to be marked
-    as `actual`.
-  * Expected declarations never contain any implementation code.
-
-Note that expected declarations are not restricted to interfaces and interface members.
-In this example, the expected class has a constructor and can be created directly from common code.
-You can apply the `expect` modifier to other declarations as well, including top-level declarations and
-annotations:
-
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
-``` kotlin
-// Common
-expect fun formatString(source: String, vararg args: Any): String
-
-expect annotation class Test
-
-// JVM
-actual fun formatString(source: String, vararg args: Any) =
-    String.format(source, args)
+* a *target* is a part of a multiplatform project that can be though of as a complete piece of software built for 
+  a certain *target platform* like JVM 6, Android, NodeJS, Browser, iOS, Linux x64.
+  
+  * building a target, depending on its target platform, involves one or more Kotlin *compilations* from different 
+    sources, for example, assembling the production sources first and then the tests;
     
-actual typealias Test = org.junit.Test
-```
-</div>
+* a *source set* is a collection of Kotlin sources, along with their dependencies, that takes part in one or more of 
+  the target compilations
+  
+Using these terms, you can configure a Kotlin multiplatform project and build it for any and all of the supported
+target platforms, as described below.
 
-The compiler ensures that every expected declaration has actual declarations in all platform
-modules that implement the corresponding common module, and reports an error if any actual declarations are 
-missing. The IDE provides tools that help you create the missing actual declarations.
+## Setting up a Multiplatform Project
 
-If you have a platform-specific library that you want to use in common code while providing your own
-implementation for another platform, you can provide a typealias to an existing class as the actual
-declaration:
+As of Kotlin 1.3, multiplatform projects are built with Gradle 4.7 and above; other build systems and older Gradle 
+versions are not supported.
 
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
-``` kotlin
-expect class AtomicRef<V>(value: V) {
-  fun get(): V
-  fun set(value: V)
-  fun getAndSet(value: V): V
-  fun compareAndSet(expect: V, update: V): Boolean
+You can create a new multiplatform project in the IDE by selecting one of the multiplatform project templates in the 
+New Project dialog under the "Kotlin" section. 
+
+For example, if you choose "Kotlin (Multiplatform Library)", a library project is created that has three targets, one 
+for the JVM, one for JS, and one for the Native platform that you are using. These are configured in the `build.gradle`
+script in the following way:
+
+<div class="sample" markdown="1" theme="idea" mode='groovy'>
+
+```groovy
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform' version '{{ site.data.releases.latest.version }}'
 }
 
-actual typealias AtomicRef<V> = java.util.concurrent.atomic.AtomicReference<V>
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    targets {
+        fromPreset(presets.jvm, 'jvm')
+        fromPreset(presets.js, 'js')
+        fromPreset(presets.mingwX64, 'mingw')
+    }
+    
+    sourceSets { /* ... */ }
+}
 ```
 </div>
+
+The three targets are created from the presets that provide some [default configuration](building-mpp-with-gradle.html#default-project-layout). 
+There are presets for each of the [supported platforms](building-mpp-with-gradle.html#supported-platforms).
+
+The source sets and their dependencies are configured as follows:
+
+```groovy
+/* ... */
+
+kotlin {
+    targets { /* ... */ }
+
+    sourceSets { 
+        commonMain {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-test-common'
+                implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
+            }
+        }
+        jvmMain {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+            }
+        }
+        jvmTest {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-test'
+                implementation 'org.jetbrains.kotlin:kotlin-test-junit'
+            }
+        }
+        jsMain {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
+            }
+        }
+        jsTest {
+            dependencies {
+                implementation 'org.jetbrains.kotlin:kotlin-test-js'
+            }
+        }
+        mingwMain { }
+        mingwTest { }
+    }
+}
+```
+</div>
+
+These are the default source set names for the production and test sources for the targets configured above. The source 
+sets `commonMain` and `commonTest` are included into production and test compilations, respectively, of all targets. 
+Note that the dependencies for common source sets `commonMain` and `commonTest` are the common artifacts, and the 
+platform libraries go to the source sets of the specific targets. Go to [Adding Dependencies](building-mpp-with-gradle.html#adding-dependencies) 
+for details on dependencies configuration.
+
+General information on configuring a Kotlin multiplatform project Gradle build can be found in [Building Multiplatform Projects with Gradle](building-mpp-with-gradle.html).
 
 ## Multiplatform tests
 
-It is possible to write tests in a common project so that they will be compiled and run in each platform project. 
-There are 4 annotations provided in `kotlin.test` package to markup tests in common code: `@Test`, `@Ignore`, 
-`@BeforeTest` and `@AfterTest`.
-In JVM platform these annotations are mapped to the corresponding JUnit 4 annotations, and in JS they are already 
-available since 1.1.4 to support JS unit testing.
-
-In order to use them you need to add a dependency on `kotlin-test-annotations-common` to your common module, on 
-`kotlin-test-junit` to your JVM module, and on `kotlin-test-js` to the JS module.
+It is possible to write tests in a common project so that they will be compiled and run on each target platform. See [Running Tests](building-mpp-with-gradle.html#running-tests)

--- a/pages/docs/reference/multiplatform.md
+++ b/pages/docs/reference/multiplatform.md
@@ -79,7 +79,7 @@ internal actual fun writeLogMessage(message: String, logLevel: LogLevel) {
 
 </div>
 
-In 1.3 we reworked the entire multiplatform model. The [new DSL](building-mpp-with-gradle.md) we have for describing multiplatform Gradle 
+In 1.3 we reworked the entire multiplatform model. The [new DSL](building-mpp-with-gradle.html) we have for describing multiplatform Gradle 
 projects is much more flexible, and we'll keep working on it to make project configuration straightforward.
 
 ## Multiplatform Libraries
@@ -98,7 +98,7 @@ Sharing code between mobile platforms is one of the major Kotlin Multiplatform u
 possible to build mobile applications with parts of the code, such as business logic, connectivity, 
 and more, shared between Android and iOS.
 
-See: [Multiplatform Project: iOS and Android](/docs/tutorials/native/mpp-ios-android.html)
+See: [Multiplatform Project: iOS and Android] TODO /docs/tutorials/native/mpp-ios-android.html
 
 ### Client — Server
 
@@ -111,8 +111,8 @@ The [Ktor framework](https://ktor.io/) can be used for building connected multip
 ## How to start
 
 * Tutorials and samples:
-    * [Multiplatform Kotlin Library](/docs/tutorials/multiplatform-library.html)
-    * [Multiplatform Project: iOS and Android](/docs/tutorials/native/mpp-ios-android.html)
+    * [Multiplatform Kotlin Library] TODO /docs/tutorials/multiplatform-library.html
+    * [Multiplatform Project: iOS and Android] TODO /docs/tutorials/native/mpp-ios-android.html
     * [KotlinConf Schedule Application](https://github.com/JetBrains/kotlinconf-app)
 * Docs: 
     * [Setting up a Multiplatform Project](building-mpp-with-gradle.html#setting-up-a-multiplatform-project) 

--- a/pages/docs/reference/multiplatform.md
+++ b/pages/docs/reference/multiplatform.md
@@ -5,140 +5,116 @@ category: "Other"
 title: "Multiplatform Projects"
 ---
 
-# Multiplatform Projects
+# Multiplatform Programming
 
 > Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
 and tooling features described in this document are subject to change in future Kotlin versions.
 {:.note}
 
-A Kotlin multiplatform project allows you to compile your codebases to multiple target
-platforms. This allows for code reuse between all of the Kotlin target platforms: the JVM, JS, and Native.
+Working on all platforms is an explicit goal for Kotlin, but we see it as a premise to a much more important 
+goal: sharing code between platforms. With support for JVM, Android, JavaScript, iOS, Linux, Windows, 
+Mac and even embedded systems like STM32, Kotlin can handle any and all components of a modern application. 
+And this brings the invaluable benefit of reuse for code and expertise, saving the effort for tasks more 
+challenging than implementing everything twice or multiple times.
 
-## Basic Concepts
+## How it works
 
-Multiplatform projects are not just about compiling all the code for all target platforms, instead a project may 
-contain platform-specific code, such as GUI logic, along with the common part shared between the platforms. 
+Overall, multiplatform is not about compiling all code for all platforms. This model has its obvious 
+limitations, and we understand that modern applications need access to unique features of the platforms 
+they are running on. Kotlin doesn't limit you to the common subset of all APIs in the world. 
+Every component can share as much code as needed with others but can access platform APIs at any time 
+through the [`expect`/`actual` mechanism](platform-specific-declarations.html) provided by the language. 
 
-To define the API for platform-specific logic and provide the implementations for certain target platforms, you can use 
-[`expect` and `actual` declarations](platform-specific-declarations.html).
+Here's an example of code sharing and interaction between the common and platform logic in a minimalistic 
+logging framework. The common code would look like this:
 
-* an `expect` declaration does not require an implementation and is placed in the common code, communicating that
- its platform-specific implementations are *expected*; it can then be used in other `expect` declarations and the 
- common code;
-  
-* an `actual` declaration specifies a platform-specific implementation of a certain `expect` declaration for one or more
-  of the target platforms; each `expect` declaration must have an actual counterpart on all of the target platforms.
-  
-Kotlin multiplatform projects support flexible code reuse between the target platforms by grouping the sources within 
-source sets and directing them to certain targets. There is a set of building blocks that are used to define the 
-structure of a multiplatform project:
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
 
-* a *target* is a part of a multiplatform project that can be though of as a complete piece of software built for 
-  a certain *target platform* like JVM 6, Android, NodeJS, Browser, iOS, Linux x64.
-  
-  * building a target, depending on its target platform, involves one or more Kotlin *compilations* from different 
-    sources, for example, assembling the production sources first and then the tests;
-    
-* a *source set* is a collection of Kotlin sources, along with their dependencies, that takes part in one or more of 
-  the target compilations
-  
-Using these terms, you can configure a Kotlin multiplatform project and build it for any and all of the supported
-target platforms, as described below.
-
-## Setting up a Multiplatform Project
-
-As of Kotlin 1.3, multiplatform projects are built with Gradle 4.7 and above; other build systems and older Gradle 
-versions are not supported.
-
-You can create a new multiplatform project in the IDE by selecting one of the multiplatform project templates in the 
-New Project dialog under the "Kotlin" section. 
-
-For example, if you choose "Kotlin (Multiplatform Library)", a library project is created that has three targets, one 
-for the JVM, one for JS, and one for the Native platform that you are using. These are configured in the `build.gradle`
-script in the following way:
-
-<div class="sample" markdown="1" theme="idea" mode='groovy'>
-
-```groovy
-plugins {
-    id 'org.jetbrains.kotlin.multiplatform' version '{{ site.data.releases.latest.version }}'
-}
-
-repositories {
-    mavenCentral()
-}
-
-kotlin {
-    targets {
-        fromPreset(presets.jvm, 'jvm')
-        fromPreset(presets.js, 'js')
-        fromPreset(presets.mingwX64, 'mingw')
-    }
-    
-    sourceSets { /* ... */ }
-}
 ```
+// compiled for all platforms:
+enum class LogLevel {
+    DEBUG, WARN, ERROR
+}
+
+// expected platform-specific API:
+internal expect fun writeLogMessage(message: String, logLevel: LogLevel)
+
+// expected API can be used in the common code:
+fun logDebug(message: String) = writeLogMessage(message, LogLevel.DEBUG)
+fun logWarn(message: String) = writeLogMessage(message, LogLevel.WARN)
+fun logError(message: String) = writeLogMessage(message, LogLevel.ERROR)
+```
+
 </div>
 
-The three targets are created from the presets that provide some [default configuration](building-mpp-with-gradle.html#default-project-layout). 
-There are presets for each of the [supported platforms](building-mpp-with-gradle.html#supported-platforms).
+It expects the targets to provide platform-specific implementations for `writeLogMessage`, and the common code can 
+now use this declaration without any consideration of how it is implemented.
 
-The source sets and their dependencies are configured as follows:
+On the JVM, one could provide an implementation that writes the log to the standard output:
 
-```groovy
-/* ... */
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
 
-kotlin {
-    targets { /* ... */ }
+```
+internal actual fun writeLogMessage(message: String, logLevel: LogLevel) {
+    println("[$logLevel]: $message")
+}
+```
 
-    sourceSets { 
-        commonMain {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
-            }
-        }
-        commonTest {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test-common'
-                implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
-            }
-        }
-        jvmMain {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-            }
-        }
-        jvmTest {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test'
-                implementation 'org.jetbrains.kotlin:kotlin-test-junit'
-            }
-        }
-        jsMain {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
-            }
-        }
-        jsTest {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test-js'
-            }
-        }
-        mingwMain { }
-        mingwTest { }
+</div>
+
+In the JavaScript world, a completely different set of APIs is availiable, 
+so one could instead implement logging to the console:
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```
+internal actual fun writeLogMessage(message: String, logLevel: LogLevel) {
+    when (logLevel) {
+        LogLevel.DEBUG -> console.log(message)
+        LogLevel.WARN -> console.warn(message)
+        LogLevel.ERROR -> console.error(message)
     }
 }
 ```
+
 </div>
 
-These are the default source set names for the production and test sources for the targets configured above. The source 
-sets `commonMain` and `commonTest` are included into production and test compilations, respectively, of all targets. 
-Note that the dependencies for common source sets `commonMain` and `commonTest` are the common artifacts, and the 
-platform libraries go to the source sets of the specific targets. Go to [Adding Dependencies](building-mpp-with-gradle.html#adding-dependencies) 
-for details on dependencies configuration.
+In 1.3 we reworked the entire multiplatform model. The [new DSL](building-mpp-with-gradle.md) we have for describing multiplatform Gradle 
+projects is much more flexible, and we'll keep working on it to make project configuration straightforward.
 
-General information on configuring a Kotlin multiplatform project Gradle build can be found in [Building Multiplatform Projects with Gradle](building-mpp-with-gradle.html).
+## Multiplatform Libraries
 
-## Multiplatform tests
+Common code can rely on a set of libraries that cover everyday tasks such as HTTP, serialization and managing 
+coroutines. Also, an extensive standard library is available on all platforms. 
 
-It is possible to write tests in a common project so that they will be compiled and run on each target platform. See [Running Tests](building-mpp-with-gradle.html#running-tests)
+You can always write your 
+own library providing a common API and implementing it differently on every platform.
+
+## Use cases
+
+### Android — iOS
+
+Sharing code between mobile platforms is one of the major Kotlin Multiplatform use cases, and it is now 
+possible to build mobile applications with parts of the code, such as business logic, connectivity, 
+and more, shared between Android and iOS.
+
+See: [Multiplatform Project: iOS and Android](/docs/tutorials/native/mpp-ios-android.html)
+
+### Client — Server
+
+Another scneraio when code sharing may bring benefits is a connected application where the logic may be 
+reused on both the server and the client side running in the browser. This is covered by Kotlin 
+Multiplatform as well.
+
+The [Ktor framework](https://ktor.io/) can be used for building connected multiplatform applications.
+
+## How to start
+
+* Tutorials and samples:
+    * [Multiplatform Kotlin Library](/docs/tutorials/multiplatform-library.html)
+    * [Multiplatform Project: iOS and Android](/docs/tutorials/native/mpp-ios-android.html)
+    * [KotlinConf Schedule Application](https://github.com/JetBrains/kotlinconf-app)
+* Docs: 
+    * [Setting up a Multiplatform Project](building-mpp-with-gradle.html#setting-up-a-multiplatform-project) 
+    * [Platform-Specific Declarations](platform-specific-declarations.html) 
+  

--- a/pages/docs/reference/multiplatform.md
+++ b/pages/docs/reference/multiplatform.md
@@ -102,11 +102,11 @@ See: [Multiplatform Project: iOS and Android] TODO /docs/tutorials/native/mpp-io
 
 ### Client — Server
 
-Another scneraio when code sharing may bring benefits is a connected application where the logic may be 
+Another scenario when code sharing may bring benefits is a connected application where the logic may be 
 reused on both the server and the client side running in the browser. This is covered by Kotlin 
 Multiplatform as well.
 
-The [Ktor framework](https://ktor.io/) can be used for building connected multiplatform applications.
+The [Ktor framework](https://ktor.io/) is suitable for building asynchronous servers and clients in connected systems.
 
 ## How to start
 

--- a/pages/docs/reference/platform-specific-declarations.md
+++ b/pages/docs/reference/platform-specific-declarations.md
@@ -1,0 +1,108 @@
+---
+type: doc
+layout: reference
+category: "Other"
+title: "Platform-Specific Declarations"
+---
+
+## Platform-Specific Declarations
+
+> Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
+and tooling features described in this document are subject to change in future Kotlin versions.
+{:.note}
+
+One of the key capabilities of Kotlin's multiplatform code is a way for common code to
+depend on platform-specific declarations. In other languages, this can often be accomplished
+by building a set of interfaces in the common code and implementing these interfaces in platform-specific
+modules. However, this approach is not ideal in cases when you have a library on one of the platforms
+that implements the functionality you need, and you'd like to use the API of this library directly
+without extra wrappers. Also, it requires common declarations to be expressed as interfaces, which
+doesn't cover all possible cases.
+
+As an alternative, Kotlin provides a mechanism of _expected and actual declarations_.
+With this mechanism, a common module can define _expected declarations_, and a platform module
+can provide _actual declarations_ corresponding to the expected ones. 
+To see how this works, let's look at an example first. This code is part of a common module:
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+``` kotlin
+package org.jetbrains.foo
+
+expect class Foo(bar: String) {
+    fun frob()
+}
+
+fun main(args: Array<String>) {
+    Foo("Hello").frob()
+}
+```
+</div>
+
+And this is the corresponding JVM module:
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+``` kotlin
+package org.jetbrains.foo
+
+actual class Foo actual constructor(val bar: String) {
+    actual fun frob() {
+        println("Frobbing the $bar")
+    }
+}
+```
+</div>
+
+This illustrates several important points:
+
+  * An expected declaration in the common module and its actual counterparts always
+    have exactly the same fully qualified name.
+  * An expected declaration is marked with the `expect` keyword; the actual declaration
+    is marked with the `actual` keyword.
+  * All actual declarations that match any part of an expected declaration need to be marked
+    as `actual`.
+  * Expected declarations never contain any implementation code.
+
+Note that expected declarations are not restricted to interfaces and interface members.
+In this example, the expected class has a constructor and can be created directly from common code.
+You can apply the `expect` modifier to other declarations as well, including top-level declarations and
+annotations:
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+``` kotlin
+// Common
+expect fun formatString(source: String, vararg args: Any): String
+
+expect annotation class Test
+
+// JVM
+actual fun formatString(source: String, vararg args: Any) =
+    String.format(source, args)
+    
+actual typealias Test = org.junit.Test
+```
+</div>
+
+The compiler ensures that every expected declaration has actual declarations in all platform
+modules that implement the corresponding common module, and reports an error if any actual declarations are 
+missing. The IDE provides tools that help you create the missing actual declarations.
+
+If you have a platform-specific library that you want to use in common code while providing your own
+implementation for another platform, you can provide a typealias to an existing class as the actual
+declaration:
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+``` kotlin
+expect class AtomicRef<V>(value: V) {
+  fun get(): V
+  fun set(value: V)
+  fun getAndSet(value: V): V
+  fun compareAndSet(expect: V, update: V): Boolean
+}
+
+actual typealias AtomicRef<V> = java.util.concurrent.atomic.AtomicReference<V>
+```
+</div>

--- a/pages/docs/reference/using-gradle.md
+++ b/pages/docs/reference/using-gradle.md
@@ -15,6 +15,7 @@ The `kotlin-gradle-plugin` compiles Kotlin sources and modules.
 The version of Kotlin to use is usually defined as the `kotlin_version` property:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` groovy
 buildscript {
     ext.kotlin_version = '{{ site.data.releases.latest.version }}'
@@ -31,6 +32,11 @@ buildscript {
 </div>
 
 This is not required when using Kotlin Gradle plugin 1.1.1 and above with the [Gradle plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block), and with [Gradle Kotlin DSL](https://github.com/gradle/kotlin-dsl).
+
+## Building Kotlin Multiplatform Projects
+
+Using the `kotlin-multiplatform` plugin for building [multiplatform projects](multiplatform.html) is described in 
+[Building Multiplatform Projects with Gradle](building-mpp-with-gradle.html).
 
 ## Targeting the JVM
 


### PR DESCRIPTION
* Rewrite old MPP page, turn it into an introduction
* Move expect/actual to a separate page
* Add a page for Gradle configuration and DSL, also explaining the
  concepts