### PR TITLE
Add mention of caveat with default interface methods in delegation page

### DIFF
--- a/pages/docs/reference/delegation.md
+++ b/pages/docs/reference/delegation.md
@@ -104,11 +104,7 @@ fun main() {
 
 </div>
 
-### Caveats when implementing interface with `@JvmDefault` methods
-
-When delegation is used to implement a Kotlin interface that has its methods annotated with `@JvmDefault`
-(or a Java interface with `default` methods), note that the default method implementations are called
-even if the actual delegate type provides its own implementations.
-
-See the [Caveats when used together with delegation](java-to-kotlin-interop.html#caveats-when-used-together-with-delegation)
-section of the calling Kotlin from Java documentation for an example.
+> **On the JVM**: when an interface with `default` methods is used for delegation (including Kotlin interfaces with  `@JvmDefault`),
+>the default implementations are called even if the actual delegate type provides its own implementations.
+>For details, see [Calling Kotlin from Java](java-to-kotlin-interop.html#using-in-delegates).
+{:.note}

--- a/pages/docs/reference/delegation.md
+++ b/pages/docs/reference/delegation.md
@@ -103,3 +103,12 @@ fun main() {
 ```
 
 </div>
+
+### Caveats when implementing interface with `@JvmDefault` methods
+
+When delegation is used to implement a Kotlin interface that has its methods annotated with `@JvmDefault`
+(or a Java interface with `default` methods), note that the default method implementations are called
+even if the actual delegate type provides its own implementations.
+
+See the [Caveats when used together with delegation](java-to-kotlin-interop.html#caveats-when-used-together-with-delegation)
+section of the calling Kotlin from Java documentation for an example.

--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -408,6 +408,8 @@ Depending on the case of adding the annotation, specify one of the argument valu
 
 For more details about compatibility issues, see the `@JvmDefault` [reference page](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/index.html).
 
+### Caveats when used together with delegation
+
 Note that if an interface with `@JvmDefault` methods is used as a [delegate](/docs/reference/delegation.html),
 the default method implementations are called even if the actual delegate type provides its own implementations.
 

--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -408,7 +408,7 @@ Depending on the case of adding the annotation, specify one of the argument valu
 
 For more details about compatibility issues, see the `@JvmDefault` [reference page](/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/index.html).
 
-### Caveats when used together with delegation
+### Using in delegates
 
 Note that if an interface with `@JvmDefault` methods is used as a [delegate](/docs/reference/delegation.html),
 the default method implementations are called even if the actual delegate type provides its own implementations.


### PR DESCRIPTION
I got bit by this caveat today, and I was quite surprised to discover
that this behavior is actually by design, and is clearly documented
on the Java interop page -- I had never even considered looking there.

So I suggest adding a small call-out to the delegation page, so that
others may discover it if they run into the same issue.