### PR TITLE
Fix a "bug" in code snippet

### DIFF
--- a/pages/docs/reference/platform-specific-declarations.md
+++ b/pages/docs/reference/platform-specific-declarations.md
@@ -79,7 +79,7 @@ expect annotation class Test
 
 // JVM
 actual fun formatString(source: String, vararg args: Any) =
-    String.format(source, args)
+    String.format(source, *args)
     
 actual typealias Test = org.junit.Test
 ```


### PR DESCRIPTION
Java String.format uses vararg, so we should pass arguments as vararg. Otherwise it compiles ok but throws a runtime exception |java.util.IllegalFormatConversionException: x != [Ljava.lang.Object;"

I banged my head for half a day to understand what's wrong and in the end Andrey Mischenko showed me the answer.