### PR TITLE
 Document limitations on data classes size

### DIFF
--- a/pages/docs/reference/data-classes.md
+++ b/pages/docs/reference/data-classes.md
@@ -58,7 +58,7 @@ data class User(val name: String = "", val age: Int = 0)
 
 </div>
 
-> Due to the way data class are compiled and restrictions hard-coded in the JVM, data classes are restricted to a maximum of 127 propreties (inclusively). Otherwise, the number of arguments in the `copy()` function will go beyond the maximum number or arguments for a JVM function (255). Needless to say having a data class this big, is discouraged anyway.
+> Due to the way data class are compiled and restrictions hard-coded in the JVM, data classes are restricted to a maximum of 254 propreties (inclusively). Otherwise, the number of arguments in the `copy()` function will go beyond the maximum number or arguments for a JVM function (255). Needless to say having a data class this big, is discouraged anyway. Moreover, keep in mind that double and long properties count double for this purpose.
 
 ## Properties Declared in the Class Body
 

--- a/pages/docs/reference/data-classes.md
+++ b/pages/docs/reference/data-classes.md
@@ -58,6 +58,8 @@ data class User(val name: String = "", val age: Int = 0)
 
 </div>
 
+> Due to the way data class are compiled and restrictions hard-coded in the JVM, data classes are restricted to a maximum of 127 propreties (inclusively). Otherwise, the number of arguments in the `copy()` function will go beyond the maximum number or arguments for a JVM function (255). Needless to say having a data class this big, is discouraged anyway.
+
 ## Properties Declared in the Class Body
 
 Note that the compiler only uses the properties defined inside the primary constructor for the automatically generated functions. To exclude a property from the generated implementations, declare it inside the class body:


### PR DESCRIPTION
I've just found this the hard way. In my case, the data-class is automatically generated from an API description and has 166 double properties.

On a side-note:
I think compilers and IDEs should also make sure they do not allow method/functions beyond the maximum arity and give a compilation error if that's the case.
Keeping in mind that long and double properties count as two arguments.

These restrictions are hardcoded in the JDK (https://zgrepcode.com/java/oracle/jdk-8u181/java/lang/invoke/methodtype.java#L-131), is specified in the JVM Spec https://cr.openjdk.java.net/~iris/se/11/latestSpec/java-se-11-jvms-draft-diffs.pdf => page 352), and Classfile Spec (https://download.oracle.com/otn-pub/jcp/jvm-se7-mr3-approved-oth-JSpec/jvm-javase7-mr3-spec.pdf?AuthParam=1559313255_8b5d89c3bc9ff99e287b98eda3f6e8a5 => page 88).