### PR TITLE
adding a tip for those using `implementation`

### DIFF
--- a/pages/docs/tutorials/javascript/getting-started-gradle/getting-started-with-gradle.md
+++ b/pages/docs/tutorials/javascript/getting-started-gradle/getting-started-with-gradle.md
@@ -79,6 +79,8 @@ assemble.dependsOn assembleWeb
 
 This task copies both dependencies runtime files and the compilation output to the `web` directory.
 
+if you using `implementation` instead of `compile` in the `dependencies` section, you should probably use `configurations.runtimeClasspath.each` instead of `configurations.compile.each`.
+
 For more information on the output generated and the instructions for running the application, please see [Kotlin to JavaScript](../kotlin-to-javascript/kotlin-to-javascript.html)
 
 ## Configuring Compiler Options


### PR DESCRIPTION
if you use `implementation` in `dependencies` section the code above will not generate any `.js` file from `.jar` files, so we can just modify our task so it will consider them for the task job