### PR TITLE
Fix broken link

### DIFF
--- a/pages/docs/tutorials/javascript/working-with-javascript.md
+++ b/pages/docs/tutorials/javascript/working-with-javascript.md
@@ -9,7 +9,7 @@ showAuthorInfo: false
 ---
 
 >__Warning__: this tutorial does not reflect all newest changes for Kotlin {{ site.data.releases.latest.version }}.
->To get started with writing modern Kotlin/JS projects, please see [Setting up a Kotlin/JS project](setting-up)
+>To get started with writing modern Kotlin/JS projects, please see [Setting up a Kotlin/JS project](setting-up.html)
 {:.note}
 >
 


### PR DESCRIPTION
The link to the "lastest version" in the warning banner was broken without the .html