### PR TITLE
Avoid sum overflow calculation.

### DIFF
--- a/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
+++ b/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
@@ -249,7 +249,7 @@ All these have already started, all we need is collect the results:
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-val sum = deferred.sumBy { it.await() }
+val sum = deferred.map { it.await() }.sum()
 ```
 
 </div>
@@ -264,14 +264,14 @@ We simply take every coroutine and await its result here, then all results are a
 
 ```kotlin
 runBlocking {
-    val sum = deferred.sumBy { it.await() }
+    val sum = deferred.map { it.await() }.sum()
     println("Sum: $sum")
 }
 ```
 
 </div>
 
-Now it prints something sensible: `1784293664`, because all coroutines complete.
+Now it prints something sensible: `500000500000`, because all coroutines complete.
 
 Let's also make sure that our coroutines actually run in parallel. If we add a 1-second `delay()` to each of the `async`'s, the resulting program won't run for 1'000'000 seconds (over 11,5 days):
 


### PR DESCRIPTION
The current code does not return the correct answer when using coroutines.
The sumBy function returns an `Int`, however the answer does not fit in an Int resulting in a wrong value.
answer: 500000500000
current: 1784293664

https://www.wolframalpha.com/input/?i=sum+1..1000000