### PR TITLE
Update links for Sydney Kotlin UG

### DIFF
--- a/data/events.xml
+++ b/data/events.xml
@@ -4255,7 +4255,7 @@ and much more.</p>
         <speaker>Paul Thompson</speaker>
         <title>Sydney Kotlin User Group</title>
         <subject>Make 100,000 unique HTTP requests fast with coroutines</subject>
-        <url>https://sydkotlin.space/#meetup-july-2019</url>
+        <url>https://sydspace.org/kotlin/#meetup-july-2019</url>
         <description>
             <![CDATA[
 <p>Sometimes you need to perform many thousands of HTTP requests, to download files, interact with an API, or load test. In the past we at Canva were constantly creating Python or batch scripts to perform our tasks. Now we use a custom Kotlin DSL to make HTTP request scripting easy and ludicrously fast.</p>
@@ -4271,7 +4271,7 @@ and much more.</p>
         <speaker>Jacob Bass</speaker>
         <title>Sydney Kotlin User Group</title>
         <subject>FP Answers to OO Questions</subject>
-        <url>https://sydkotlin.space/#meetup-july-2019</url>
+        <url>https://sydspace.org/kotlin/#meetup-july-2019</url>
         <description>
             <![CDATA[
 <p>A tour through some functional design patterns, showcasing how to solve common object-oriented problems. Talk will demonstrate how they work, how to substitute them and what their trade-offs are.</p>
@@ -5331,7 +5331,7 @@ Those questions will be answered during the Kotlin Introduction.<p>
         <speaker>Eugene Petrenko</speaker>
         <title>Sydney Kotlin User Group</title>
         <subject>Native with Kotlin/Native</subject>
-        <url>https://sydkotlin.space/#meetup-may-2019</url>
+        <url>https://sydspace.org/kotlin/#meetup-may-2019</url>
         <description>
             <![CDATA[
 <p>Have you tried Native with Kotlin/Native? It compiles your Kotlin code for various native platforms, including iOS, Mac, Linux, and Windows. No virtual machine is needed! The native world brings native libraries, C static and dynamic libraries, Apple frameworks, Swift and Objective-C dependencies. Kotlin adds multiplatform libraries to share Kotlin code between different platforms. That is the way to share code between Android and iOS, between backend and frontend, between JVM, JavaScript, C, and Swift/Objective-C. You benefit from both platform libraries and multiplatform pure Kotlin libraries. Join us to learn about native development new Kotlin/Native, code reuse between platforms and multiplatform development fun.</p>
@@ -5347,7 +5347,7 @@ Those questions will be answered during the Kotlin Introduction.<p>
         <speaker>Adi Polak</speaker>
         <title>Sydney Kotlin User Group</title>
         <subject>Coroutines to the Rescue!</subject>
-        <url>https://sydkotlin.space/#meetup-may-2019</url>
+        <url>https://sydspace.org/kotlin/#meetup-may-2019</url>
         <description>
             <![CDATA[
 <p>Coroutines to the Rescue! Asynchronous or non-blocking programming is the new reality. Whether we're creating server-side, desktop or mobile applications, using microservices architecture or not, it provides an experience that is not only fluid from the user's perspective, but scalable when needed. Coroutines is a new feature that was released in Kotlin 1.3 and has similar counterparts in other languages like C# and JavaScript. Let’s understand together what it is all about.</p>
@@ -7818,7 +7818,7 @@ Kotlin gurus in attendance.</p>
         <speaker>Dave Glover</speaker>
         <title>Sydney Kotlin User Group</title>
         <subject>Building an End-to-End Secure, Scalable IoT Serverless Solution</subject>
-        <url>https://sydkotlin.space/#meetup-march-2019</url>
+        <url>https://sydspace.org/kotlin/#meetup-march-2019</url>
         <description>
             <![CDATA[
 <p>Learn how to build and run your IoT solutions securely and at scale. We will cover device security with Azure Sphere, distribute intelligence to the edge with Azure IoT Edge, and building real-time serverless solutions with Azure Functions and Azure SignalR</p>

--- a/pages/user-groups/user-group-list.md
+++ b/pages/user-groups/user-group-list.md
@@ -192,7 +192,7 @@ The most common way to begin one is to find a few like-minded people and to get 
 
 * [Brisbane Kotlin User Group](https://www.meetup.com/Brisbane-Kotlin-User-Group/), Australia
 * [Melbourne Kotlin User Group](https://www.meetup.com/Melbourne-Kotlin-Meetup/), Australia
-* [Sydney Kotlin User Group](https://sydkotlin.space/), Australia
+* [Sydney Kotlin User Group](https://sydspace.org/kotlin/), Australia
 * [Wellington Kotlin User Group](https://www.meetup.com/Wellington-kt/), New Zealand
 
 ### Africa


### PR DESCRIPTION
Sydney Kotlin User Group was consolidated with other related local meetups into SYDspace last year. This updates all the sydkotlin.space links to sydspace.org/kotlin links.