### PR TITLE
Typo

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -357,7 +357,7 @@ interface Foo {
     val count: Int
 }
 
-class Bar1(override val count: Int) : Foo
+class Bar1(override var count: Int) : Foo
 
 class Bar2 : Foo {
     override var count: Int = 0


### PR DESCRIPTION
This example with 'val' does not make any sense for me.