### PR TITLE
Added 'constructor generic type parameters' to list of Jva-only constructs

### DIFF
--- a/pages/docs/reference/comparison-to-java.md
+++ b/pages/docs/reference/comparison-to-java.md
@@ -26,6 +26,8 @@ Kotlin fixes a series of issues that Java suffers from:
 * [Non-private fields](properties.html)
 * [Wildcard-types](generics.html)
 * [Ternary-operator `a ? b : c`](control-flow.html#if-expression)
+* [Constructor generic type parameters](generics.html)
+
 
 ## What Kotlin has that Java does not
 


### PR DESCRIPTION
i. e. Kotlin prohibits such hard to read constructs:
```
public class X<T> {
    public <U> X() {}
}
...
new <U>X<T>();
```