### PR TITLE
docs: jvmdefault annotation

### DIFF
--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -408,6 +408,37 @@ Depending on the case of adding the annotation, specify one of the argument valu
 
 For more details about compatibility issues, see the `@JvmDefault` [reference page](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/index.html).
 
+Note that if an interface with `@JvmDefault` methods is used as a [delegate](/docs/reference/delegation.html),
+the default method implementations are called even if the actual delegate type provides its own implementations.
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```kotlin
+interface Producer {
+    @JvmDefault fun produce() {
+        println("interface method")
+    }
+}
+
+class ProducerImpl: Producer {
+    override fun produce() {
+        println("class method")
+    }
+}
+
+class DelegatedProducer(val p: Producer): Producer by p {
+}
+
+fun main() {
+    val prod = ProducerImpl()
+    DelegatedProducer(prod).produce() // prints "interface method"
+}
+```
+</div>
+
+For more details about interface delegation in Kotlin, see [Delegation](/docs/reference/delegation.html).
+
+
 ## Visibility
 
 The Kotlin visibilities are mapped to Java in the following way:

--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -404,7 +404,7 @@ Depending on the case of adding the annotation, specify one of the argument valu
    This includes adding the entire interface for your API.
 * `-Xjvm-default=compatibility` should be used if you are adding a `@JvmDefault` to the methods that were available in the API before.
    This mode helps avoid compatibility breaks: all the interface implementations written for the previous versions will be fully compatible with the new version.
-   However, the compatibility mode may add some overhead to the resulting bytecode size and Kaffect the performance.
+   However, the compatibility mode may add some overhead to the resulting bytecode size and affect the performance.
 
 For more details about compatibility issues, see the `@JvmDefault` [reference page](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/index.html).
 

--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -9,7 +9,7 @@ title: "Calling Kotlin from Java"
 
 Kotlin code can be easily called from Java.
 For example, instances of a Kotlin class can be seamlessly created and operated in Java methods.
-However, there are certain differences between Java and Kotlin that may require some attention when
+However, there are certain differences between Java and Kotlin that require attention when
 integrating Kotlin code into Java. 
 On this page, we'll describe the ways to tailor the interop of your Kotlin code with its Java clients.
 
@@ -310,7 +310,7 @@ Obj.INSTANCE.callStatic(); // works too
 
 Starting from Kotlin 1.3, `@JvmStatic` applies to functions defined in companion objects of interfaces as well.
 Such functions compile to static methods in interfaces. Note that static method in interfaces were introduced in Java 1.8,
-so use the corresponding targets.  
+so be sure to use the corresponding targets.  
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
@@ -404,7 +404,7 @@ Depending on the case of adding the annotation, specify one of the argument valu
    This includes adding the entire interface for your API.
 * `-Xjvm-default=compatibility` should be used if you are adding a `@JvmDefault` to the methods that were available in the API before.
    This mode helps avoid compatibility breaks: all the interface implementations written for the previous versions will be fully compatible with the new version.
-   However, the compatibility mode may add some overhead to the resulting bytecode size and could affect the performance.
+   However, the compatibility mode may add some overhead to the resulting bytecode size and Kaffect the performance.
 
 For more details about compatibility issues, see the `@JvmDefault` [reference page](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/index.html).
 

--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -7,7 +7,12 @@ title: "Calling Kotlin from Java"
 
 # Calling Kotlin from Java
 
-Kotlin code can be called from Java easily.
+Kotlin code can be easily called from Java.
+For example, instances of a Kotlin class can be seamlessly created and operated in Java methods.
+However, there are certain differences between Java and Kotlin that may require some attention when
+integrating Kotlin code into Java. 
+On this page, we'll describe the ways to tailor the interop of your Kotlin code with its Java clients.
+
 
 ## Properties
 
@@ -20,6 +25,7 @@ A Kotlin property is compiled to the following Java elements:
 For example, `var firstName: String` gets compiled to the following Java declarations:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 private String firstName;
 
@@ -38,110 +44,120 @@ the same as the property name, and the name of the setter will be obtained by re
 For example, for a property `isOpen`, the getter will be called `isOpen()` and the setter will be called `setOpen()`.
 This rule applies for properties of any type, not just `Boolean`.
 
-## Package-Level Functions
+## Package-level functions
 
