### PR TITLE
Missing spring dependency-management gradle plugin

### DIFF
--- a/pages/docs/tutorials/spring-boot-restful.md
+++ b/pages/docs/tutorials/spring-boot-restful.md
@@ -33,12 +33,14 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version" // Required for Kotlin integration
 	classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version" // See https://kotlinlang.org/docs/reference/compiler-plugins.html#kotlin-spring-compiler-plugin
         classpath "org.springframework.boot:spring-boot-gradle-plugin:$spring_boot_version"
+	classpath "io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE"
     }
 }
 
 apply plugin: 'kotlin' // Required for Kotlin integration
 apply plugin: "kotlin-spring" // See https://kotlinlang.org/docs/reference/compiler-plugins.html#kotlin-spring-compiler-plugin
 apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
 
 jar {
     baseName = 'gs-rest-service'


### PR DESCRIPTION
You either need to use the plugin or implicitly specify the version of `spring-boot-starter-web`