### PR TITLE
Update spring plugin description for Maven

### DIFF
--- a/pages/docs/reference/compiler-plugins.md
+++ b/pages/docs/reference/compiler-plugins.md
@@ -148,14 +148,24 @@ plugins {
 
 </div>
 
-In Maven, enable the `spring` plugin:
+In Maven, the `spring` plugin is provided by the `kotlin-maven-allopen` plugin dependency, so to enable it:
 
 <div class="sample" markdown="1" theme="idea" mode="xml" auto-indent="false">
 
 ```xml
-<compilerPlugins>
-    <plugin>spring</plugin>
-</compilerPlugins>
+<configuration>
+    <compilerPlugins>
+        <plugin>spring</plugin>
+    </compilerPlugins>
+</configuration>
+
+<dependencies>
+    <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-allopen</artifactId>
+        <version>${kotlin.version}</version>
+    </dependency>
+</dependencies>
 ```
 
 </div>


### PR DESCRIPTION
The `spring` compiler plugin in Maven depends on the `kotlin-maven-allopen` plugin dependency, so the documentation should mention it explicitly. Otherwise it may have been confusing since the Gradle dependency is called `kotlin-spring`, but there is no such artifact for Maven.