### PR TITLE
Remove Griffon from build-tools.md

### DIFF
--- a/pages/docs/tutorials/build-tools.md
+++ b/pages/docs/tutorials/build-tools.md
@@ -6,11 +6,10 @@ description:
 authors: Hadi Hariri
 showAuthorInfo: false
 ---
-In addition to the command line compiler and IntelliJ IDEA, you can also use Ant, Maven, Gradle and Griffon to build Kotlin projects.
+In addition to the command line compiler and IntelliJ IDEA, you can also build Kotlin projects with Ant, Maven, and Gradle.
 
 For information on how to do use each of these tutorials refer to the corresponding section:
 
 - [Ant](/docs/reference/using-ant.html)
 - [Maven](/docs/reference/using-maven.html)
 - [Gradle](/docs/reference/using-gradle.html)
-- [Griffon (external support)](https://github.com/griffon/griffon-kotlin-plugin)


### PR DESCRIPTION
As Griffon now uses Gradle as its recommended build system, there's no need to mention it in the build tools section.