### PR TITLE
Remove ambiguity from infix function calls predence examples

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -301,13 +301,13 @@ infix fun Int.shl(x: Int): Int { ... }
 
 > Infix function calls have lower precedence than the arithmetic operators, type casts, and the `rangeTo` operator.
 > The following expressions are equivalent:
-> * `1 shl 2 + 3` and `1 shl (2 + 3)`
-> * `0 until n * 2` and `0 until (n * 2)`
-> * `xs union ys as Set<*>` and `xs union (ys as Set<*>)`
+> * `1 shl 2 + 3` is equivalent to `1 shl (2 + 3)`
+> * `0 until n * 2` is equivalent to `0 until (n * 2)`
+> * `xs union ys as Set<*>` is equivalent to `xs union (ys as Set<*>)`
 >
 > On the other hand, infix function call's precedence is higher than that of the boolean operators `&&` and `||`, `is`- and `in`-checks, and some other operators. These expressions are equivalent as well:
-> * `a && b xor c` and `a && (b xor c)`
-> * `a xor b in c` and `(a xor b) in c`
+> * `a && b xor c` is equivalent to `a && (b xor c)`
+> * `a xor b in c` is equivalent to `(a xor b) in c`
 > 
 > See the [Grammar reference](grammar.html#expressions) for the complete operators precedence hierarchy.
 {:.note}


### PR DESCRIPTION
The examples showing precedence of infix function calls have some ambiguity due to the use of the conjunction `and`, which is also a bitwise operation keyword in Kotlin, to join two equivalent expressions in a sentence. 

The example block is enclosed in indented quoting (>) which drowns the monospace font otherwise differentiating the conjunctive use of the `and` between the expressions. It all appears as though one long expressions and takes you a few minutes to get the gist of what's going on.

see:
![image](https://user-images.githubusercontent.com/9881595/68292248-84bb7f80-009c-11ea-996c-3e41c6da9112.png)
