### PR TITLE
Fixed a typo in sam-with-receiver samples

### DIFF
--- a/pages/docs/reference/compiler-plugins.md
+++ b/pages/docs/reference/compiler-plugins.md
@@ -376,7 +376,7 @@ public interface TaskRunner {
 
 ```kotlin
 fun test(context: TaskContext) {
-    val handler = TaskHandler { 
+    val runner = TaskRunner { 
         // Here 'this' is an instance of 'Task'
         
         println("$name is started")


### PR DESCRIPTION
TaskRunner is defined as  the sample of SAM with receiver stuff but TaskHandler class, which is not defined, is used.