### PR TITLE
Remove broken link to a user group

### DIFF
--- a/pages/user-groups/user-group-list.md
+++ b/pages/user-groups/user-group-list.md
@@ -58,7 +58,6 @@ The most common way to begin one is to find a few like-minded people and to get 
  * [Moscow Kotlin User Group](https://vk.com/kotlinmoscow), Russia
  * [Munich Kotlin User Group](https://www.meetup.com/Kotlin-User-Group-Munich/), Germany
  * [Nizhny Novgorod Kotlin User Group](https://www.meetup.com/kotlin_nn/), Russia
- * [Novosibirsk Kotlin User Group](https://vk.com/kotlin54), Russia
  * [Oslo Kotlin User Group](https://www.meetup.com/meetup-group-nWeRbyMu/), Norway
  * [Paris Kotlin User Group](https://www.meetup.com/Kotlin-Paris-Meetup/), France
  * [Rhein-Main Kotlin](https://www.meetup.com/de-DE/Kotlin-Rhein-Main/), Germany


### PR DESCRIPTION
Novosibirsk Kotlin User Group (https://vk.com/kotlin54) seems to be nonexistent.