### PR TITLE
KT-28714 Fix plugin statement

### DIFF
--- a/pages/docs/tutorials/httpservlets.md
+++ b/pages/docs/tutorials/httpservlets.md
@@ -27,7 +27,7 @@ We also need to use the *war* plugin that helps us generate the corresponding WA
 
 <div class="sample" markdown="1" theme="idea" mode="groovy">
 ``` groovy
-apply plugin: war
+apply plugin: 'war'
 ```
 </div>
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-28714

According to the code in https://github.com/JetBrains/kotlin-examples/blob/master/tutorials/servlet-web-applications/build.gradle , `war` is surrounded by `'`.