### PR TITLE
Add XCFramework example

### DIFF
--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -2334,6 +2334,22 @@ kotlin {
 </div>
 </div>
 
+#### Building universal frameworks with XCFramework
+
+When building multi-architecture frameworks targeting Apple platforms, we can leverage a new technology introduced in Xcode 11, called XCFramework. These are special folders that are treated as normal frameworks when imported into an Xcode project and are automatically split based on the target architecture where the frameworks is being included.
+
+The following script merges all architectures together in a single XCFramework. It should be run inside your `bin` folder, where all the single-architecture frameworks are located.
+
+<div class="multi-language-sample" data-lang="bash">
+<div class="sample" markdown="1" theme="idea" mode='bash' data-highlight-only>
+   
+```bash
+xcodebuild -create-xcframework -framework <Arch1>.framework -framework <Arch2>.framework -output <ResultingFramework>.xcframework
+```
+
+</div>
+</div>
+
 ### CInterop support
 
 Since Kotlin/Native provides [interoperability with native languages](/docs/reference/native/c_interop.html),


### PR DESCRIPTION
The docs suggest that the only way to produce a _fat framework_ when building for Apple platforms is to merge all the architectures into a single framework, using `lipo`. Since Xcode 11, this is no longer true, as the preferred way to do this should be taking advantage of XCFrameworks.

There is an [excellent video from WWDC '19](https://developer.apple.com/videos/play/wwdc2019/416/) that explains in details how XCFrameworks work.

I have added a new section with a sample Bash script that shows how to merge multiple architectures into a single XCFramework that can then be imported into any Xcode project.

_The script I'm using is a little bit more complicated than this, because I'm launching it through an Xcode custom target. I'm not sure if that configuration should be included here, as it seems a bit too specific to my case. Just for reference, this is the full script from where I've extracted the sample: let me know if you think it could help adding more lines to the sample._

```bash
#! /bin/bash

action="$1"
if [[ action = "clean" ]]; then
    rm -rf <multi-platform-project-root>/build/bin/ios*
else
    rm -rf <multi-platform-project-root>/build/bin/ios*
    app-multiplatform-core/gradlew -p <multi-platform-project-name> linkDebugFrameworkIosArm64 linkDebugFrameworkIosX64
    rm -rf <multi-platform-project-root>/build/bin/xcframework/<FrameworkName>.xcframework
    xcodebuild -create-xcframework -framework <multi-platform-project-root>/build/bin/iosArm64/debugFramework/<FrameworkName>.framework -framework <multi-platform-project-root>/build/bin/iosX64/debugFramework/<FrameworkName>.framework -output <multi-platform-project-root>/build/bin/xcframework/<FrameworkName>.xcframework
fi
```

