### PR TITLE
chore: fix wording ("camel humps" and "be able to")

### DIFF
--- a/pages/docs/reference/annotations.md
+++ b/pages/docs/reference/annotations.md
@@ -30,6 +30,7 @@ Additional attributes of the annotation can be specified by annotating the annot
     generated API documentation.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION,
         AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION)
@@ -42,6 +43,7 @@ annotation class Fancy
 ### Usage
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 @Fancy class Foo {
     @Fancy fun baz(@Fancy foo: Int): Int {
@@ -55,6 +57,7 @@ If you need to annotate the primary constructor of a class, you need to add the 
 to the constructor declaration, and add the annotations before it:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 class Foo @Inject constructor(dependency: MyDependency) { ... }
 ```
@@ -63,6 +66,7 @@ class Foo @Inject constructor(dependency: MyDependency) { ... }
 You can also annotate property accessors:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only auto-indent="false">
+
 ```kotlin
 class Foo {
     var x: MyDependency? = null
@@ -76,6 +80,7 @@ class Foo {
 Annotations may have constructors that take parameters.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 annotation class Special(val why: String)
 
@@ -98,6 +103,7 @@ of an annotation attribute.
 If an annotation is used as a parameter of another annotation, its name is not prefixed with the @ character:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 annotation class ReplaceWith(val expression: String)
 
@@ -111,10 +117,11 @@ annotation class Deprecated(
 
 If you need to specify a class as an argument of an annotation, use a Kotlin class
 ([KClass](/api/latest/jvm/stdlib/kotlin.reflect/-k-class/index.html)). The Kotlin compiler will
-automatically convert it to a Java class, so that the Java code will be able to see the annotations and arguments
+automatically convert it to a Java class, so that the Java code can access the annotations and arguments
 normally.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 
 import kotlin.reflect.KClass
@@ -132,6 +139,7 @@ of the lambda is generated. This is useful for frameworks like [Quasar](http://w
 which uses annotations for concurrency control.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 annotation class Suspendable
 
@@ -146,6 +154,7 @@ generated from the corresponding Kotlin element, and therefore multiple possible
 the generated Java bytecode. To specify how exactly the annotation should be generated, use the following syntax:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 class Example(@field:Ann val foo,    // annotate Java field
               @get:Ann val bar,      // annotate Java getter
@@ -157,6 +166,7 @@ The same syntax can be used to annotate the entire file. To do this, put an anno
 the top level of a file, before the package directive or before all imports if the file is in the default package:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 @file:JvmName("Foo")
 
@@ -168,6 +178,7 @@ If you have multiple annotations with the same target, you can avoid repeating t
 target and putting all the annotations inside the brackets:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 class Example {
      @set:[Inject VisibleForTesting]
@@ -191,6 +202,7 @@ The full list of supported use-site targets is:
 To annotate the receiver parameter of an extension function, use the following syntax:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 fun @receiver:Fancy String.myExtension() { ... }
 ```
@@ -203,12 +215,12 @@ being used. If there are multiple applicable targets, the first applicable targe
   * `property`;
   * `field`.
 
-
 ## Java Annotations
 
 Java annotations are 100% compatible with Kotlin:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 import org.junit.Test
 import org.junit.Assert.*
@@ -231,6 +243,7 @@ Since the order of parameters for an annotation written in Java is not defined, 
 call syntax for passing the arguments. Instead, you need to use the named argument syntax:
 
 <div class="sample" markdown="1" mode="java" theme="idea">
+
 ``` java
 // Java
 public @interface Ann {
@@ -241,6 +254,7 @@ public @interface Ann {
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // Kotlin
 @Ann(intValue = 1, stringValue = "abc") class C
@@ -250,6 +264,7 @@ public @interface Ann {
 Just like in Java, a special case is the `value` parameter; its value can be specified without an explicit name:
 
 <div class="sample" markdown="1" theme="idea" mode="java">
+
 ``` java
 // Java
 public @interface AnnWithValue {
@@ -259,6 +274,7 @@ public @interface AnnWithValue {
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // Kotlin
 @AnnWithValue("abc") class C
@@ -270,6 +286,7 @@ public @interface AnnWithValue {
 If the `value` argument in Java has an array type, it becomes a `vararg` parameter in Kotlin:
 
 <div class="sample" markdown="1" theme="idea" mode="java">
+
 ``` java
 // Java
 public @interface AnnWithArrayValue {
@@ -279,6 +296,7 @@ public @interface AnnWithArrayValue {
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // Kotlin
 @AnnWithArrayValue("abc", "foo", "bar") class C
@@ -289,6 +307,7 @@ For other arguments that have an array type, you need to use the array literal s
 `arrayOf(...)`:
 
 <div class="sample" markdown="1" theme="idea" mode="java">
+
 ``` java
 // Java
 public @interface AnnWithArrayMethod {
@@ -298,6 +317,7 @@ public @interface AnnWithArrayMethod {
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // Kotlin 1.2+:
 @AnnWithArrayMethod(names = ["abc", "foo", "bar"]) 
@@ -314,6 +334,7 @@ class D
 Values of an annotation instance are exposed as properties to Kotlin code:
 
 <div class="sample" markdown="1" theme="idea" mode="java">
+
 ``` java
 // Java
 public @interface Ann {
@@ -323,6 +344,7 @@ public @interface Ann {
 </div>
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 // Kotlin
 fun foo(ann: Ann) {

--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -515,4 +515,4 @@ of a class (for example, a factory method), you can write it as a member of an [
 inside that class.
 
 Even more specifically, if you declare a [companion object](object-declarations.html#companion-objects) inside your class,
-you'll be able to call its members using only the class name as a qualifier.
+you can access its members using only the class name as a qualifier.

--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -44,8 +44,8 @@ statement.
 
 If a Kotlin file contains a single class (potentially with related top-level declarations), its name should be the same
 as the name of the class, with the .kt extension appended. If a file contains multiple classes, or only top-level declarations,
-choose a name describing what the file contains, and name the file accordingly. Use camel humps with an uppercase first letter
-(e.g. `ProcessDeclarations.kt`).
+choose a name describing what the file contains, and name the file accordingly.
+Use the [camel case](https://en.wikipedia.org/wiki/Camel_case) with an uppercase first letter (for example, `ProcessDeclarations.kt`).
 
 The name of the file should describe what the code in the file does. Therefore, you should avoid using meaningless
 words such as "Util" in file names.
@@ -71,9 +71,8 @@ Generally, the contents of a class is sorted in the following order:
 - Companion object
 
 Do not sort the method declarations alphabetically or by visibility, and do not separate regular methods
-from extension methods. Instead, put related stuff together, so that someone reading the class from top to bottom would
-be able to follow the logic of what's happening. Choose an order (either higher-level stuff first, or vice versa)
-and stick to it.
+from extension methods. Instead, put related stuff together, so that someone reading the class from top to bottom can 
+follow the logic of what's happening. Choose an order (either higher-level stuff first, or vice versa) and stick to it.
 
 Put nested classes next to the code that uses those classes. If the classes are intended to be used externally and aren't
 referenced inside the class, put them in the end, after the companion object.
@@ -93,29 +92,29 @@ Package and class naming rules in Kotlin are quite simple:
 
 * Names of packages are always lower case and do not use underscores (`org.example.project`). Using multi-word
 names is generally discouraged, but if you do need to use multiple words, you can either simply concatenate them together
-or use camel humps (`org.example.myProject`).
+or use the camel case (`org.example.myProject`).
 
-* Names of classes and objects start with an upper case letter and use camel humps:
+* Names of classes and objects start with an upper case letter and use the camel case:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-open class DeclarationProcessor { ... }
+open class DeclarationProcessor { /*...*/ }
 
-object EmptyDeclarationProcessor : DeclarationProcessor() { ... }
+object EmptyDeclarationProcessor : DeclarationProcessor() { /*...*/ }
 ```
 
 </div>
 
 ### Function names
  
-Names of functions, properties and local variables start with a lower case letter and use camel humps and no underscores:
+Names of functions, properties and local variables start with a lower case letter and use the camel case and no underscores:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-fun processDeclarations() { ... }
-var declarationCount = ...
+fun processDeclarations() { /*...*/ }
+var declarationCount = 1
 ```
 
 </div>
@@ -125,18 +124,17 @@ Exception: factory functions used to create instances of classes can have the sa
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-abstract class Foo { ... }
+abstract class Foo { /*...*/ }
 
-class FooImpl : Foo { ... }
+class FooImpl : Foo { /*...*/ }
 
-fun Foo(): Foo { return FooImpl(...) }
+fun FooImpl(): Foo { return FooImpl() }
 ```
-
 </div>
 
 #### Names for test methods
 
-In tests (and only in tests), it's acceptable to use method names with spaces enclosed in backticks.
+In tests (and **only** in tests), it's acceptable to use method names with spaces enclosed in backticks.
 (Note that such method names are currently not supported by the Android runtime.) Underscores in method names are
 also allowed in test code.
 
@@ -144,9 +142,9 @@ also allowed in test code.
 
 ```kotlin
 class MyTestCase {
-     @Test fun `ensure everything works`() { ... }
+     @Test fun `ensure everything works`() { /*...*/ }
      
-     @Test fun ensureEverythingWorks_onAndroid() { ... }
+     @Test fun ensureEverythingWorks_onAndroid() { /*...*/ }
 }
 ```
 
@@ -166,7 +164,7 @@ val USER_NAME_FIELD = "UserName"
 
 </div>
 
-Names of top-level or object properties which hold objects with behavior or mutable data should use regular camel-hump names:
+Names of top-level or object properties which hold objects with behavior or mutable data should use camel-case names:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
@@ -181,13 +179,13 @@ Names of properties holding references to singleton objects can use the same nam
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-val PersonComparator: Comparator<Person> = ...
+val PersonComparator: Comparator<Person> = /*...*/
 ```
 
 </div>
  
 For enum constants, it's OK to use either uppercase underscore-separated names
-(`enum class Color { RED, GREEN }`) or regular camel-humps names starting with an uppercase letter, depending on the usage.
+(`enum class Color { RED, GREEN }`) or regular camel-case names starting with an uppercase first letter, depending on the usage.
    
 #### Names for backing properties
 
@@ -303,9 +301,9 @@ abstract class Foo<out T : Any> : IFoo {
 }
 
 class FooImpl : Foo() {
-    constructor(x: String) : this(x) { ... }
+    constructor(x: String) : this(x) { /*...*/ }
     
-    val x = object : IFoo { ... } 
+    val x = object : IFoo { /*...*/ } 
 } 
 ```
 
@@ -334,7 +332,7 @@ class Person(
     id: Int,
     name: String,
     surname: String
-) : Human(id, name) { ... }
+) : Human(id, name) { /*...*/ }
 ```
 
 </div>
@@ -349,7 +347,7 @@ class Person(
     name: String,
     surname: String
 ) : Human(id, name),
-    KotlinMaker { ... }
+    KotlinMaker { /*...*/ }
 ```
 
 </div>
@@ -364,7 +362,7 @@ class MyFavouriteVeryLongClassHolder :
     SomeOtherInterface,
     AndAnotherOne {
 
-    fun foo() { ... }
+    fun foo() { /*...*/ }
 }
 ```
 
@@ -381,7 +379,7 @@ class MyFavouriteVeryLongClassHolder :
     SomeOtherInterface,
     AndAnotherOne 
 {
-    fun foo() { ... }
+    fun foo() { /*...*/ }
 }
 ```
 
@@ -461,7 +459,7 @@ A single annotation without arguments may be placed on the same line as the corr
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-@Test fun foo() { ... }
+@Test fun foo() { /*...*/ }
 ```
 
 </div>
@@ -548,7 +546,7 @@ For more complex properties, always put `get` and `set` keywords on separate lin
 
 ```kotlin
 val foo: String
-    get() { ... }
+    get() { /*...*/ }
 ```
 
 </div>
@@ -768,14 +766,14 @@ directly into the documentation comment, and add links to parameters wherever th
  * @param number The number to return the absolute value for.
  * @return The absolute value.
  */
-fun abs(number: Int) = ...
+fun abs(number: Int) { /*...*/ }
 
 // Do this instead:
 
 /**
  * Returns the absolute value of the given [number].
  */
-fun abs(number: Int) = ...
+fun abs(number: Int) { /*...*/ }
 ```
 
 </div>
@@ -855,10 +853,10 @@ Prefer declaring functions with default parameter values to declaring overloaded
 ```kotlin
 // Bad
 fun foo() = foo("a")
-fun foo(a: String) { ... }
+fun foo(a: String) { /*...*/ }
 
 // Good
-fun foo(a: String = "a") { ... }
+fun foo(a: String = "a") { /*...*/ }
 ```
 
 </div>
@@ -946,8 +944,8 @@ Prefer using `if` for binary conditions instead of `when`. Instead of
 
 ```kotlin
 when (x) {
-    null -> ...
-    else -> ...
+    null -> // ...
+    else -> // ...
 }
 ```
 
@@ -976,8 +974,8 @@ Use the `until` function to loop over an open range:
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-for (i in 0..n - 1) { ... }  // bad
-for (i in 0 until n) { ... }  // good
+for (i in 0..n - 1) { /*...*/ }  // bad
+for (i in 0 until n) { /*...*/ }  // good
 ```
 
 </div>

--- a/pages/docs/reference/delegated-properties.md
+++ b/pages/docs/reference/delegated-properties.md
@@ -124,8 +124,9 @@ you can use `LazyThreadSafetyMode.NONE`: it doesn't incur any thread-safety guar
 
 ### Observable
 
-[`Delegates.observable()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-delegates/observable.html) takes two arguments: the initial value and a handler for modifications.
-The handler gets called every time we assign to the property (_after_ the assignment has been performed). It has three
+[`Delegates.observable()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-delegates/observable.html)
+takes two arguments: the initial value and a handler for modifications.
+The handler is called every time we assign to the property (_after_ the assignment has been performed). It has three
 parameters: a property being assigned to, the old value and the new one:
 
 <div class="sample" markdown="1" theme="idea">
@@ -149,7 +150,7 @@ fun main() {
 
 </div>
 
-If you want to intercept an assignment and "veto" it, use [`vetoable()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-delegates/vetoable.html) instead of `observable()`.
+If you want to intercept assignments and "veto" them, use [`vetoable()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-delegates/vetoable.html) instead of `observable()`.
 The handler passed to the `vetoable` is called _before_ the assignment of a new property value has been performed.
 
 ## Storing Properties in a Map

--- a/pages/docs/reference/delegated-properties.md
+++ b/pages/docs/reference/delegated-properties.md
@@ -149,7 +149,7 @@ fun main() {
 
 </div>
 
-If you want to be able to intercept an assignment and "veto" it, use [`vetoable()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-delegates/vetoable.html) instead of `observable()`.
+If you want to intercept an assignment and "veto" it, use [`vetoable()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.properties/-delegates/vetoable.html) instead of `observable()`.
 The handler passed to the `vetoable` is called _before_ the assignment of a new property value has been performed.
 
 ## Storing Properties in a Map

--- a/pages/docs/reference/experimental.md
+++ b/pages/docs/reference/experimental.md
@@ -239,7 +239,9 @@ annotation class ExperimentalDateTime
 
 </div>
 
-If you publish several features in the experimental state, declare a marker for each. Separate markers make the use of experimental features safer for your clients: they'll be able to use only the features that they explicitly accept. This also lets you graduate the features to stable independently.
+If you publish several features in the experimental state, declare a marker for each.
+Separate markers make the use of experimental features safer for your clients: they can use only the features that they explicitly accept.
+This also lets you graduate the features to stable independently.
 
 ### Marking API elements
 

--- a/pages/docs/reference/generics.md
+++ b/pages/docs/reference/generics.md
@@ -75,7 +75,7 @@ interface Collection<E> ... {
 
 </div>
 
-But then, we would not be able to do the following simple thing (which is perfectly safe):
+But then, we can't do the following simple thing (which is perfectly safe):
 
 <div class="sample" markdown="1" mode="java" theme="idea">
 

--- a/pages/docs/reference/nested-classes.md
+++ b/pages/docs/reference/nested-classes.md
@@ -26,7 +26,7 @@ val demo = Outer.Nested().foo() // == 2
 
 ## Inner classes
 
-A class may be marked as *inner*{: .keyword } to be able to access members of outer class. Inner classes carry a reference to an object of an outer class:
+A nested class marked as *inner*{: .keyword } can access the members of its outer class. Inner classes carry a reference to an object of an outer class:
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 

--- a/pages/docs/tutorials/android-plugin.md
+++ b/pages/docs/tutorials/android-plugin.md
@@ -234,7 +234,7 @@ fun MyActivity.a() {
 ### `Parcelable` implementations generator
 
 Android Extensions plugin provides [`Parcelable`](https://developer.android.com/reference/android/os/Parcelable) implementation generator as an experimental feature.
-To be able to use it, [turn on](#enabling-experimental-features) the experimental flag.
+If you want to use it, [turn on](#enabling-experimental-features) the experimental flag.
 
 #### How to use
 


### PR DESCRIPTION
Fix wording according to received feedback 
- _camel case_ instead of _camel humps_
- _can_ instead of _be able to_ where applicable

Fix formatting.