### PR TITLE
Update basic-types.md to clarify integer division

### DIFF
--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -235,9 +235,7 @@ val l = 1L + 3 // Long + Int => Long
 Kotlin supports the standard set of arithmetical operations over numbers (`+` `-` `*` `/` `%`), which are declared as members of appropriate classes (but the compiler optimizes the calls down to the corresponding instructions).
 See [Operator overloading](operator-overloading.html).
 
-Note that division between integers always returns an integer. Any fractional part is discarded.
-
-For example:
+Note that division between integers always returns an integer. Any fractional part is discarded. For example:
 
 ```kotlin
 val x = 5 / 2

--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -237,27 +237,38 @@ See [Operator overloading](operator-overloading.html).
 
 Note that division between integers always returns an integer. Any fractional part is discarded. For example:
 
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 val x = 5 / 2
-println(x == 2.5) // ERROR: Operator '==' cannot be applied to 'Int' and 'Double'
-
-val y = 5 / 2
-println(y == 2) // true
+// println(x == 2.5) // ERROR: Operator '==' cannot be applied to 'Int' and 'Double'
+println(x == 2)
 ```
+
+</div>
+
 
 This is true of division between any two integer types.
 
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 val x = 5L / 2
-println(x == 2L) // true
+println(x == 2L)
 ```
+
+</div>
 
 To return a floating-point type, explicitly convert one of the arguments to a floating-point type.
 
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
 ```kotlin
 val x = 5 / 2.toDouble()
-println(x == 2.5) // true
+println(x == 2.5)
 ```
+
+</div>
 
 As of bitwise operations, there're no special characters for them, but just named functions that can be called in infix form, for example:
 

--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -252,7 +252,7 @@ val x = 5L / 2
 println(x == 2L) // true
 ```
 
-To return a floating-point type, explicitly convert one of the arguments to a floating point type.
+To return a floating-point type, explicitly convert one of the arguments to a floating-point type.
 
 ```kotlin
 val x = 5 / 2.toDouble()

--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -232,8 +232,33 @@ val l = 1L + 3 // Long + Int => Long
 
 ### Operations
 
-Kotlin supports the standard set of arithmetical operations over numbers (`+` `-` `*` `/` `%`), which are declared as members of appropriate classes (but the compiler optimizes the calls down to the corresponding instructions). Note that calling `/` between an `Int` and an `Int` results in integer division and returns an `Int`, e.g. `5 / 2` returns `2`. For floating-point division between two arguments of type `Int`, convert one of the arguments to a floating-point type, e.g. `5 / 2.toDouble()` returns `2.5` as a `Double`.
+Kotlin supports the standard set of arithmetical operations over numbers (`+` `-` `*` `/` `%`), which are declared as members of appropriate classes (but the compiler optimizes the calls down to the corresponding instructions).
 See [Operator overloading](operator-overloading.html).
+
+Note that division between integers always returns an integer. Any fractional part is discarded.
+For example:
+
+```kotlin
+val x = 5 / 2
+println(x == 2.5) // ERROR: Operator '==' cannot be applied to 'Int' and 'Double'
+
+val y = 5 / 2
+println(y == 2) // true
+```
+
+This is true of division between any two integer types.
+
+```kotlin
+val x = 5L / 2
+println(x == 2L)
+```
+
+To return a floating-point type, explicitly convert one of the arguments to a floating point type.
+
+```kotlin
+val x = 5 / 2.toDouble()
+println(x == 2.5)
+```
 
 As of bitwise operations, there're no special characters for them, but just named functions that can be called in infix form, for example:
 

--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -232,7 +232,7 @@ val l = 1L + 3 // Long + Int => Long
 
 ### Operations
 
-Kotlin supports the standard set of arithmetical operations over numbers, which are declared as members of appropriate classes (but the compiler optimizes the calls down to the corresponding instructions).
+Kotlin supports the standard set of arithmetical operations over numbers (`+` `-` `*` `/` `%`), which are declared as members of appropriate classes (but the compiler optimizes the calls down to the corresponding instructions). Note that calling `/` between an `Int` and an `Int` results in integer division and returns an `Int`, e.g. `5 / 2` returns `2`. For floating-point division between two arguments of type `Int`, convert one of the arguments to a floating-point type, e.g. `5 / 2.toDouble()` returns `2.5` as a `Double`.
 See [Operator overloading](operator-overloading.html).
 
 As of bitwise operations, there're no special characters for them, but just named functions that can be called in infix form, for example:

--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -240,9 +240,11 @@ Note that division between integers always returns an integer. Any fractional pa
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-val x = 5 / 2
-// println(x == 2.5) // ERROR: Operator '==' cannot be applied to 'Int' and 'Double'
-println(x == 2)
+fun main() {
+    val x = 5 / 2
+    // println(x == 2.5) // ERROR: Operator '==' cannot be applied to 'Int' and 'Double'
+    println(x == 2)
+}
 ```
 
 </div>
@@ -253,8 +255,10 @@ This is true of division between any two integer types.
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-val x = 5L / 2
-println(x == 2L)
+fun main() {
+    val x = 5L / 2
+    println(x == 2L)
+}
 ```
 
 </div>
@@ -264,8 +268,10 @@ To return a floating-point type, explicitly convert one of the arguments to a fl
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
-val x = 5 / 2.toDouble()
-println(x == 2.5)
+fun main() {
+    val x = 5 / 2.toDouble()
+    println(x == 2.5)
+}
 ```
 
 </div>

--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -236,6 +236,7 @@ Kotlin supports the standard set of arithmetical operations over numbers (`+` `-
 See [Operator overloading](operator-overloading.html).
 
 Note that division between integers always returns an integer. Any fractional part is discarded.
+
 For example:
 
 ```kotlin
@@ -250,14 +251,14 @@ This is true of division between any two integer types.
 
 ```kotlin
 val x = 5L / 2
-println(x == 2L)
+println(x == 2L) // true
 ```
 
 To return a floating-point type, explicitly convert one of the arguments to a floating point type.
 
 ```kotlin
 val x = 5 / 2.toDouble()
-println(x == 2.5)
+println(x == 2.5) // true
 ```
 
 As of bitwise operations, there're no special characters for them, but just named functions that can be called in infix form, for example:


### PR DESCRIPTION
I have just started to learn Kotlin. While going through the basic-types section of the docs, it wasn't clear to me what the behavior of the division operator was. 

A quick search led me to https://discuss.kotlinlang.org/t/dividing-integers/1662

I understand any implied consistency with Java, but figured that it would be good to be more explicit about it in the docs since people might be coming to Kotlin from a variety of languages or be new to programming in general.