### PR TITLE
Update object-declarations.md to reflect relaxed restriction on final keyword since Java 8

### DIFF
--- a/pages/docs/reference/object-declarations.md
+++ b/pages/docs/reference/object-declarations.md
@@ -83,7 +83,7 @@ class C {
 </div>
 
 Just like Java's anonymous inner classes, code in object expressions can access variables from the enclosing scope.
-(Unlike Java, this is not restricted to final variables.)
+(Unlike Java, this is not restricted to final or effectively final variables.)
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ```kotlin


### PR DESCRIPTION
Since Java 8,  'final' keyword is not mandatory for variables accessed from anonymous inner classes when variables are effectively final.