### PR TITLE
new_value must be supertype not subtype.

### DIFF
--- a/pages/docs/reference/delegated-properties.md
+++ b/pages/docs/reference/delegated-properties.md
@@ -257,7 +257,7 @@ For a **mutable** property (a *var*{:.keyword}), a delegate has to _additionally
  
 * `thisRef` --- same as for `getValue()`;
 * `property` --- same as for `getValue()`;
-* `new value` --- must be of the same type as the property or its subtype.
+* `new value` --- must be of the same type as the property or its supertype.
  
 `getValue()` and/or `setValue()` functions may be provided either as member functions of the delegate class or extension functions.
 The latter is handy when you need to delegate property to an object which doesn't originally provide these functions.


### PR DESCRIPTION
Consider following example.

the type of new value in setValue() must be the same type as property or its supertype.
```
open class Parent
open class Child: Parent()

class DelegateA{

    //this function must return the same type as property (or its subtype).
    operator fun getValue(thisRef: Any?, property: KProperty<*>): Child {
        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
    }

    //new value — must be of the same type as the property or its supertype.
    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: Parent) {
        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
    }
}

class Container{

    val valChild:Child by DelegateA()

    val valParent:Parent by DelegateA()

    var varChild:Child by DelegateA()

    var varParent:Parent by DelegateA()

}
```