### PR TITLE
Add space between for and opening parenthesis

### DIFF
--- a/pages/docs/reference/idioms.md
+++ b/pages/docs/reference/idioms.md
@@ -325,7 +325,7 @@ class Turtle {
 val myTurtle = Turtle()
 with(myTurtle) { //draw a 100 pix square
     penDown()
-    for(i in 1..4) {
+    for (i in 1..4) {
         forward(100.0)
         turn(90.0)
     }


### PR DESCRIPTION
[As suggested in the documentation](https://kotlinlang.org/docs/reference/coding-conventions.html#horizontal-whitespace), `if`s, `when`s, `for`s and `while`s should have a space before its opening parenthesis.