### PR TITLE
Use appropriate keyword for definition

### DIFF
--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -33,7 +33,7 @@ To specify the `Long` value explicitly, append the suffix `L` to the value.
 ```kotlin
 val one = 1 // Int
 val threeBillion = 3000000000 // Long
-val oneLong = 1L // Long
+var oneLong = 1L // Long
 val oneByte: Byte = 1
 ```
 


### PR DESCRIPTION
Defining an integer constant with an `L` suffix doesn't make sense. Because we can't change its value in the future. It will never be inside long type bounds.