### PR TITLE
Update coroutines-basic-jvm.md

### DIFF
--- a/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
+++ b/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
@@ -334,4 +334,4 @@ GlobalScope.async {
 
 </div>
 
-Our `workload()` function can be called from a coroutine (or another suspending function), but _can not_ be called from outside a coroutine. Naturally, `delay()` and `await()` that we used above are themselves declared as `suspend`, and this is why we had to put them inside `runBlocking {}`, `launch {}` or `async {}`.
+Our `workload()` function can be called from a coroutine (or another suspending function), but _cannot_ be called from outside a coroutine. Naturally, `delay()` and `await()` that we used above are themselves declared as `suspend`, and this is why we had to put them inside `runBlocking {}`, `launch {}` or `async {}`.


### PR DESCRIPTION
It is incorrect to use "can not" here. Use "cannot" instead.