### PR TITLE
Print the results in order to provide feedback

### DIFF
--- a/pages/docs/reference/scope-functions.md
+++ b/pages/docs/reference/scope-functions.md
@@ -107,6 +107,7 @@ fun main() {
         age = 20                       // same as this.age = 20 or adam.age = 20
         city = "London"
     }
+    println(adam)
 //sampleEnd
 }
 ```
@@ -485,6 +486,7 @@ fun main() {
         age = 32
         city = "London"        
     }
+    println(adam)
 //sampleEnd
 }
 ```


### PR DESCRIPTION
Print the results in order to get more feedback from the samples.

This also fixes "variable 'adam' is never used" noticed messages.