### PR TITLE
Rename kotlintest to kotest

### DIFF
--- a/data/oss-projects.yml
+++ b/data/oss-projects.yml
@@ -218,10 +218,10 @@
   type: Application
   link: https://github.com/datawire/discovery
 
-- name: KotlinTest
+- name: Kotest
   description: Kotlin port of the famous ScalaTest
   type: Library
-  link: https://github.com/kotlintest/kotlintest
+  link: https://github.com/kotest/kotest
   
 - name: Black-and-White
   description: A library of algorithms for the Black-and-White tree coloring


### PR DESCRIPTION
Since 4.0 release kotlintest has been renamed to [kotest](https://github.com/kotest/kotest) so changing that name here.