### PR TITLE
Update idioms.md

### DIFF
--- a/pages/docs/reference/idioms.md
+++ b/pages/docs/reference/idioms.md
@@ -102,7 +102,6 @@ for (i in 1..100) { ... }  // closed range: includes 100
 for (i in 1 until 100) { ... } // half-open range: does not include 100
 for (x in 2..10 step 2) { ... }
 for (x in 10 downTo 1) { ... }
-if (x in 1..10) { ... }
 ```
 </div>
 


### PR DESCRIPTION
Range example with 'in' was repeated. Hence removed it.