### PR TITLE
Update delegated-properties.md

### DIFF
--- a/pages/docs/reference/delegated-properties.md
+++ b/pages/docs/reference/delegated-properties.md
@@ -273,7 +273,7 @@ interface ReadOnlyProperty<in R, out T> {
     operator fun getValue(thisRef: R, property: KProperty<*>): T
 }
 
-interface ReadWriteProperty<in R, T> {
+interface ReadWriteProperty<in R, out T> {
     operator fun getValue(thisRef: R, property: KProperty<*>): T
     operator fun setValue(thisRef: R, property: KProperty<*>, value: T)
 }


### PR DESCRIPTION
In Property Delegate Requirements,  
mutable property  

interface ReadWriteProperty<in R, T> out is missing.