### PR TITLE
Clarify constructor and property initializer execution order

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -166,7 +166,7 @@ class Person(val name: String) {
 </div>
 
 Note that code in initializer blocks effectively becomes part of the primary constructor. Delegation to the primary
-constructor happens as the first statement of a secondary constructor, so the code in all initializer blocks is executed
+constructor happens as the first statement of a secondary constructor, so the code in all initializer blocks and property initializers is executed
 before the secondary constructor body. Even if the class has no primary constructor, the delegation still happens
 implicitly, and the initializer blocks are still executed:
 


### PR DESCRIPTION
This is a small change based on the discussion here: https://discuss.kotlinlang.org/t/why-is-by-lazy-not-happy-with-in-construction-property-initialization/15184/8?u=wasabi375

The problem there is 
```kotlin
class A {
    val y: Int
    val z: Int by lazy {
        y // ERROR: variable 'y' must be initialized -- Why?
    }
    val w: Int
        get() = y // No error!

    constructor(x: Int) {
        y = x
    }
}
```
The original author missed that the initializer of `z` ( in this case the lazy delegate) is created before the secondary constructor `y = x` is executed. He suggested the change here.