### PR TITLE
Make code blocks visible if JS is disabled

### DIFF
--- a/static/css/playgrounds.scss
+++ b/static/css/playgrounds.scss
@@ -1,10 +1,5 @@
 @import './static/css/_config';
 
-// Hide plain text before loading runnable examples
-.sample {
-  visibility: hidden;
-}
-
 .CodeMirror,
 .CodeMirror pre,
 .CodeMirror .CodeMirror-code,


### PR DESCRIPTION
**Not intended to be merged as-is.**

Right now, if JS is disabled, code blocks are not visible at all, and leave blank space on the page:

---

![image](https://user-images.githubusercontent.com/6563664/76027082-06fa6a00-5efe-11ea-9d4d-dd890b28ae94.png)

---

Obviously just removing the style is not sufficient, so this is more like an issue than a PR (I would have submitted a proper PR, but it's not a quick job for someone unfamiliar with the code base, so I figured I'd try this first).