### PR TITLE
Moved the lambda function outside the parentheses

### DIFF
--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -392,7 +392,7 @@ val arr = IntArray(5)
 
 // e.g. initialise the values in the array with a constant
 // Array of int of size 5 with values [42, 42, 42, 42, 42]
-val arr = IntArray(5, { 42 })
+val arr = IntArray(5) { 42 }
 
 // e.g. initialise the values in the array using a lambda
 // Array of int of size 5 with values [0, 1, 2, 3, 4] (values initialised to their index value)


### PR DESCRIPTION
Moved the lambda function outside the parentheses for IntArray for the best practice