### PR TITLE
we can't declare method that has no open modifier in base class with …

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -326,9 +326,7 @@ class Circle() : Shape() {
 
 </div>
 
-The *override*{: .keyword } modifier is required for `Circle.draw()`. If it were missing, the compiler would complain.
-If there is no *open*{: .keyword } modifier on a function, like `Shape.fill()`, declaring a method with the same signature in a subclass is illegal,
-either with *override*{: .keyword } or without it. The *open*{: .keyword } modifier has no effect when added on members of a final class (i.e.. a class with no *open*{: .keyword } modifier).
+The *override*{: .keyword } modifier is required for `Circle.draw()`. If it were missing, the compiler would complain.The *open*{: .keyword } modifier has no effect when added on members of a final class (i.e.. a class with no *open*{: .keyword } modifier).
 
 A member marked *override*{: .keyword } is itself open, i.e. it may be overridden in subclasses. If you want to prohibit re-overriding, use *final*{: .keyword }:
 


### PR DESCRIPTION
This line is not true.. 
If there is no *open*{: .keyword } modifier on a function, like `Shape.fill()`, declaring a method with the same signature in a subclass is illegal,
either with *override*{: .keyword } or without it.

whenever i am  trying to declare a method or function with same signature and name in subclass which has no open modifier in base class  compiler is complaining  that.. 
"<methodName> hides member of supertype <BaseClass> and needs 'override' modifier" and thus i need to add override before 'fun' keyword and if i do soo 
then we have to declare that function or method in base class as open..
so this line below  is totally wrong...

" If there is no open modifier on a function, like Shape.fill(), declaring a method with the same signature in a subclass is illegal, either with override or without it.  "