### PR TITLE
chore: remove kotlin for py

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -435,16 +435,6 @@ tutorials:
           title: Learning Kotlin with EduTools plugin
         - url: /docs/tutorials/edu-tools-educator.html
           title: Teaching Kotlin with EduTools plugin
-    - title: Migrating from Python
-      external:
-        path: kotlin-for-python-developers
-        nav: kotlinlang.org.yaml
-        base: /docs/tutorials/kotlin-for-py
-        branch: master
-        repo: https://github.com/Khan/kotlin-for-python-developers
-        type: tutorial
-        wrap_code_snippets: True
-        github_edit_page: README.md
 
 foundation:
   content:

--- a/kotlin-website.py
+++ b/kotlin-website.py
@@ -240,10 +240,33 @@ def optin_redirect():
 def resources_redirect():
     return render_template('redirect.html', url="https://kotlin.link/")
 
-@app.route('/docs/tutorials/kotlin-for-py/<path:pagename>')
-def kotlin_for_py_redirect(pagename):
+@app.route('/docs/tutorials/kotlin-for-py/introduction.html')
+@app.route('/docs/tutorials/kotlin-for-py/hello-world.html')
+@app.route('/docs/tutorials/kotlin-for-py/compiling-and-running.html')
+@app.route('/docs/tutorials/kotlin-for-py/declaring-variables.html')
+@app.route('/docs/tutorials/kotlin-for-py/primitive-data-types-and-their-limitations.html')
+@app.route('/docs/tutorials/kotlin-for-py/strings.html')
+@app.route('/docs/tutorials/kotlin-for-py/conditionals.html')
+@app.route('/docs/tutorials/kotlin-for-py/collections.html')
+@app.route('/docs/tutorials/kotlin-for-py/loops.html')
+@app.route('/docs/tutorials/kotlin-for-py/functions.html')
+@app.route('/docs/tutorials/kotlin-for-py/classes.html')
+@app.route('/docs/tutorials/kotlin-for-py/exceptions.html')
+@app.route('/docs/tutorials/kotlin-for-py/null-safety.html')
+@app.route('/docs/tutorials/kotlin-for-py/functional-programming.html')
+@app.route('/docs/tutorials/kotlin-for-py/packages-and-imports.html')
+@app.route('/docs/tutorials/kotlin-for-py/visibility-modifiers.html')
+@app.route('/docs/tutorials/kotlin-for-py/inheritance.html')
+@app.route('/docs/tutorials/kotlin-for-py/objects-and-companion-objects.html')
+@app.route('/docs/tutorials/kotlin-for-py/generics.html')
+@app.route('/docs/tutorials/kotlin-for-py/extension-functionsproperties.html')
+@app.route('/docs/tutorials/kotlin-for-py/member-references-and-reflection.html')
+@app.route('/docs/tutorials/kotlin-for-py/annotations.html')
+@app.route('/docs/tutorials/kotlin-for-py/file-io.html')
+@app.route('/docs/tutorials/kotlin-for-py/scoped-resource-usage.html')
+@app.route('/docs/tutorials/kotlin-for-py/documentation.html')
+def kotlin_for_py_redirect():
     return render_template('redirect.html', url="https://khan.github.io/kotlin-for-python-developers/")
-
 
 @app.route('/')
 def index_page():

--- a/kotlin-website.py
+++ b/kotlin-website.py
@@ -240,6 +240,10 @@ def optin_redirect():
 def resources_redirect():
     return render_template('redirect.html', url="https://kotlin.link/")
 
+@app.route('/docs/tutorials/kotlin-for-py/<path:pagename>')
+def kotlin_for_py_redirect(pagename):
+    return render_template('redirect.html', url="https://khan.github.io/kotlin-for-python-developers/")
+
 
 @app.route('/')
 def index_page():

--- a/pages/docs/reference/generics.md
+++ b/pages/docs/reference/generics.md
@@ -54,7 +54,7 @@ better than Java's arrays, since the following code would have compiled and caus
 ``` java
 // Java
 List<String> strs = new ArrayList<String>();
-List<Object> objs = strs; // !!! The cause of the upcoming problem sits here. Java prohibits this!
+List<Object> objs = strs; // !!! A compile-time error here saves us from a runtime exception later
 objs.add(1); // Here we put an Integer into a list of Strings
 String s = strs.get(0); // !!! ClassCastException: Cannot cast Integer to String
 ```


### PR DESCRIPTION
Removing the "Kotlin for Python developers" guide from the documentation to avoid confusion and search collisions. The content duplicates many parts of the official Kotlin documentation.