### PR TITLE
Added two more sentences about the 'where' clause

### DIFF
--- a/pages/docs/reference/generics.md
+++ b/pages/docs/reference/generics.md
@@ -385,6 +385,8 @@ fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
 
 </div>
 
+A where clause creates an intersection type; each sub-clause must be satisfied.  In the above example, the threshold and all list items must implement *both* CharSequence and Comparable.
+
 ## Type erasure
 
 The type safety checks that Kotlin performs for generic declaration usages are only done at compile time.

--- a/pages/docs/reference/generics.md
+++ b/pages/docs/reference/generics.md
@@ -385,7 +385,7 @@ fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
 
 </div>
 
-A where clause creates an intersection type; each sub-clause must be satisfied.  In the above example, the threshold and all list items must implement *both* CharSequence and Comparable.
+The passed type must satisfy all conditions of the `where` clause simultaneously. In the above example, the `T` type must implement *both* `CharSequence` and `Comparable`.
 
 ## Type erasure
 


### PR DESCRIPTION
When I read the documentation, I wrongly assumed that a `where` clause created a union type.  If I had looked really carefully, I probably could have figured out that it was an intersection type.  Given how brief the documentation was for this feature, I thought a little clarification would be beneficial.