### PR TITLE
docs(ranges) : remove incorrect example

### DIFF
--- a/pages/docs/reference/ranges.md
+++ b/pages/docs/reference/ranges.md
@@ -26,8 +26,6 @@ The compiler takes care of converting this analogously to Java's indexed *for*{:
 fun main() {
 //sampleStart
 for (i in 1..4) print(i)
-
-for (i in 4..1) print(i)
 //sampleEnd
 }
 ```


### PR DESCRIPTION
The range 4..1 is empty, thus incorrect. Should use downTo instead