### PR TITLE
remove AndroidRivers

### DIFF
--- a/data/oss-projects.yml
+++ b/data/oss-projects.yml
@@ -58,11 +58,6 @@
   type: Tools
   link: https://github.com/griffon/griffon-kotlin-plugin
 
-- name: Android Rivers
-  description: RSS Readers for Android
-  type: Android App
-  link: https://github.com/dodyg/AndroidRivers
-
 - name: Stew
   description: A simple Android app for soup.io
   type: Android App


### PR DESCRIPTION
https://github.com/dodyg/AndroidRivers has not been touched in over four years and doesn´t even build with gradle