### PR TITLE
Add Armeria for server-side framework

### DIFF
--- a/pages/docs/reference/server-overview.md
+++ b/pages/docs/reference/server-overview.md
@@ -38,6 +38,9 @@ It serves as an alternative to traditional templating systems such as JSP and Fr
  * [Micronaut](https://micronaut.io/) is a modern, JVM-based, full-stack framework for building modular, easily testable microservice and serverless applications. It comes with a lot of built-in, handy features.
  
  * [Javalin](https://javalin.io) is a very lightweight web framework for Kotlin and Java which supports WebSockets, HTTP2 and async requests.
+ 
+ * [Armeria](https://armeria.dev) is your go-to microservice framework for any situation. You can build any type of microservice leveraging your favorite technologies, 
+including Kotlin, gRPC, Thrift, Retrofit, Reactive Streams, Spring Boot and Dropwizard.
 
  * The available options for persistence include direct JDBC access, JPA, as well as using NoSQL databases through their Java drivers.
 For JPA, the [kotlin-jpa compiler plugin](/docs/reference/compiler-plugins.html#jpa-support) adapts


### PR DESCRIPTION
[Armeria](https://armeria.dev) is nicely compatible with Kotlin on server-side.
Some users already use Ameria with Kotlin for developing reactive web applications.
- https://github.com/search?l=Kotlin&q=com.linecorp.armeria&type=Code
- [Kotlin's case study in Armeria intro slide](https://speakerdeck.com/trustin/armeria-a-microservice-framework-well-suited-everywhere?slide=41)
- [gRPC-Kotlin](https://github.com/grpc/grpc-kotlin) supports - https://github.com/line/armeria/tree/master/examples/grpc-kotlin