### PR TITLE
Update 'Joining a course' section in edu-tools-learner.md

### DIFF
--- a/pages/docs/tutorials/edu-tools-learner.md
+++ b/pages/docs/tutorials/edu-tools-learner.md
@@ -25,6 +25,8 @@ To open the list of available courses, go to **Browse Courses** on the **Welcome
 
 ![Join a course]({{ url_for('tutorial_img', filename='education/learning/join_course.png') }})
 
+*If the course does not show on the list, make sure that **Gradle** and **Gradle Extension** bundled plugins are enabled.*
+
 *If you have a course archive shared with you by your teacher or co-worker, use the **Import Course** icon to open it. You can also log in to [Stepik](https://stepik.org/) with the corresponding link to see all the courses available to you on this MOOC platform.*
 
 ### Getting around


### PR DESCRIPTION
Related issue: https://intellij-support.jetbrains.com/hc/en-us/community/posts/360007655759-Unable-to-find-Kotlin-Koans-course-with-Learn-and-Teach-EduTools-

User had to enable 'Gradle Extension' bundled plugin to be able to see the course in the 'Select Course' window.

Since Gradle is used in this course, I suggest adding the following info to the 'Joining a course' section:

*If the course does not show on the list, make sure that **Gradle** and **Gradle Extension** bundled plugins are enabled.*