### PR TITLE
Use the `it` convention (from coding conventions)

### DIFF
--- a/pages/docs/reference/idioms.md
+++ b/pages/docs/reference/idioms.md
@@ -39,14 +39,6 @@ fun foo(a: Int = 0, b: String = "") { ... }
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 ```kotlin
-val positives = list.filter { x -> x > 0 }
-```
-</div>
-
-Or alternatively, even shorter:
-
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
-```kotlin
 val positives = list.filter { it > 0 }
 ```
 </div>


### PR DESCRIPTION
Lambda parameters:
In lambdas which are short and not nested, it's recommended to use the `it` convention instead of declaring the parameter explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jetbrains/kotlin-web-site/1522)
<!-- Reviewable:end -->
