### PR TITLE
Replace FunKtionale by Arrow and Arrow Meta

### DIFF
--- a/data/oss-projects.yml
+++ b/data/oss-projects.yml
@@ -33,10 +33,15 @@
   type: Library
   link: https://github.com/cheptsov/kotlin-nosql
 
-- name: FunKtionale
-  description: Functional Helpers for Kotlin
+- name: Arrow
+  description: A functional companion to Kotlin's Standard Library
   type: Library
-  link: https://github.com/MarioAriasC/funKTionale
+  link: https://arrow-kt.io
+
+- name: Arrow Meta
+  description: A functional companion to Kotlin's Compiler and IDE
+  type: Library
+  link: http://meta.arrow-kt.io
 
 - name: KotlinPrimavera
   description: Kotlin Wrapper for Spring Framework


### PR DESCRIPTION
Please, this pull request replaces **FunKtionale** by **Arrow** and **Arrow Meta** libraries.

**FunKtionale** and **Kategory** libraries were joined to create **Arrow**.

Thanks in advance!