### PR TITLE
Remove restriction about inner classes for for inline classes

### DIFF
--- a/pages/docs/reference/inline-classes.md
+++ b/pages/docs/reference/inline-classes.md
@@ -63,7 +63,6 @@ fun main() {
 
 However, there are some restrictions for inline class members:
 * inline classes cannot have *init*{: .keyword } blocks
-* inline classes cannot have *inner*{: .keyword } classes
 * inline class properties cannot have [backing fields](properties.html#backing-fields)
     * it follows that inline classes can only have simple computable properties (no lateinit/delegated properties)
 


### PR DESCRIPTION
This restriction was removed in Kotlin 1.3.20. See related issues: [KT-26506](https://youtrack.jetbrains.com/issue/KT-26506), [KT-27706](https://youtrack.jetbrains.com/issue/KT-27706), [KT-27705](https://youtrack.jetbrains.com/issue/KT-27705)