### PR TITLE
Add note about lack of thread-safety of immutable collection ops

### DIFF
--- a/pages/docs/reference/collections.md
+++ b/pages/docs/reference/collections.md
@@ -45,7 +45,7 @@ val items = listOf(1, 2, 3)
 
 </div>
 
-Currently, the `listOf` method is implemented using an array list, but in future more memory-efficient fully immutable collection types could be returned that exploit the fact that they know they can't change. 
+Currently, the `listOf` method is implemented using an array list, but in future more memory-efficient fully immutable collection types could be returned that exploit the fact that they know they can't change.
 
 Note that the read-only types are [covariant](generics.html#variance). That means, you can take a `List<Rectangle>` and assign it to `List<Shape>` assuming `Rectangle` inherits from `Shape` (the collection types have the same inheritance relationship as the element types). This wouldn't be allowed with the mutable collection types because it would allow for failures at runtime: you might add a `Circle` into the `List<Shape>`, creating a `List<Rectangle>` with a `Circle` in it somewhere else in the program.
 

--- a/pages/docs/reference/collections.md
+++ b/pages/docs/reference/collections.md
@@ -45,7 +45,7 @@ val items = listOf(1, 2, 3)
 
 </div>
 
-Currently, the `listOf` method is implemented using an array list, but in future more memory-efficient fully immutable collection types could be returned that exploit the fact that they know they can't change. It's important to note, that the operations on readonly collections which return a modified collection (like `+`, `filter`, `drop`, etc.) do not create their results atomically, therefore the results are not safe to use from a different thread without proper syncronisation. 
+Currently, the `listOf` method is implemented using an array list, but in future more memory-efficient fully immutable collection types could be returned that exploit the fact that they know they can't change. 
 
 Note that the read-only types are [covariant](generics.html#variance). That means, you can take a `List<Rectangle>` and assign it to `List<Shape>` assuming `Rectangle` inherits from `Shape` (the collection types have the same inheritance relationship as the element types). This wouldn't be allowed with the mutable collection types because it would allow for failures at runtime: you might add a `Circle` into the `List<Shape>`, creating a `List<Rectangle>` with a `Circle` in it somewhere else in the program.
 
@@ -83,6 +83,8 @@ val item = rwList.firstOrNull()
 </div>
 
 ... as well as all the utilities you would expect such as sort, zip, fold, reduce and so on.
+
+It's important to note, that the operations on readonly collections which return a modified collection (like `+`, `filter`, `drop`, etc.) do not create their results atomically, therefore the results are not safe to use from a different thread without proper synchronization. 
 
 Maps follow the same pattern. They can be easily instantiated and accessed like this:
 

--- a/pages/docs/reference/collections.md
+++ b/pages/docs/reference/collections.md
@@ -45,7 +45,7 @@ val items = listOf(1, 2, 3)
 
 </div>
 
-Currently, the `listOf` method is implemented using an array list, but in future more memory-efficient fully immutable collection types could be returned that exploit the fact that they know they can't change.
+Currently, the `listOf` method is implemented using an array list, but in future more memory-efficient fully immutable collection types could be returned that exploit the fact that they know they can't change. It's important to note, that the operations on readonly collections which return a modified collection (like `+`, `filter`, `drop`, etc.) do not create their results atomically, therefore the results are not safe to use from a different thread without proper syncronisation. 
 
 Note that the read-only types are [covariant](generics.html#variance). That means, you can take a `List<Rectangle>` and assign it to `List<Shape>` assuming `Rectangle` inherits from `Shape` (the collection types have the same inheritance relationship as the element types). This wouldn't be allowed with the mutable collection types because it would allow for failures at runtime: you might add a `Circle` into the `List<Shape>`, creating a `List<Rectangle>` with a `Circle` in it somewhere else in the program.
 


### PR DESCRIPTION
I think it's important to note this, as a lot of people (like myself) might come from languages where the standard library has persistent collections (like Scala) and operations on them therefore are completely thread-safe. Given the ones in Kotlin look very similar one might immediately assume they can be used the same way while a little more care needed in practice.