### PR TITLE
Using dukat instead of ts2kt in examples for converting typescript de…

### DIFF
--- a/pages/docs/reference/js-overview.md
+++ b/pages/docs/reference/js-overview.md
@@ -34,7 +34,7 @@ You may want to compile Kotlin to JavaScript in the following scenarios:
 
 Kotlin can be used together with existing third-party libraries and frameworks, such as jQuery or React. To access third-party frameworks
 with a strongly-typed API, you can convert TypeScript definitions from the [Definitely Typed](http://definitelytyped.org/)
-type definitions repository to Kotlin using the [ts2kt](https://github.com/kotlin/ts2kt) tool. Alternatively, you can use
+type definitions repository to Kotlin using the [dukat](https://github.com/kotlin/dukat) tool. Alternatively, you can use
 the [dynamic type](dynamic-type.html) to access any framework without strong typing.
 
 JetBrains develops and maintains several tools specifically for the React community: [React bindings](https://github.com/JetBrains/kotlin-wrappers) as well as [Create React Kotlin App](https://github.com/JetBrains/create-react-kotlin-app). The latter helps you start building React apps with Kotlin with no build configuration.

--- a/pages/docs/tutorials/javascript/working-with-javascript.md
+++ b/pages/docs/tutorials/javascript/working-with-javascript.md
@@ -104,7 +104,7 @@ The standard library provides us with a series of wrappers around DOM as well as
 when we want to use a library such as jQuery? Kotlin does not have its own "header" files for all the different libraries available on the JavaScript ecosystem
 however, TypeScript does. The [Definitely Typed repository](https://github.com/DefinitelyTyped/DefinitelyTyped/)  provides us with a very large selection of header files. 
 
-Using the tool `dukat` (TypeScript to Kotlin) we can convert any `d.ts` files to Kotlin. To install the tool we can use `npm`
+Using the `dukat` tool we can convert any TypeScript declaration files to Kotlin. To install the tool we can use `npm`
 
 ```bash
 npm -g install dukat

--- a/pages/docs/tutorials/javascript/working-with-javascript.md
+++ b/pages/docs/tutorials/javascript/working-with-javascript.md
@@ -13,7 +13,7 @@ In this tutorial we'll see how to
 
 * [Interact with the DOM](#interacting-with-the-dom)
 * [Use kotlinx.html to generate HTML](#using-kotlinxhtml)
-* [Use ts2kt to interact with libraries](#using-ts2kt-to-generate-header-files-for-kotlin)
+* [Use dukat to interact with libraries](#using-dukat-to-generate-header-files-for-kotlin)
 * [Use dynamic to interact with libraries](#using-dynamic)
 
 
@@ -98,23 +98,23 @@ fun printHello() {
 ```
 </div>
 
-## Using ts2kt to generate header files for Kotlin
+## Using dukat to generate header files for Kotlin
 
 The standard library provides us with a series of wrappers around DOM as well as functions to work with JavaScript, using static typing. What happens however
 when we want to use a library such as jQuery? Kotlin does not have its own "header" files for all the different libraries available on the JavaScript ecosystem
 however, TypeScript does. The [Definitely Typed repository](https://github.com/DefinitelyTyped/DefinitelyTyped/)  provides us with a very large selection of header files. 
 
-Using the tool `ts2kt` (TypeScript to Kotlin) we can convert any `d.ts` files to Kotlin. To install the tool we can use `npm`
+Using the tool `dukat` (TypeScript to Kotlin) we can convert any `d.ts` files to Kotlin. To install the tool we can use `npm`
 
 ```bash
-npm -g install ts2kt
+npm -g install dukat
 ```
 
 To convert a file we simply provide the input file, and optionally an output directory. The command below will convert the file `jquery.d.ts` in the current folder, which we've previously
  downloaded from the [Definitely Typed repository](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/types/jquery/jquery.d.ts) to the output folder `headers`:
 
 ```bash
-ts2kt -d headers jquery.d.ts 
+dukat -d headers jquery.d.ts 
 ```
 
 Once we have the file generated, we can simply include it in our project and use it:


### PR DESCRIPTION
Today we've released dukat version good enough to substitute ts2kt and we'll introduce further improvements only to dukat. That said, docs should be updated.  