### PR TITLE
Improve example for using when without an argument

### DIFF
--- a/pages/docs/reference/control-flow.md
+++ b/pages/docs/reference/control-flow.md
@@ -146,8 +146,8 @@ If no argument is supplied, the branch conditions are simply boolean expressions
 ```kotlin
 when {
     x.isOdd() -> print("x is odd")
-    x.isEven() -> print("x is even")
-    else -> print("x is funny")
+    y.isEven() -> print("y is even")
+    else -> print("x and y are both funny")
 }
 ```
 

--- a/pages/docs/reference/control-flow.md
+++ b/pages/docs/reference/control-flow.md
@@ -147,7 +147,7 @@ If no argument is supplied, the branch conditions are simply boolean expressions
 when {
     x.isOdd() -> print("x is odd")
     y.isEven() -> print("y is even")
-    else -> print("x and y are both funny")
+    else -> print("x+y is even.")
 }
 ```
 
@@ -285,4 +285,3 @@ See the [grammar for *while*{: .keyword }](grammar.html#whileStatement).
 ## Break and continue in loops
 
 Kotlin supports traditional *break*{: .keyword } and *continue*{: .keyword } operators in loops. See [Returns and jumps](returns.html).
-


### PR DESCRIPTION
In the current example:
Both branches are for x, it makes sense to use `when(x)` in it.

But if we switch the example to have two variables, then it makes sense to just use when without arguments.