### PR TITLE
chore: clarify kotlin-jpa plugin introduction

### DIFF
--- a/pages/docs/reference/compiler-plugins.md
+++ b/pages/docs/reference/compiler-plugins.md
@@ -309,7 +309,7 @@ noArg {
 
 ### JPA support
 
-As with the *kotlin-spring* plugin, *kotlin-jpa* is a wrapped on top of *no-arg*. The plugin specifies 
+As with the *kotlin-spring* plugin wrapped on top of *all-open*, *kotlin-jpa* is a wrapped on top of *no-arg*. The plugin specifies 
 [`@Entity`](http://docs.oracle.com/javaee/7/api/javax/persistence/Entity.html), [`@Embeddable`](http://docs.oracle.com/javaee/7/api/javax/persistence/Embeddable.html) and [`@MappedSuperclass`](https://docs.oracle.com/javaee/7/api/javax/persistence/MappedSuperclass.html) 
 *no-arg* annotations automatically.
 


### PR DESCRIPTION
One might wrongly understand that *kotlin-spring* is also wrapped on top of *no-arg*, which is not the case since it's a subplugin of *allopen*.

I'm not a native english speaker, so rephrasing suggestions are welcome.