### PR TITLE
Remove java.lang.Deprecated from mapped types

### DIFF
--- a/pages/docs/reference/java-interop.md
+++ b/pages/docs/reference/java-interop.md
@@ -403,7 +403,6 @@ Some non-primitive built-in classes are also mapped:
 | `java.lang.Comparable`   | `kotlin.Comparable!`    |
 | `java.lang.Enum`         | `kotlin.Enum!`    |
 | `java.lang.Annotation`   | `kotlin.Annotation!`    |
-| `java.lang.Deprecated`   | `kotlin.Deprecated!`    |
 | `java.lang.CharSequence` | `kotlin.CharSequence!`   |
 | `java.lang.String`       | `kotlin.String!`   |
 | `java.lang.Number`       | `kotlin.Number!`     |


### PR DESCRIPTION
It is not mapped same way as say `kotlin.CharSequence`, because `kotlin.Deprecated` is a separate real annotation class.