-All the functions and properties declared in a file `example.kt` inside a package `org.foo.bar`, including extension functions,
-are compiled into static methods of a Java class named `org.foo.bar.ExampleKt`.
+All the functions and properties declared in a file `app.kt` inside a package `org.example`, including extension functions,
+are compiled into static methods of a Java class named `org.example.AppKt`.
+
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
-// example.kt
-package demo
+// app.kt
+package org.example
 
-class Foo
+class Util
 
-fun bar() { ... }
+fun getTime() { /*...*/ }
 
 ```
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Java
-new demo.Foo();
-demo.ExampleKt.bar();
+new org.example.Util();
+org.example.AppKt.getTime();
 ```
 </div>
 
 The name of the generated Java class can be changed using the `@JvmName` annotation:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 @file:JvmName("DemoUtils")
 
-package demo
+package org.example
 
-class Foo
+class Util
 
-fun bar() { ... }
+fun getTime() { /*...*/ }
 
 ```
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Java
-new demo.Foo();
-demo.DemoUtils.bar();
+new org.example.Util();
+org.example.DemoUtils.getTime();
 ```
 </div>
 
 Having multiple files which have the same generated Java class name (the same package and the same name or the same
-@JvmName annotation) is normally an error. However, the compiler has the ability to generate a single Java facade
-class which has the specified name and contains all the declarations from all the files which have that name.
-To enable the generation of such a facade, use the @JvmMultifileClass annotation in all of the files.
+[`@JvmName`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-name/index.html) annotation) is normally an error.
+However, the compiler has the ability to generate a single Java facade class which has the specified name and contains all the declarations from all the files which have that name.
+To enable the generation of such a facade, use the [`@JvmMultifileClass`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-multifile-class/index.html) annotation in all of the files.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // oldutils.kt
 @file:JvmName("Utils")
 @file:JvmMultifileClass
 
-package demo
+package org.example
 
