### PR TITLE
Update reflection.md

### DIFF
--- a/pages/docs/reference/reflection.md
+++ b/pages/docs/reference/reflection.md
@@ -191,7 +191,7 @@ fun main() {
 ```       
 </div>            
 
-A property reference can be used where a function with one parameter is expected:
+A property reference can be used where a function with a single generic parameter is expected:
 
 <div class="sample" markdown="1" theme="idea">
 ```kotlin


### PR DESCRIPTION
Strictly speaking, this phrase is incorrect:"where a function with one parameter is expected".
It doesn't specify the type of that "one parameter". 
For example, a function with one parameter can be such:
**private fun foo(length: Int){}** 
As String:length property is an Int type, but the property reference can't be used in the foo function above.
The property reference only can be used in a function with a single generic parameter, like this:
**private fun < T > foo(length: T){}** 

Note: I don't know why < T > without blank inside can't show correctly here, so that I added two spaces inside the angle brackets.