### PR TITLE
Removed the space before the colon

### DIFF
--- a/pages/docs/reference/generics.md
+++ b/pages/docs/reference/generics.md
@@ -316,7 +316,7 @@ fun <T> singletonList(item: T): List<T> {
     // ...
 }
 
-fun <T> T.basicToString() : String {  // extension function
+fun <T> T.basicToString(): String {  // extension function
     // ...
 }
 ```


### PR DESCRIPTION
In according to [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#colon) there are no cases where a space before a colon is needed.