### PR TITLE
Remove footnote about tailrec functions in JVM backend

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -427,4 +427,4 @@ private fun findFixPoint(): Double {
 ```
 </div>
 
-To be eligible for the `tailrec` modifier, a function must call itself as the last operation it performs. You cannot use tail recursion when there is more code after the recursive call, and you cannot use it within try/catch/finally blocks. Currently tail recursion is only supported in the JVM backend.
+To be eligible for the `tailrec` modifier, a function must call itself as the last operation it performs. You cannot use tail recursion when there is more code after the recursive call, and you cannot use it within try/catch/finally blocks.


### PR DESCRIPTION
The footnote claims that tailrec functions are only available in the JVM backend, but this is no longer the case.