### PR TITLE
Removed link from Android Studio description

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -87,7 +87,7 @@
 
                                     {% call render_get_kotlin_item(id="android-studio", title="Android Studio",
                                                 instructions="/docs/tutorials/kotlin-android.html",  download="https://developer.android.com/studio/") %}
-                                        Bundled with <a href="https://developer.android.com/studio/" target="_blank">Studio 3.0</a>, plugin available for earlier versions
+                                        Bundled with Studio 3.0, plugin available for earlier versions
                                     {% endcall %}
 
                                     {% call render_get_kotlin_item(id="eclipse", title="Eclipse", instructions="/docs/tutorials/getting-started-eclipse.html") %}


### PR DESCRIPTION
Removed link in "Studio 3.0" words, as it's essentially the same as the download link.