### PR TITLE
fix: added info about stateless lambdas optimization (KT-32067)

### DIFF
--- a/pages/docs/reference/lambdas.md
+++ b/pages/docs/reference/lambdas.md
@@ -431,7 +431,7 @@ print(sum)
 </div>
 
 For lambdas that don't capture any variables (also know as _stateless_ lambdas), there is a built-in optimization:
-the compiler creates such lambdas as singleton classes. All references to them use the same instance of this class. 
+the compiler creates only one instance for each such lambda. So, all references to a stateless lambda use the same instance. 
 
 ### Function literals with receiver
 

--- a/pages/docs/reference/lambdas.md
+++ b/pages/docs/reference/lambdas.md
@@ -430,6 +430,9 @@ print(sum)
 
 </div>
 
+For lambdas that don't capture any variables (also know as _stateless_ lambdas), there is a built-in optimization:
+the compiler creates such lambdas as singleton classes. All references to them use the same instance of this class. 
+
 ### Function literals with receiver
 
 [Function types](#function-types) with receiver, such as `A.(B) -> C`, can be instantiated with a special form of function literals – 

--- a/pages/docs/reference/lambdas.md
+++ b/pages/docs/reference/lambdas.md
@@ -431,7 +431,19 @@ print(sum)
 </div>
 
 For lambdas that don't capture any variables (also know as _stateless_ lambdas), there is a built-in optimization:
-the compiler creates only one instance for each such lambda. So, all references to a stateless lambda use the same instance. 
+the compiler creates only one instance for each such lambda. So, all instances of a stateless lambda point to the same instance.
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+ 
+ ```kotlin
+ val lambdaProvider = {
+    { Unit }  // returns a stateless lambda
+}
+val lambda1 = lambdaProvider.invoke()
+val lambda2 = lambdaProvider.invoke() // the same exact instance as `lambda1`
+ ```
+ 
+ </div>
 
 ### Function literals with receiver
 


### PR DESCRIPTION
Added a note about creating stateless lambdas as singletons per requests from YT and Discourse:
https://youtrack.jetbrains.com/issue/KT-32067
https://discuss.kotlinlang.org/t/lambdas-and-implicit-references-to-the-instance-of-the-enclosing-class/