### PR TITLE
Update java-to-kotlin-interop.md NullPointerException -> IllegalArgumentException

### DIFF
--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -612,7 +612,7 @@ fun writeToFile() {
 
 When calling Kotlin functions from Java, nobody prevents us from passing *null*{: .keyword } as a non-null parameter.
 That's why Kotlin generates runtime checks for all public functions that expect non-nulls.
-This way we get a `NullPointerException` in the Java code immediately.
+This way we get a `IllegalArgumentException` in the Java code immediately.
 
 ## Variant generics
 


### PR DESCRIPTION
Calling kotlin function from java with required parameter as null actually returns `IllegalArgumentException`. Example: `Exception in thread "main" java.lang.IllegalArgumentException: Parameter specified as non-null is null: method MyUtils__OldutilsKt.doSomething, parameter circle``