### PR TITLE
Escape keyword used as a parameter name.

### DIFF
--- a/pages/docs/reference/platform-specific-declarations.md
+++ b/pages/docs/reference/platform-specific-declarations.md
@@ -100,7 +100,7 @@ expect class AtomicRef<V>(value: V) {
   fun get(): V
   fun set(value: V)
   fun getAndSet(value: V): V
-  fun compareAndSet(expect: V, update: V): Boolean
+  fun compareAndSet(`expect`: V, update: V): Boolean
 }
 
 actual typealias AtomicRef<V> = java.util.concurrent.atomic.AtomicReference<V>


### PR DESCRIPTION
As `expect` is a keyword in Kotlin, the parameter name should be escaped by backtics.