### PR TITLE
Improve readability about object class init timing

### DIFF
--- a/pages/docs/reference/object-declarations.md
+++ b/pages/docs/reference/object-declarations.md
@@ -130,7 +130,7 @@ object DataProviderManager {
 This is called an *object declaration*, and it always has a name following the *object*{: .keyword } keyword.
 Just like a variable declaration, an object declaration is not an expression, and cannot be used on the right hand side of an assignment statement.
 
-Object declaration's initialization is thread-safe.
+Object declaration's initialization is thread-safe and done at first access.
 
 To refer to the object, we use its name directly:
 


### PR DESCRIPTION
It was very hard to look for explanations about initialization timing of instances which is declared with `object` keyword usage instead of `class` keyword since the explanations about 'lazy initialization' is located at bottom paragraph when excerpt the part of lazy init stuff.

Most of people who are looking for about initialization timing of object instances will excerpt the part of object class declaration paragraph, not to the end of the document.