### PR TITLE
Use fully qualified Android Gradle plugin ID

### DIFF
--- a/pages/docs/reference/using-gradle.md
+++ b/pages/docs/reference/using-gradle.md
@@ -305,7 +305,7 @@ buildscript {
 }
 plugins {
     id("com.android.application")
-    id("kotlin-android")
+    kotlin("android")
 }
 ```
 


### PR DESCRIPTION
According to Gradle documentation [1]:

> To apply a community plugin from the portal, the fully qualified plugin id must be used

> All other binary plugins must use the fully qualified form of the plugin id (e.g. com.github.foo.bar), although some legacy plugins may still utilize a short, unqualified form.

`kotlin()` is used in other code snippets on the page. I don't see a reason not to use it in Android snippet as well.

[1] https://docs.gradle.org/current/userguide/plugins.html