### PR TITLE
'Map nullable value if not null' idiom fix

### DIFF
--- a/pages/docs/reference/idioms.md
+++ b/pages/docs/reference/idioms.md
@@ -217,7 +217,8 @@ value?.let {
 ```kotlin
 val value = ...
 
-val mapped = value?.let { transformValue(it) } ?: defaultValueIfValueOrTransformationResultIsNull
+val mapped = value?.let { transformValue(it) } ?: defaultValue 
+// defaultValue is returned if the value or the transform result is null.
 ```
 </div>
 

--- a/pages/docs/reference/idioms.md
+++ b/pages/docs/reference/idioms.md
@@ -217,7 +217,7 @@ value?.let {
 ```kotlin
 val value = ...
 
-val mapped = value?.let { transformValue(it) } ?: defaultValueIfValueIsNull
+val mapped = value?.let { transformValue(it) } ?: defaultValueIfValueOrTransformationResultIsNull
 ```
 </div>
 


### PR DESCRIPTION
Renamed `defaultValueIfValueIsNull` to formally correct (and terribly long) `defaultValueIfValueOrTransformationResultIsNull`.
Other possible fixes:
* remove idiom as not correct enough
* replace with `it (value != null) transform(value) else defaultValue`
* find a correct idiom (I was unable to do so)