### PR TITLE
Deleted unused parameter p

### DIFF
--- a/pages/docs/reference/extensions.md
+++ b/pages/docs/reference/extensions.md
@@ -254,7 +254,7 @@ class Host(val hostname: String) {
 class Connection(val host: Host, val port: Int) {
      fun printPort() { print(port) }
 
-     fun Host.printConnectionString(p: Int) {
+     fun Host.printConnectionString() {
          printHostname()   // calls Host.printHostname()
          print(":")
          printPort()   // calls Connection.printPort()
@@ -262,7 +262,7 @@ class Connection(val host: Host, val port: Int) {
 
      fun connect() {
          /*...*/
-         host.printConnectionString(port)   // calls the extension function
+         host.printConnectionString()   // calls the extension function
      }
 }
 


### PR DESCRIPTION
The unused parameter p: Int is confusing. On the first sight the reader might get the impression that p - as the port - is needed, but is actually already set within the constructor.