-fun foo() { ... }
+fun getTime() { /*...*/ }
 ```
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // newutils.kt
 @file:JvmName("Utils")
 @file:JvmMultifileClass
 
-package demo
+package org.example
 
-fun bar() { ... }
+fun getDate() { /*...*/ }
 ```
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Java
-demo.Utils.foo();
-demo.Utils.bar();
+org.example.Utils.getTime();
+org.example.Utils.getDate();
 ```
 </div>
 
-## Instance Fields
+## Instance fields
 
-If you need to expose a Kotlin property as a field in Java, you need to annotate it with the `@JvmField` annotation.
+If you need to expose a Kotlin property as a field in Java, annotate it with the [`@JvmField`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-field/index.html) annotation.
 The field will have the same visibility as the underlying property. You can annotate a property with `@JvmField`
 if it has a backing field, is not private, does not have `open`, `override` or `const` modifiers, and is not a delegated property.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
-class C(id: String) {
+class User(id: String) {
     @JvmField val ID = id
 }
 ```
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Java
 class JavaClient {
-    public String getID(C c) {
-        return c.ID;
+    public String getID(User user) {
+        return user.ID;
     }
 }
 ```
@@ -150,20 +166,21 @@ class JavaClient {
 [Late-Initialized](properties.html#late-initialized-properties-and-variables) properties are also exposed as fields. 
 The visibility of the field will be the same as the visibility of `lateinit` property setter.
 
-## Static Fields
+## Static fields
 
 Kotlin properties declared in a named object or a companion object will have static backing fields
 either in that named object or in the class containing the companion object.
 
 Usually these fields are private but they can be exposed in one of the following ways:
 
- - `@JvmField` annotation;
+ - [`@JvmField`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-field/index.html) annotation;
  - `lateinit` modifier;
  - `const` modifier.
  
 Annotating such a property with `@JvmField` makes it a static field with the same visibility as the property itself.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 class Key(val value: Int) {
     companion object {
@@ -175,6 +192,7 @@ class Key(val value: Int) {
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Java
 Key.COMPARATOR.compare(key1, key2);
@@ -186,6 +204,7 @@ A [late-initialized](properties.html#late-initialized-properties-and-variables) 
 has a static backing field with the same visibility as the property setter.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 object Singleton {
     lateinit var provider: Provider
@@ -194,6 +213,7 @@ object Singleton {
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Java
 Singleton.provider = new Provider();
@@ -201,9 +221,10 @@ Singleton.provider = new Provider();
 ```
 </div>
 
-Properties annotated with `const` (in classes as well as at the top level) are turned into static fields in Java:
+Properties declared as `const` (in classes as well as at the top level) are turned into static fields in Java:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // file example.kt
 
@@ -224,49 +245,53 @@ const val MAX = 239
 In Java:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
-int c = Obj.CONST;
-int d = ExampleKt.MAX;
-int v = C.VERSION;
+int const = Obj.CONST;
+int max = ExampleKt.MAX;
+int version = C.VERSION;
 ```
 </div>
 
-## Static Methods
+## Static methods
 
 As mentioned above, Kotlin represents package-level functions as static methods.
-Kotlin can also generate static methods for functions defined in named objects or companion objects if you annotate those functions as `@JvmStatic`.
+Kotlin can also generate static methods for functions defined in named objects or companion objects if you annotate those functions as [`@JvmStatic`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-static/index.html).
 If you use this annotation, the compiler will generate both a static method in the enclosing class of the object and an instance method in the object itself.
 For example:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 class C {
     companion object {
-        @JvmStatic fun foo() {}
-        fun bar() {}
+        @JvmStatic fun callStatic() {}
+        fun callNonStatic() {}
     }
 }
 ```
 </div>
 
-Now, `foo()` is static in Java, while `bar()` is not:
+Now, `callStatic()` is static in Java, while `callNonStatic()` is not:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
-C.foo(); // works fine
-C.bar(); // error: not a static method
-C.Companion.foo(); // instance method remains
-C.Companion.bar(); // the only way it works
+C.callStatic(); // works fine
+C.callNonStatic(); // error: not a static method
+C.Companion.callStatic(); // instance method remains
+C.Companion.callNonStatic(); // the only way it works
 ```
 </div>
 
 Same for named objects:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 object Obj {
-    @JvmStatic fun foo() {}
-    fun bar() {}
+    @JvmStatic fun callStatic() {}
+    fun callNonStatic() {}
 }
 ```
 </div>
@@ -274,16 +299,114 @@ object Obj {
 In Java:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
-Obj.foo(); // works fine
-Obj.bar(); // error
-Obj.INSTANCE.bar(); // works, a call through the singleton instance
-Obj.INSTANCE.foo(); // works too
+Obj.callStatic(); // works fine
+Obj.callNonStatic(); // error
+Obj.INSTANCE.callNonStatic(); // works, a call through the singleton instance
+Obj.INSTANCE.callStatic(); // works too
+```
+</div>
+
+Starting from Kotlin 1.3, `@JvmStatic` applies to functions defined in companion objects of interfaces as well.
+Such functions compile to static methods in interfaces. Note that static method in interfaces were introduced in Java 1.8,
+so use the corresponding targets.  
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```kotlin
+interface ChatBot {
+    companion object {
+        @JvmStatic fun greet(username: String) {
+            println("Hello, $username")
+        }
+    }
+}
 ```
 </div>
 
 `@JvmStatic` annotation can also be applied on a property of an object or a companion object
-making its getter and setter methods be static members in that object or the class containing the companion object.
+making its getter and setter methods static members in that object or the class containing the companion object.
+
+## Default methods in interfaces
+
+> Default methods are available only for targets JVM 1.8 and above.
+{:.note}
+
+> The `@JvmDefault` annotation is experimental in Kotlin 1.3. Its name and behavior may change, leading to future incompatibility.
+{:.note}
+
+Starting from JDK 1.8, interfaces in Java can contain [default methods](https://docs.oracle.com/javase/tutorial/java/IandI/defaultmethods.html).
+You can declare a non-abstract member of a Kotlin interface as default for the Java classes implementing it.
+To make a member default, mark it with the [`@JvmDefault`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/index.html) annotation.
+Here is an example of a Kotlin interface with a default method:
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```kotlin
+interface Robot {
+    @JvmDefault fun move() { println("~walking~") }
+    fun speak(): Unit
+}
+```
+</div>
+
+The default implementation is available for Java classes implementing the interface.
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```java
+//Java implementation
+public class C3PO implements Robot {
+    // move() implementation from Robot is available implicitly
+    @Override
+    public void speak() {
+        System.out.println("I beg your pardon, sir");
+    }
+}
+```
+</div>
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```java
+C3PO c3po = new C3PO();
+c3po.move(); // default implementation from the Robot interface
+c3po.speak();
+```
+</div>
+
+Implementations of the interface can override default methods.
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```java
+//Java
+public class BB8 implements Robot {
+    //own implementation of the default method
+    @Override
+    public void move() {
+        System.out.println("~rolling~");
+    }
+
+    @Override
+    public void speak() {
+        System.out.println("Beep-beep");
+    }
+}
+```
+</div>
+
+For the `@JvmDefault` annotation to take effect, the interface must be compiled with an `-Xjvm-default` argument.
+Depending on the case of adding the annotation, specify one of the argument values:
+
+* `-Xjvm-default=enabled` should be used if you add only new methods with the `@JvmDefault` annotation.
+   This includes adding the entire interface for your API.
+* `-Xjvm-default=compatibility` should be used if you are adding a `@JvmDefault` to the methods that were available in the API before.
+   This mode helps avoid compatibility breaks: all the interface implementations written for the previous versions will be fully compatible with the new version.
+   However, the compatibility mode may add some overhead to the resulting bytecode size and could affect the performance.
+
+For more details about compatibility issues, see the `@JvmDefault` [reference page](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/index.html).
 
 ## Visibility
 
@@ -305,17 +428,19 @@ There is no automatic conversion from `Class` to `KClass`, so you have to do it 
 the `Class<T>.kotlin` extension property:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 kotlin.jvm.JvmClassMappingKt.getKotlinClass(MainView.class)
 ```
 </div>
 
-## Handling signature clashes with @JvmName
+## Handling signature clashes with `@JvmName`
 
 Sometimes we have a named function in Kotlin, for which we need a different JVM name in the byte code.
 The most prominent example happens due to *type erasure*:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 fun List<String>.filterValid(): List<String>
 fun List<Int>.filterValid(): List<Int>
@@ -323,9 +448,10 @@ fun List<Int>.filterValid(): List<Int>
 </div>
 
 These two functions can not be defined side-by-side, because their JVM signatures are the same: `filterValid(Ljava/util/List;)Ljava/util/List;`.
-If we really want them to have the same name in Kotlin, we can annotate one (or both) of them with `@JvmName` and specify a different name as an argument:
+If we really want them to have the same name in Kotlin, we can annotate one (or both) of them with [`@JvmName`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-name/index.html) and specify a different name as an argument:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 fun List<String>.filterValid(): List<String>
 
@@ -339,6 +465,7 @@ From Kotlin they will be accessible by the same name `filterValid`, but from Jav
 The same trick applies when we need to have a property `x` alongside with a function `getX()`:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only auto-indent="false">
+
 ```kotlin
 val x: Int
     @JvmName("getX_prop")
@@ -351,6 +478,7 @@ fun getX() = 10
 To change the names of generated accessor methods for properties without explicitly implemented getters and setters, you can use `@get:JvmName` and `@set:JvmName`:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 @get:JvmName("x")
 @set:JvmName("changeX")
@@ -358,19 +486,20 @@ var x: Int = 23
 ```
 </div>
 
-## Overloads Generation
+## Overloads generation
 
 Normally, if you write a Kotlin function with default parameter values, it will be visible in Java only as a full
 signature, with all parameters present. If you wish to expose multiple overloads to Java callers, you can use the
-`@JvmOverloads` annotation.
+[`@JvmOverloads`](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-overloads/index.html) annotation.
 
-The annotation also works for constructors, static methods etc. It can't be used on abstract methods, including methods
+The annotation also works for constructors, static methods, and so on. It can't be used on abstract methods, including methods
 defined in interfaces.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
-class Foo @JvmOverloads constructor(x: Int, y: Double = 0.0) {
-    @JvmOverloads fun f(a: String, b: Int = 0, c: String = "abc") { ... }
+class Circle @JvmOverloads constructor(centerX: Int, centerY: Int, radius: Double = 1.0) {
+    @JvmOverloads fun draw(label: String, lineWidth: Int = 1, color: String = "red") { /*...*/ }
 }
 ```
 </div>
@@ -380,15 +509,16 @@ all parameters to the right of it in the parameter list removed. In this example
 generated:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Constructors:
-Foo(int x, double y)
-Foo(int x)
+Circle(int centerX, int centerY, double radius)
+Circle(int centerX, int centerY)
 
 // Methods
-void f(String a, int b, String c) { }
-void f(String a, int b) { }
-void f(String a) { }
+void draw(String label, int lineWidth, String color) { }
+void draw(String label, int lineWidth) { }
+void draw(String label) { }
 ```
 </div>
 
@@ -397,18 +527,20 @@ values for all constructor parameters, a public no-argument constructor will be 
 if the `@JvmOverloads` annotation is not specified.
 
 
-## Checked Exceptions
+## Checked exceptions
 
 As we mentioned above, Kotlin does not have checked exceptions.
 So, normally, the Java signatures of Kotlin functions do not declare exceptions thrown.
 Thus if we have a function in Kotlin like this:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // example.kt
 package demo
 
-fun foo() {
+fun writeToFile() {
+    /*...*/
     throw IOException()
 }
 ```
@@ -417,24 +549,27 @@ fun foo() {
 And we want to call it from Java and catch the exception:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // Java
 try {
-  demo.Example.foo();
+  demo.Example.writeToFile();
 }
-catch (IOException e) { // error: foo() does not declare IOException in the throws list
+catch (IOException e) { // error: writeToFile() does not declare IOException in the throws list
   // ...
 }
 ```
 </div>
 
-we get an error message from the Java compiler, because `foo()` does not declare `IOException`.
-To work around this problem, use the `@Throws` annotation in Kotlin:
+we get an error message from the Java compiler, because `writeToFile()` does not declare `IOException`.
+To work around this problem, use the [`@Throws`](/api/latest/jvm/stdlib/kotlin.jvm/-throws/index.html) annotation in Kotlin:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 @Throws(IOException::class)
-fun foo() {
+fun writeToFile() {
+    /*...*/
     throw IOException()
 }
 ```
@@ -452,6 +587,7 @@ When Kotlin classes make use of [declaration-site variance](generics.html#declar
 options of how their usages are seen from the Java code. Let's say we have the following class and two functions that use it:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 class Box<out T>(val value: T)
 
@@ -466,6 +602,7 @@ fun unboxBase(box: Box<Base>): Base = box.value
 A naive way of translating these functions into Java would be this:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 Box<Derived> boxDerived(Derived value) { ... }
 Base unboxBase(Box<Base> box) { ... }
@@ -477,6 +614,7 @@ The problem is that in Kotlin we can say `unboxBase(boxDerived("s"))`, but in Ja
   To make it work in Java we'd have to define `unboxBase` as follows:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 Base unboxBase(Box<? extends Base> box) { ... }  
 ```
@@ -491,6 +629,7 @@ we don't generate wildcards, because otherwise Java clients will have to deal wi
 Java coding style). Therefore, the functions from our example are actually translated as follows:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ``` java
 // return type - no wildcards
 Box<Derived> boxDerived(Derived value) { ... }
@@ -500,12 +639,13 @@ Base unboxBase(Box<? extends Base> box) { ... }
 ```
 </div>
 
-NOTE: when the argument type is final, there's usually no point in generating the wildcard, so `Box<String>` is always
-  `Box<String>`, no matter what position it takes.
+> When the argument type is final, there's usually no point in generating the wildcard, so `Box<String>` is always `Box<String>`, no matter what position it takes.
+{:.note}
 
 If we need wildcards where they are not generated by default, we can use the `@JvmWildcard` annotation:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 fun boxDerived(value: Derived): Box<@JvmWildcard Derived> = Box(value)
 // is translated to 
@@ -516,6 +656,7 @@ fun boxDerived(value: Derived): Box<@JvmWildcard Derived> = Box(value)
 On the other hand, if we don't need wildcards where they are generated, we can use `@JvmSuppressWildcards`:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 fun unboxBase(box: Box<@JvmSuppressWildcards Base>): Base = box.value
 // is translated to 
@@ -523,16 +664,17 @@ fun unboxBase(box: Box<@JvmSuppressWildcards Base>): Base = box.value
 ```
 </div>
 
-NOTE: `@JvmSuppressWildcards` can be used not only on individual type arguments, but on entire declarations, such as 
-functions or classes, causing all wildcards inside them to be suppressed.
+>`@JvmSuppressWildcards` can be used not only on individual type arguments, but on entire declarations, such as functions or classes, causing all wildcards inside them to be suppressed.
+{:.note}
 
-### Translation of type Nothing
+### Translation of type `Nothing`
  
 The type [`Nothing`](exceptions.html#the-nothing-type) is special, because it has no natural counterpart in Java. Indeed, every Java reference type, including
 `java.lang.Void`, accepts `null` as a value, and `Nothing` doesn't accept even that. So, this type cannot be accurately
 represented in the Java world. This is why Kotlin generates a raw type where an argument of type `Nothing` is used:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 fun emptyList(): List<Nothing> = listOf()
 // is translated to


### PR DESCRIPTION
Added doc on using `@JvmDefault` annotation.
Added the page intro.
Replaced the meaningless examples.

Staging build: https://branch-doc-jvmdefault.kotlin-web-site.labs.jb.gg/docs/reference/java-to-kotlin-interop.html#default-methods-in-interfaces