### PR TITLE
Update Kotlin team and GitHub contributors numbers

### DIFF
--- a/pages/docs/reference/faq.md
+++ b/pages/docs/reference/faq.md
@@ -106,8 +106,8 @@ There are too many companies using Kotlin to list, but some more visible compani
  
 ### Who develops Kotlin?
 
-Kotlin is primarily developed by a team of engineers at JetBrains (current team size is 40+). The lead language designer is 
-[Andrey Breslav](https://twitter.com/abreslav). In addition to the core team, there are also over 100 external contributors on GitHub. 
+Kotlin is primarily developed by a team of engineers at JetBrains (current team size is 50+). The lead language designer is 
+[Andrey Breslav](https://twitter.com/abreslav). In addition to the core team, there are also over 250 external contributors on GitHub. 
 
 ### Where can I learn more about Kotlin?
 


### PR DESCRIPTION
They now match what was announced at KotlinConf 2018.