### PR TITLE
Update properties.md

### DIFF
--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -176,7 +176,7 @@ so no function call overhead is introduced in this case.
 
 ## Compile-Time Constants
 
-Property values which are known at compile time can be marked as _compile time constants_ using the *const*{: .keyword } modifier.
+If the value of a read-only property is known at the compile time, mark it as a _compile time constant_ using the *const*{: .keyword } modifier.
 Such properties need to fulfil the following requirements:
 
   * Top-level, or member of an [*object*{: .keyword } declaration](object-declarations.html#object-declarations) or [a *companion object*{: .keyword }](object-declarations.html#companion-objects).

--- a/pages/docs/reference/properties.md
+++ b/pages/docs/reference/properties.md
@@ -176,7 +176,7 @@ so no function call overhead is introduced in this case.
 
 ## Compile-Time Constants
 
-Properties the value of which is known at compile time can be marked as _compile time constants_ using the *const*{: .keyword } modifier.
+Property values which are known at compile time can be marked as _compile time constants_ using the *const*{: .keyword } modifier.
 Such properties need to fulfil the following requirements:
 
   * Top-level, or member of an [*object*{: .keyword } declaration](object-declarations.html#object-declarations) or [a *companion object*{: .keyword }](object-declarations.html#companion-objects).


### PR DESCRIPTION
Grammatical correction of the 1st sentence of "Compile-Time Constants". 
Proposition -
"Properties the value of which is known at compile time ... " -> "Property values which are known at compile time .... "