### PR TITLE
Add missing div end tags

### DIFF
--- a/pages/docs/reference/using-gradle.md
+++ b/pages/docs/reference/using-gradle.md
@@ -234,6 +234,9 @@ kotlin {
 }
 ```
 
+</div>
+</div>
+
 
 ## Targeting Android
 


### PR DESCRIPTION
This was causing the rest of the page to render in the code block despite the closing backticks.