### PR TITLE
Fix broken libcurl.def in tutorial

### DIFF
--- a/pages/docs/tutorials/native/interop-with-c.md
+++ b/pages/docs/tutorials/native/interop-with-c.md
@@ -35,6 +35,7 @@ to make some HTTP calls, so we'll create a file named `libcurl.def` with the fol
 ```
 headers = curl/curl.h
 headerFilter = curl/*
+compilerOpts.linux = -I/usr/include -I/usr/include/x86_64-linux-gnu
 linkerOpts.osx = -L/opt/local/lib -L/usr/local/opt/curl/lib -lcurl
 linkerOpts.linux = -L/usr/lib/x86_64-linux-gnu -lcurl
 ```


### PR DESCRIPTION
I downloaded the Kotlin/Native compiler using the linux artifact on version 0.9.3. I'm running Ubuntu 18.04 with libcurl4 and libcurl4-openssl-dev installed. The original .def file did not work, with `cinterop` saying "Could not find curl/curl.h". I then added `-I/usr/include/x86_64-linux-gnu`, and curl.h was found but it was complaining about a missing definition for the macro `__glibc_clang_prereq`. After adding the second compiler include (`-I/usr/include`) creation of the .klib worked.