### PR TITLE
docs(android): Link to Android Studio stable

### DIFF
--- a/pages/docs/tutorials/kotlin-android.md
+++ b/pages/docs/tutorials/kotlin-android.md
@@ -9,7 +9,7 @@ showAuthorInfo: false
 
 ### Installing the Kotlin plugin
 
-The Kotlin plugin is bundled with Android Studio starting from [version 3.0](https://developer.android.com/studio/preview/index.html). If you use an earlier version, you'll need to install the Kotlin plugin.
+The Kotlin plugin is bundled with Android Studio starting from [version 3.0](https://developer.android.com/studio/). If you use an earlier version, you'll need to install the Kotlin plugin.
 Go to _File \| Settings \| Plugins \| Install JetBrains plugin..._ and then search for and install *Kotlin*.
 If you are looking at the "Welcome to Android Studio" screen, choose _Configure \| Plugins \| Install JetBrains plugin..._
 You'll need to restart the IDE after this completes.

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -118,7 +118,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     <h3 class="option-title">Android Studio</h3>
 
                     <p class="option-description">
-                        Bundled with <a href="https://developer.android.com/studio/preview/index.html" target="_blank">Studio 3.0</a>, plugin available for earlier versions
+                        Bundled with <a href="https://developer.android.com/studio/" target="_blank">Studio 3.0</a>, plugin available for earlier versions
                     </p>
 
 


### PR DESCRIPTION
- before the main weg page and the Android sub page were
  linking to Android Studio Preview. Since Android Studio 3.0 stable
  is out for some time now we really should link to the stable version
  instead!