### PR TITLE
Remove duplicate TornadoFX link

### DIFF
--- a/data/oss-projects.yml
+++ b/data/oss-projects.yml
@@ -203,11 +203,6 @@
   type: Library
   link: https://github.com/hotchemi/khronos
 
-- name: TornadoFX
-  description: Lightweight JavaFX Framework for Kotlin
-  type: Library
-  link: https://github.com/edvin/tornadofx
-
 - name: Hexagon
   description: A microservices framework in Kotlin
   type: Framework


### PR DESCRIPTION
TornadoFX is already referenced at the bottom of the page. I removed this section instead of that one because this incorrectly labels it as a library.