### PR TITLE
Clarify 'Null Safety' examples

### DIFF
--- a/pages/docs/reference/null-safety.md
+++ b/pages/docs/reference/null-safety.md
@@ -88,7 +88,7 @@ More complex conditions are supported as well:
 ```kotlin
 fun main() {
 //sampleStart
-    val b = "Kotlin"
+    val b: String? = "Kotlin"
     if (b != null && b.length > 0) {
         print("String of length ${b.length}")
     } else {
@@ -115,7 +115,7 @@ fun main() {
     val a = "Kotlin"
     val b: String? = null
     println(b?.length)
-    println(a?.length)
+    println(a?.length) // Unnecessary safe call
 //sampleEnd
 }
 ```


### PR DESCRIPTION
- In the 'Checking for null in conditions' example, type of `b` is `String` by default. So `b != null` is always `true`. So, it will be better to specify the variable's type to `String?`:
- In the 'Safe Calls' example, it will be better to mention that a safe call on non-null receiver of type `String` is unnecessary.