### PR TITLE
Added the space after the object keyword

### DIFF
--- a/pages/docs/reference/nested-classes.md
+++ b/pages/docs/reference/nested-classes.md
@@ -52,7 +52,7 @@ Anonymous inner class instances are created using an [object expression](object-
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-window.addMouseListener(object: MouseAdapter() {
+window.addMouseListener(object : MouseAdapter() {
 
     override fun mouseClicked(e: MouseEvent) { ... }
 


### PR DESCRIPTION
In according to [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#colon)
> put a space before a colon ... after the object keyword.