### PR TITLE
The dependency plugin should be run before the compile phase

### DIFF
--- a/pages/docs/tutorials/javascript/getting-started-maven/getting-started-with-maven.md
+++ b/pages/docs/tutorials/javascript/getting-started-maven/getting-started-with-maven.md
@@ -103,7 +103,7 @@ Maven does not expand the JAR as part of the build process, so we would need to 
     <executions>
         <execution>
             <id>unpack</id>
-            <phase>compile</phase>
+            <phase>process-resources</phase>
             <goals>
                 <goal>unpack</goal>
             </goals>


### PR DESCRIPTION
The dependency plugin should be run before the compile phase
This helps prevent potential plugin ordering issues, and is _more_ correct as the dependency plugin doesn't actually compile anything
it _could_ run in an earlier phase as well