### PR TITLE
Fix in thread-based calculation.

### DIFF
--- a/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
+++ b/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
@@ -194,7 +194,7 @@ val c = AtomicLong()
 for (i in 1..1_000_000L)
     thread(start = true) {
         c.addAndGet(i)
-    }
+    }.join()
 
 println(c.get())
 ```


### PR DESCRIPTION
In order to provide a proper result, we need to wait for every thread to finish. Otherwise, it shows an arbitrary number instead of "500000500000". This could be confusing after a reader fixes the coroutine approach and get the right result.