### PR TITLE
update: gradle metadata publishing

### DIFF
--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -962,8 +962,7 @@ kotlin {
 </div>
 </div>
 
-Likewise, if a multiplatform library is published in the experimental [Gradle metadata publishing mode](#metadata-publishing) and the project 
-is set up to consume the metadata as well, then it is enough to specify a dependency only once, for the common source set. 
+Likewise, if a multiplatform library is published with [Gradle metadata](#metadata-publishing), it is enough to specify a dependency only once, for the common source set. 
 Otherwise, each platform-specific source set should be 
 provided with a corresponding platform module of the library, in addition to the common module, as shown above.
 
@@ -1301,12 +1300,12 @@ kotlin {
 
 Gradle module metadata provides rich publishing and dependency resolution features that are used in Kotlin 
 multiplatform projects to simplify dependencies configuration for build authors. In particular, the publications of a 
-multiplatform library may include a special 'root' module that stands for the whole library and is automatically 
+multiplatform library include a special 'root' module that stands for the whole library and is automatically 
 resolved to the appropriate platform-specific artifacts when added as a dependency, as described below.
 
 In Gradle 6.0 and above, the module metadata is always used during dependency resolution and included in publications.
 
-In Gradle 5.3 and above, the module metadata is used during dependency resolution, but publications don't 
+In earlier Gradle versions starting from 5.3, the module metadata is used during dependency resolution, but publications don't 
 include any module metadata by default. To enable module metadata publishing, add 
 `enableFeaturePreview("GRADLE_METADATA")` to the root project's `settings.gradle` file. 
 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -962,7 +962,7 @@ kotlin {
 </div>
 </div>
 
-Likewise, if a multiplatform library is published with [Gradle metadata](#metadata-publishing), it is enough to specify a dependency only once, for the common source set. 
+Likewise, if a multiplatform library is [published with Gradle metadata](#metadata-publishing), it is enough to specify a dependency only once, for the common source set. 
 Otherwise, each platform-specific source set should be 
 provided with a corresponding platform module of the library, in addition to the common module, as shown above.
 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -1295,6 +1295,8 @@ kotlin {
 </div>
 </div>
 
+{:#experimental-metadata-publishing-mode}
+
 ### Metadata publishing
 
 Gradle module metadata provides rich publishing and dependency resolution features that are used in Kotlin 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -1302,16 +1302,13 @@ multiplatform projects to simplify dependencies configuration for build authors.
 multiplatform library may include a special 'root' module that stands for the whole library and is automatically 
 resolved to the appropriate platform-specific artifacts when added as a dependency, as described below.
 
-In Gradle 5.3 and above, the module metadata is always used during dependency resolution, but publications don't 
+In Gradle 6.0 and above, the module metadata is always used during dependency resolution and included in publications.
+
+In Gradle 5.3 and above, the module metadata is used during dependency resolution, but publications don't 
 include any module metadata by default. To enable module metadata publishing, add 
-`enableFeaturePreview("GRADLE_METADATA")` to the root project's `settings.gradle` file. With older Gradle versions, 
-this is also required for module metadata consumption.
+`enableFeaturePreview("GRADLE_METADATA")` to the root project's `settings.gradle` file. 
 
-> Note that the module metadata published by Gradle 5.3 and above cannot be read by Gradle versions older
-> than 5.3. 
-{:.note}
-
-With Gradle metadata enabled, an additional 'root' publication named `kotlinMultiplatform` is added to the project's 
+When publications include module metadata, an additional 'root' publication named `kotlinMultiplatform` is added to the project's 
 publications. The default artifact ID of this publication matches the project name without any additional suffix. 
 To configure this publication, access it via the `publishing { ... }` DSL of the `maven-publish` plugin:
 
@@ -1406,9 +1403,6 @@ kotlin {
 
 </div>
 </div>
-
-This requires that the consumer's Gradle build can read Gradle module metadata, either using Gradle 5.3+ or explicitly 
-enabling it by `enableFeaturePreview("GRADLE_METADATA")` in `settings.gradle`. 
 
 ### Disambiguating targets
 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -28,7 +28,7 @@ those are configured and built using Gradle.
 * [Default Project Layout](#default-project-layout)
 * [Running Tests](#running-tests)
 * [Publishing a Multiplatform Library](#publishing-a-multiplatform-library)
-    * [Experimental metadata publishing mode](#experimental-metadata-publishing-mode)
+    * [Metadata publishing](#metadata-publishing)
     * [Disambiguating targets](#disambiguating-targets)
 * [Java Support in JVM Targets](#java-support-in-jvm-targets)
 * [Android Support](#android-support)
@@ -962,7 +962,7 @@ kotlin {
 </div>
 </div>
 
-Likewise, if a multiplatform library is published in the experimental [Gradle metadata publishing mode](#experimental-metadata-publishing-mode) and the project 
+Likewise, if a multiplatform library is published in the experimental [Gradle metadata publishing mode](#metadata-publishing) and the project 
 is set up to consume the metadata as well, then it is enough to specify a dependency only once, for the common source set. 
 Otherwise, each platform-specific source set should be 
 provided with a corresponding platform module of the library, in addition to the common module, as shown above.
@@ -1295,7 +1295,7 @@ kotlin {
 </div>
 </div>
 
-### Experimental metadata publishing mode
+### Metadata publishing
 
 Gradle module metadata provides rich publishing and dependency resolution features that are used in Kotlin 
 multiplatform projects to simplify dependencies configuration for build authors. In particular, the publications of a 


### PR DESCRIPTION
Updated metadata publishing for newer Gradle versions; removed Experimental notion.