### PR TITLE
Small change to classes doc

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -456,7 +456,7 @@ class FilledRectangle: Rectangle() {
 
 ### Overriding rules
 
-In Kotlin, implementation inheritance is regulated by the following rule: if a class inherits many implementations of the same member from its immediate superclasses,
+In Kotlin, implementation inheritance is regulated by the following rule: if a class inherits multiple implementations of the same member from its immediate superclasses,
 it must override this member and provide its own implementation (perhaps, using one of the inherited ones).
 To denote the supertype from which the inherited implementation is taken, we use *super*{: .keyword } qualified by the supertype name in angle brackets, e.g. `super<Base>`:
 


### PR DESCRIPTION
"many" is ambiguous and implies that there is a certain number of inherited classes required before the behaviour kicks in. On the other hand, "multiple" simply states that if a class inherits more than one class, then it must disambiguate the construction process.