### PR TITLE
remove "disable bitcode" instructions from Kotlin/Native iOS+Android tutorial

### DIFF
--- a/pages/docs/tutorials/native/mpp-ios-android.md
+++ b/pages/docs/tutorials/native/mpp-ios-android.md
@@ -372,12 +372,6 @@ SharedCode/build/xcode-frameworks/SharedCode.framework
 We will then see something similar to this: 
 ![Xcode General Screen]({{ url_for('tutorial_img', filename='native/mpp-ios-android/xcode-general.png') }})
 
-We need to disable the *Bitcode* feature in the project too. Kotlin/Native produces the fully native
-binaries, not the LLVM bitcode, so we need to navigate to the *Build Settings* tab, pick the *All* sub-tab below, and type `bitcode` into
-the search field. Select `No` for the *Enable Bitcode* option.
-
-![Xcode Build Settings]({{ url_for('tutorial_img', filename='native/mpp-ios-android/xcode-bitcode.png') }})
-
 Now we need to explain to Xcode, where to look for frameworks. We need to add the *relative* path 
 `$(SRCROOT)/../../SharedCode/build/xcode-frameworks` into the *Search Paths | Framework Search Paths* section.
 Open the *Build Settings* tab again, pick the *All* sub-tab below, and type the *Framework Search Paths* into


### PR DESCRIPTION
The purpose of this PR is twofold:

1. Find out for myself whether Kotlin/Native supports LLVM bitcode output for Apple store submission.

2.
    a. If bitcode is supported, remove this scary instruction that suggests bitcode is not supported, rendering Kotlin/Native very very risky to ever use in an iOS project. Apple may one day require bitcode for iOS apps (they already do for tvOS and watchOS apps).

    b. Perhaps this instruction can be augmented or replaced with https://github.com/JetBrains/kotlin-native/blob/master/FAQ.md#q-how-do-i-enable-bitcode-for-my-kotlin-framework, if there is a problem with removing this section outright.