### PR TITLE
Evolution & related docs changed to reflect new stability levels

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -324,7 +324,7 @@ reference:
         - url: /docs/reference/evolution/kotlin-evolution.html
           title: Kotlin Evolution
         - url: /docs/reference/evolution/components-stability.html
-          title: Stability of different components
+          title: Stability of Kotlin components
         - url: /docs/reference/compatibility-guide-13.html
           title: Compatibility Guide for Kotlin 1.3
         - url: /docs/reference/compatibility-guide-14.html

--- a/pages/docs/reference/basic-types.md
+++ b/pages/docs/reference/basic-types.md
@@ -460,7 +460,7 @@ var arr = IntArray(5) { it * 1 }
 
 ## Unsigned integers
 
-> Unsigned types are available only since Kotlin 1.3 and currently are *experimental*. See details [below](#experimental-status-of-unsigned-integers) 
+> Unsigned types are available only since Kotlin 1.3 and currently in [Beta](evolution/components-stability.html). See details [below](#beta-status-of-unsigned-integers) 
 {:.note}
 
 Kotlin introduces following types for unsigned integers:
@@ -475,7 +475,7 @@ Unsigned types support most of the operations of their signed counterparts.
 > Note that changing type from unsigned type to signed counterpart (and vice versa) is a *binary incompatible* change
 {:.note}
 
-Unsigned types are implemented using another experimental feature, namely [inline classes](inline-classes.html).
+Unsigned types are implemented using another feature that's not yet stable, namely [inline classes](inline-classes.html).
 
 ### Specialized classes 
 
@@ -518,18 +518,18 @@ val a = 1UL // ULong, even though no expected type provided and constant fits in
 
 </div>
 
-### Experimental status of unsigned integers
+### Beta status of unsigned integers
 
-The design of unsigned types is experimental, meaning that this feature is moving fast and no compatibility guarantees are given. When using unsigned arithmetics in Kotlin 1.3+, warning will be reported, indicating that this feature is experimental. To remove warning, you have to opt-in for experimental usage of unsigned types. 
+The design of unsigned types is in [Beta](evolution/components-stability.html), meaning that its compatibility is best-effort only and not guaranteed. When using unsigned arithmetics in Kotlin 1.3+, a warning will be reported, indicating that this feature is has not been released as stable. To remove the warning, you have to opt in for usage of unsigned types. 
 
-There are two possible ways to opt-in for unsigned types: with marking your API as experimental too, or without doing that.
+There are two possible ways to opt-in for unsigned types: with requiring an opt-in for your API, or without doing that.
 
-- To propagate experimentality, annotate declarations that use unsigned integers with `@ExperimentalUnsignedTypes`.
-- To opt-in without propagating experimentality, either annotate declarations with `@OptIn(ExperimentalUnsignedTypes::class)` or pass `-Xopt-in=kotlin.ExperimentalUnsignedTypes` to the compiler.
+- To propagate the opt-in requirement, annotate declarations that use unsigned integers with `@ExperimentalUnsignedTypes`.
+- To opt-in without propagating, either annotate declarations with `@OptIn(ExperimentalUnsignedTypes::class)` or pass `-Xopt-in=kotlin.ExperimentalUnsignedTypes` to the compiler.
 
-It's up to you to decide if your clients have to explicitly opt-in into usage of your API, but bear in mind that unsigned types are an experimental feature, so API which uses them can be suddenly broken due to changes in language. 
+It's up to you to decide if your clients have to explicitly opt-in into usage of your API, but bear in mind that unsigned types are not a stable feature, so API which uses them can be broken by changes in the language. 
 
-See also or Experimental API [KEEP](https://github.com/Kotlin/KEEP/blob/master/proposals/experimental.md) for technical details.
+See also or Opt-in Requirements API [KEEP](https://github.com/Kotlin/KEEP/blob/master/proposals/experimental.md) for technical details.
 
 ### Further discussion
 

--- a/pages/docs/reference/building-mpp-with-gradle.md
+++ b/pages/docs/reference/building-mpp-with-gradle.md
@@ -6,7 +6,7 @@ title: "Building Multiplatform Projects with Gradle"
 
 # Building Multiplatform Projects with Gradle
 
-> Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
+> Multiplatform projects are an [experimental](evolution/components-stability.html) feature in Kotlin 1.2 and 1.3. All of the language
 and tooling features described in this document are subject to change in future Kotlin versions.
 {:.note}
 

--- a/pages/docs/reference/evolution/components-stability-pre-1.4.md
+++ b/pages/docs/reference/evolution/components-stability-pre-1.4.md
@@ -1,0 +1,42 @@
+---
+type: doc
+layout: reference
+category: "Compatibility"
+title: "Stability of Kotlin Components (pre 1.4)"
+---
+
+# Stability of Kotlin Components (pre 1.4)
+
+There can be different modes of stability depending of how quickly a component is evolving:
+<a name="moving-fast"></a>
+*   **Moving fast (MF)**: no compatibility should be expected between even [incremental releases](kotlin-evolution.html#feature-releases-and-incremental-releases), any functionality can be added, removed or changed without warning.
+
+*   **Additions in Incremental Releases (AIR)**: things can be added in an incremental release, removals and changes of behavior should be avoided and announced in a previous incremental release if necessary.
+
+*   **Stable Incremental Releases (SIR)**: incremental releases are fully compatible, only optimizations and bug fixes happen. Any changes can be made in a [feature release](kotlin-evolution.html#feature-releases-and-incremental-releases).
+
+<a name="fully-stable"></a>
+*   **Fully Stable (FS)**: incremental releases are fully compatible, only optimizations and bug fixes happen. Feature releases are backwards compatible.
+
+Source and binary compatibility may have different modes for the same component, e.g. the source language can reach full stability before the binary format stabilizes, or vice versa.
+
+The provisions of the [Kotlin evolution policy](kotlin-evolution.html) fully apply only to components that have reached Full Stability (FS). From that point on incompatible changes have to be approved by the Language Committee.
+
+|**Component**|**Status Entered at version**|**Mode for Sources**|**Mode for Binaries**|
+| --- | --- | --- | --- |
+Kotlin/JVM|1.0|FS|FS|
+kotlin-stdlib (JVM)|1.0|FS|FS
+KDoc syntax|1.0|FS|N/A
+Coroutines|1.3|FS|FS
+kotlin-reflect (JVM)|1.0|SIR|SIR
+Kotlin/JS|1.1|AIR|MF
+Kotlin/Native|1.3|AIR|MF
+Kotlin Scripts (*.kts)|1.2|AIR|MF
+dokka|0.1|MF|N/A
+Kotlin Scripting APIs|1.2|MF|MF
+Compiler Plugin API|1.0|MF|MF
+Serialization|1.3|MF|MF
+Multiplatform Projects|1.2|MF|MF
+Inline classes|1.3|MF|MF
+Unsigned arithmetics|1.3|MF|MF
+**All other experimental features, by default**|N/A|**MF**|**MF**

--- a/pages/docs/reference/evolution/components-stability.md
+++ b/pages/docs/reference/evolution/components-stability.md
@@ -65,6 +65,7 @@ Kotlin Scripting APIs and custom hosts|Alpha|1.2|
 Compiler Plugin API|Experimental|1.0|
 Serialization Compiler Plugin|Stable|1.4|
 Serialization Core Library|Stable|1.0.0|Versioned separately from the language
+Multiplatform Projects|Alpha|1.3|
 expect/actual language feature|Beta|1.2|
 Inline classes|Alpha|1.3|
 Unsigned arithmetics|Beta|1.3|

--- a/pages/docs/reference/evolution/components-stability.md
+++ b/pages/docs/reference/evolution/components-stability.md
@@ -2,41 +2,74 @@
 type: doc
 layout: reference
 category: "Compatibility"
-title: "Stability of Different Components"
+title: "Stability of Kotlin Components"
 ---
 
-# Stability of Different Components
+# Stability of Kotlin Components
 
-There can be different modes of stability depending of how quickly a component is evolving:
-<a name="moving-fast"></a>
-*   **Moving fast (MF)**: no compatibility should be expected between even [incremental releases](kotlin-evolution.html#feature-releases-and-incremental-releases), any functionality can be added, removed or changed without warning.
+The Kotlin language and toolset are divided into many components such as the compilers for the JVM, JS and Native targets, the Standard Library, various accompanying tools and so on. Many of these components were officially released as **Stable** which means that they are evolved in the backward-compatible way following the [principles](kotlin-evolution.html) of *Comfortable Updates* and *Keeping the Language Modern*. Among such stable components are, for example, the Kotlin compiler for the JVM, the Standard Library, and Coroutines.
 
-*   **Additions in Incremental Releases (AIR)**: things can be added in an incremental release, removals and changes of behavior should be avoided and announced in a previous incremental release if necessary.
+Following the *Feedback Loop* principle we release many things early for the community to try out, so a number of components are not yet released as **Stable**. Some of them are very early stage, some are more mature. We mark them as **Experimental**, **Alpha** or **Beta** depending on how quickly each component is evolving and how much risk the users are taking when adopting it. 
 
-*   **Stable Incremental Releases (SIR)**: incremental releases are fully compatible, only optimizations and bug fixes happen. Any changes can be made in a [feature release](kotlin-evolution.html#feature-releases-and-incremental-releases).
+## Stability Levels Explained
 
-<a name="fully-stable"></a>
-*   **Fully Stable (FS)**: incremental releases are fully compatible, only optimizations and bug fixes happen. Feature releases are backwards compatible.
+Here's a quick guide to these stability levels and their meaning:
 
-Source and binary compatibility may have different modes for the same component, e.g. the source language can reach full stability before the binary format stabilizes, or vice versa.
+**Experimental** means "try it only in toy projects":
+  * We are just trying out an idea and want some users to play with it and give feedback. If it doesn't work out, we may drop it any minute.
 
-The provisions of the [Kotlin evolution policy](kotlin-evolution.html) fully apply only to components that have reached Full Stability (FS). From that point on incompatible changes have to be approved by the Language Committee.
+**Alpha** means "use at your own risk, expect migration issues": 
+  * We decided to productize this idea, but it hasn't reached the final shape yet.
 
-|**Component**|**Status Entered at version**|**Mode for Sources**|**Mode for Binaries**|
+**Beta** means "you can use it, we'll do our best to minimize migration issues for you": 
+  * It’s almost done, user feedback is especially important now.
+  * Still, it's not 100% finished, so changes are possible (including ones based on your own feedback).
+  * Watch for deprecation warnings in advance for the best update experience.
+
+We collectively refer to _Experimental_, _Alpha_ and _Beta_ as **pre-stable** levels.
+
+<a name="stable"></a>
+**Stable** means "use it even in most conservative scenarios":
+  * It’s done. We will be evolving it according to our strict [backward compatibility rules](/foundation/language-committee-guidelines.html).
+  
+Please note that stability levels do not say anything about how soon a component will be released as Stable. Similarly, they do not indicate how much a component will be changed before release. They only say how fast a component is changing and how much risk of update issues users are running.
+
+## Stability of Subcomponents
+
+A stable component may have an experimental subcomponent, for example:
+* a stable compiler may have an experimental feature;
+* a stable API may include experimental classes or functions;
+* a stable command-line tool may have experimental options.
+
+We make sure to document precisely which subcomponents are not stable. We also do our best to warn users where possible and ask to opt in explicitly to avoid accidental usages of features that have not been released as stable.
+
+## Current Stability of Kotlin Components
+
+|**Component**|**Status**|**Status since version**|**Comment**|
 | --- | --- | --- | --- |
-Kotlin/JVM|1.0|FS|FS|
-kotlin-stdlib (JVM)|1.0|FS|FS
-KDoc syntax|1.0|FS|N/A
-Coroutines|1.3|FS|FS
-kotlin-reflect (JVM)|1.0|SIR|SIR
-Kotlin/JS|1.1|AIR|MF
-Kotlin/Native|1.3|AIR|MF
-Kotlin Scripts (*.kts)|1.2|AIR|MF
-dokka|0.1|MF|N/A
-Kotlin Scripting APIs|1.2|MF|MF
-Compiler Plugin API|1.0|MF|MF
-Serialization|1.3|MF|MF
-Multiplatform Projects|1.2|MF|MF
-Inline classes|1.3|MF|MF
-Unsigned arithmetics|1.3|MF|MF
-**All other experimental features, by default**|N/A|**MF**|**MF**
+Kotlin/JVM|Stable|1.0|
+kotlin-stdlib (JVM)|Stable|1.0|
+Coroutines|Stable|1.3|
+kotlin-reflect (JVM)|Beta|1.0|
+Kotlin/JS (Classic back-end)|Stable|1.3|
+Kotlin/JVM (IR-based)|Alpha|1.4|
+Kotlin/JS (IR-based)|Alpha|1.4|
+kotlin-stdlib API (JS)|Stable|1.3|
+Kotlin/Native Runtime|Beta|1.3|
+kotlin-stdlib API (Native)|Beta|1.3|
+KLib binaries|Alpha|1.4|
+KDoc syntax|Stable|1.0|
+dokka|Alpha|0.1|
+Kotlin Scripts (*.kts, *.gradle.kts)|Stable|1.3|
+Kotlin Scripting APIs and custom hosts|Alpha|1.2|
+Compiler Plugin API|Experimental|1.0|
+Serialization Compiler Plugin|Stable|1.4|
+Serialization Core Library|Stable|1.0.0|Versioned separately from the language
+expect/actual language feature|Beta|1.2|
+Inline classes|Alpha|1.3|
+Unsigned arithmetics|Beta|1.3|
+Contracts in stdlib|Stable|1.3|
+User-defined contracts|Experimental|1.3|
+**All other experimental components, by default**|Experimental|N/A|
+ 
+*The pre-1.4 version of this page is available [here](components-stability-pre-1.4.html).* 

--- a/pages/docs/reference/evolution/kotlin-evolution.md
+++ b/pages/docs/reference/evolution/kotlin-evolution.md
@@ -32,7 +32,7 @@ As this is key to understanding how Kotlin is moving forward, let's expand on th
 
 **Comfortable Updates**. Incompatible changes, such as removing things from a language, may lead to painful migration from one version to the next if carried out without proper care. We will always announce such changes well in advance, mark things as deprecated and provide automated migration tools _before the change happens_. By the time the language is changed we want most of the code in the world to be already updated and thus have no issues migrating to the new version.
 
-**Feedback Loop**. Going through deprecation cycles requires significant effort, so we want to minimize the number of incompatible changes we'll be making in the future. Apart from using our best judgement, we believe that trying things out in real life is the best way to validate a design. Before casting things in stone we want them battle-tested. This is why we use every opportunity to make early versions of our designs available in production versions of the language, but with _experimental_ status. Experimental features are not stable, they can be changed at any time, and the users that opt into using them do so explicitly to indicate that they are ready to deal with the future migration issues. These users provide invaluable feedback that we gather to iterate on the design and make it rock-solid.
+**Feedback Loop**. Going through deprecation cycles requires significant effort, so we want to minimize the number of incompatible changes we'll be making in the future. Apart from using our best judgement, we believe that trying things out in real life is the best way to validate a design. Before casting things in stone we want them battle-tested. This is why we use every opportunity to make early versions of our designs available in production versions of the language, but in one of the  _pre-stable_ statuses: [Experimental, Alpha, or Beta](components-stability.html). Such features are not stable, they can be changed at any time, and the users that opt into using them do so explicitly to indicate that they are ready to deal with the future migration issues. These users provide invaluable feedback that we gather to iterate on the design and make it rock-solid.
 
 
 ## Incompatible Changes
@@ -87,9 +87,9 @@ The Language Committee makes final decisions on what incompatible changes will b
 
 Stable releases with versions 1.2, 1.3, etc. are usually considered to be _feature releases_ bringing major changes in the language. Normally, we publish _incremental releases_, numbered 1.2.20, 1.2.30, etc, in between feature releases. 
 
-Incremental releases bring updates in the tooling (often including features), performance improvements and bug fixes. We try to keep such versions compatible with each other, so changes to the compiler are mostly optimizations and warning additions/removals. Experimental features may, of course, be added, removed or changed at any time.
+Incremental releases bring updates in the tooling (often including features), performance improvements and bug fixes. We try to keep such versions compatible with each other, so changes to the compiler are mostly optimizations and warning additions/removals. Pre-stable features may, of course, be added, removed or changed at any time.
 
-Feature releases often add new features and may remove or change previously deprecated ones. Feature graduation from experimental to stable also happens in feature releases.
+Feature releases often add new features and may remove or change previously deprecated ones. Feature graduation from pre-stable to stable also happens in feature releases.
 
 
 ### EAP Builds
@@ -97,11 +97,11 @@ Feature releases often add new features and may remove or change previously depr
 Before releasing stable versions, we usually publish a number of preview builds dubbed EAP (for "Early Access Preview") that let us iterate faster and gather feedback from the community. EAPs of feature releases usually produce binaries that will be later rejected by the stable compiler to make sure that possible bugs in the binary format survive no longer than the preview period. Final Release Candidates normally do not bear this limitation.
 
 
-### Experimental features
+### Pre-stable features
 
-According to the Feedback Loop principle described above, we iterate on our designs in the open and release versions of the language where some features have the _experimental_ status and _are supposed to change_. Experimental features can be added, changed or removed at any point and without warning. We make sure that experimental features can't be used accidentally by an unsuspecting user. Such features usually require some sort of an explicit opt-in either in the code or in the project configuration.
+According to the Feedback Loop principle described above, we iterate on our designs in the open and release versions of the language where some features have one of the _pre-stable_ statuses and _are supposed to change_. Such features can be added, changed or removed at any point and without warning. We do our best to ensure that pre-stable features can't be used accidentally by an unsuspecting user. Such features usually require some sort of an explicit opt-in either in the code or in the project configuration.
 
-Experimental features usually graduate to the stable status after some iterations.
+Pre-stable features usually graduate to the stable status after some iterations.
 
 
 ### Status of different components
@@ -126,7 +126,7 @@ On the other hand, a lot depends on the library authors being careful about whic
 
 Library authors can use the @Deprecated and [@RequiresOptIn](../opt-in-requirements.html) annotations to control the evolution of their API surface. Note that @Deprecated(level=HIDDEN) can be used to preserve binary compatibility even for declarations removed from the API.
 
-Also, by convention, packages named "internal" are not considered public API. All API residing in packages named "experimental" is considered experimental and can change at any moment.
+Also, by convention, packages named "internal" are not considered public API. All API residing in packages named "experimental" is considered pre-stable and can change at any moment.
 
 We evolve the Kotlin Standard Library (kotlin-stdlib) for stable platforms according to the principles stated above. Changes to the contracts for its API undergo the same procedures as changes in the language itself.
 

--- a/pages/docs/reference/evolution/kotlin-evolution.md
+++ b/pages/docs/reference/evolution/kotlin-evolution.md
@@ -124,7 +124,7 @@ On the other hand, a lot depends on the library authors being careful about whic
 *   Library code should always specify return types of public/protected functions and properties explicitly thus never relying on type inference for public API. Subtle changes in type inference may cause return types to change inadvertently, leading to binary compatibility issues.
 *   Overloaded functions and properties provided by the same library should do essentially the same thing. Changes in type inference may result in more precise static types to be known at call sites causing changes in overload resolution.
 
-Library authors can use the @Deprecated and @Experimental annotations to control the evolution of their API surface. Note that @Deprecated(level=HIDDEN) can be used to preserve binary compatibility even for declarations removed from the API.
+Library authors can use the @Deprecated and [@RequiresOptIn](../opt-in-requirements.html) annotations to control the evolution of their API surface. Note that @Deprecated(level=HIDDEN) can be used to preserve binary compatibility even for declarations removed from the API.
 
 Also, by convention, packages named "internal" are not considered public API. All API residing in packages named "experimental" is considered experimental and can change at any moment.
 

--- a/pages/docs/reference/inline-classes.md
+++ b/pages/docs/reference/inline-classes.md
@@ -7,7 +7,7 @@ title: "Inline classes"
 
 # Inline classes
 
-> Inline classes are available only since Kotlin 1.3 and currently are *experimental*. See details [below](#experimental-status-of-inline-classes)
+> Inline classes are available only since Kotlin 1.3 and currently in [Alpha](evolution/components-stability.html). See details [below](#alpha-status-of-inline-classes)
 {:.note}
 
 Sometimes it is necessary for business logic to create a wrapper around some type. However, it introduces runtime overhead due to additional heap allocations. Moreover, if the wrapped type is primitive, the performance hit is terrible, because primitive types are usually heavily optimized by the runtime, while their wrappers don't get any special treatment. 
@@ -188,11 +188,11 @@ fun main() {
 </div>
 
 
-## Experimental status of inline classes
+## Alpha status of inline classes
 
-The design of inline classes is experimental, meaning that this feature is *moving fast* and no compatibility guarantees are given. When using inline classes in Kotlin 1.3+, a warning will be reported, indicating that this feature is experimental.
+The design of inline classes is in [Alpha](evolution/components-stability.html), meaning that no compatibility guarantees are given for future versions. When using inline classes in Kotlin 1.3+, a warning will be reported, indicating that this feature has not been released as stable.
 
-To remove the warning you have to opt in to the usage of this experimental feature by passing the compiler argument `-Xinline-classes`.
+To remove the warning you have to opt in to the usage of this feature by passing the compiler argument `-Xinline-classes`.
 
 ### Enabling inline classes in Gradle
 <div class="multi-language-sample" data-lang="groovy">

--- a/pages/docs/reference/mpp-dsl-reference.md
+++ b/pages/docs/reference/mpp-dsl-reference.md
@@ -6,7 +6,7 @@ title: "Building Multiplatform Projects with Gradle"
 
 # Kotlin Multiplatform Gradle DSL Reference
 
-> Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
+> Multiplatform projects are an [experimental](evolution/components-stability.html) feature in Kotlin 1.2 and 1.3. All of the language
 and tooling features described in this document are subject to change in future Kotlin versions.
 {:.note}
 

--- a/pages/docs/reference/multiplatform.md
+++ b/pages/docs/reference/multiplatform.md
@@ -7,7 +7,7 @@ title: "Multiplatform Projects"
 
 # Multiplatform Programming
 
-> Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
+> Multiplatform projects are an [experimental](evolution/components-stability.html) feature in Kotlin 1.2 and 1.3. All of the language
 and tooling features described in this document are subject to change in future Kotlin versions.
 {:.note}
 

--- a/pages/docs/reference/opt-in-requirements.md
+++ b/pages/docs/reference/opt-in-requirements.md
@@ -287,12 +287,12 @@ fun getTime(): Time {}
 </div>
 
 
-## Opt-in requirements for experimental APIs
+## Opt-in requirements for pre-stable APIs
 
-If you use opt-in requirements for features in the experimental state, carefully handle the API graduation to avoid 
+If you use opt-in requirements for features that are not stable yet, carefully handle the API graduation to avoid 
 breaking the client code.
 
-Once your experimental API graduates and is released in a stable state, remove its opt-in requirement annotations from declarations.
+Once your pre-stable API graduates and is released in a stable state, remove its opt-in requirement annotations from declarations.
 The clients will be able to use them without restriction. However, you should leave the annotation classes in modules so that 
 the existing client code remains compatible.
 

--- a/pages/docs/reference/opt-in-requirements.md
+++ b/pages/docs/reference/opt-in-requirements.md
@@ -7,7 +7,7 @@ title: "Opt-in Requirements"
 
 # Opt-in Requirements
 
-> The opt-in requirement annotations `@RequiresOptIn` and `@OptIn` are *experimental*. 
+> The opt-in requirement annotations `@RequiresOptIn` and `@OptIn` are [experimental](evolution/components-stability.html). 
 > See the usage details [below](#experimental-status-of-the-opt-in-requirements).
 {:.note} 
 
@@ -312,7 +312,7 @@ annotation class ExperimentalDateTime
 
 ## Experimental status of the opt-in requirements
 
-The opt-in requirement mechanism is experimental in Kotlin 1.3.
+The opt-in requirement mechanism is [experimental](evolution/components-stability.html) in Kotlin 1.3.
 This means that in future releases it may be changed in ways that make it incompatible.
 
 To make the users of annotations `@OptIn` and `@RequiresOptIn` aware of their experimental status,

--- a/pages/docs/reference/platform-specific-declarations.md
+++ b/pages/docs/reference/platform-specific-declarations.md
@@ -7,7 +7,7 @@ title: "Platform-Specific Declarations"
 
 ## Platform-Specific Declarations
 
-> Multiplatform projects are an experimental feature in Kotlin 1.2 and 1.3. All of the language
+> The `expect`/`actual` feature is available since Kotlin 1.2 and is currently in [Beta](evolution/components-stability.html). All of the language
 and tooling features described in this document are subject to change in future Kotlin versions.
 {:.note}
 

--- a/pages/docs/reference/whatsnew13.md
+++ b/pages/docs/reference/whatsnew13.md
@@ -508,7 +508,7 @@ Kotlin 1.3 introduces support for the [recommended code style](coding-convention
 
 See here for [details](https://github.com/Kotlin/kotlinx.serialization#current-project-status).
 
-> Please, note, that even though kotlinx.serialization now ships with the Kotlin Compiler distribution, it is still considered to be an experimental feature. 
+> Please, note, that even though kotlinx.serialization now ships with the Kotlin Compiler distribution, it is still considered to be an experimental feature in Kotlin 1.3. 
 {:.note}
 
 ## Scripting update

--- a/pages/docs/reference/whatsnew13.md
+++ b/pages/docs/reference/whatsnew13.md
@@ -313,7 +313,7 @@ See [reference](inline-classes.html) for inline classes for details.
 
 ## Unsigned integers
 
-> Unsigned integers are available only since Kotlin 1.3 and currently are *experimental*. See details in the [reference](basic-types.html#experimental-status-of-unsigned-integers).
+> Unsigned integers are available only since Kotlin 1.3 and currently are in [Beta](evolution/components-stability.html). See details in the [reference](basic-types.html#beta-status-of-unsigned-integers).
 {:.note}
 
 Kotlin 1.3 introduces unsigned integer types:

--- a/pages/docs/reference/whatsnew13.md
+++ b/pages/docs/reference/whatsnew13.md
@@ -277,7 +277,7 @@ We expect that the progressive mode will be a nice choice for any actively maint
 
 ## Inline classes
 
-> Inline classes are available only since Kotlin 1.3 and currently are *experimental*. See details in the [reference](inline-classes.html#experimental-status-of-inline-classes).
+> Inline classes are available only since Kotlin 1.3 and currently are in [Alpha](evolution/components-stability.html). See details in the [reference](inline-classes.html#alpha-status-of-inline-classes).
 {:.note}
 
 

--- a/pages/docs/reference/whatsnew14.md
+++ b/pages/docs/reference/whatsnew14.md
@@ -342,8 +342,8 @@ For more details about the explicit API mode, see the [KEEP](https://github.com/
 The new Kotlin compiler is going to be really fast; it will unify all the supported platforms and provide 
 an API for compiler extensions. It's a long-term project, and we've already completed several steps in Kotlin 1.4:
 
-* [New, more powerful type inference algorithm](#new-more-powerful-type-inference-algorithm) is enabled by default. 
-* [New JVM and JS IR back-ends](#unified-back-ends-and-extensibility) are available in experimental mode. They will become the default once we stabilize them.
+* [New, more powerful type inference algorithm](#new-more-powerful-type-inference-algorithm) is stable and enabled by default. 
+* [New JVM and JS IR back-ends](#unified-back-ends-and-extensibility) are in [Alpha](evolution/components-stability.html). They will become the default once we stabilize them.
 
 ### New more powerful type inference algorithm
 
@@ -537,7 +537,7 @@ infrastructure built around an internal representation (IR) for Kotlin code.
 
 We are now migrating Kotlin/JVM and Kotlin/JS to the same IR. As a result, all three back-ends
 share a lot of logic and have a unified pipeline. This allows us to implement most features, optimizations, and bug fixes 
-only once for all platforms.
+only once for all platforms. Both new IR-based back-ends are in [Alpha](evolution/components-stability.html).
 
 A common back-end infrastructure also opens the door for multiplatform compiler extensions. You will be able to plug into the 
 pipeline and add custom processing and transformations that will automatically work for all platforms. 

--- a/pages/foundation/language-committee-guidelines.md
+++ b/pages/foundation/language-committee-guidelines.md
@@ -45,7 +45,7 @@ Only features and components published as [Stable](/docs/reference/evolution/com
 *   KDoc syntax
 
 For example, the following matters are out of scope for the Language Committee:
-*   Experimental language features & APIs
+*   Pre-stable language features & APIs
 *   Build tools and plugins for them (e.g. Gradle support)
 *   IDE and static analysis tools (other than the compiler)
 *   Java2Kotlin converter and other source code manipulation tools

--- a/pages/foundation/language-committee-guidelines.md
+++ b/pages/foundation/language-committee-guidelines.md
@@ -36,7 +36,7 @@ When an issue has all the necessary details, it can be scheduled for review by t
 
 # Scope
 
-Only features and components published as [Fully Stable](/docs/reference/evolution/components-stability.html#fully-stable) are in the scope of Language Committee. Besides, the Language Committee's scope is limited to the following:
+Only features and components published as [Stable](/docs/reference/evolution/components-stability.html#stable) are in the scope of Language Committee. Besides, the Language Committee's scope is limited to the following:
 *   Language: syntax, static checks, execution semantics of language constructs
 *   The interop subsystem of the language: how foreign declarations are seen from Kotlin, and how Kotlin declarations are seen from other languages
 *   Compatibility of binary artifacts produced by kotlinc with one another and with other binaries (e.g. Java binaries)


### PR DESCRIPTION
Commits concerning the Language Committee:

- f9c2be3f update(evolution): new descriptions for stability levels
- a95a2a53 update(evolution): KT-34653 - replace @Experimental with @RequiresOptIn
- 80c73c35 update(evolution): replace "experimental" with "pre-stable

The rest is updating statuses in the docs mentioning pre-stable features, mostly "experimental" -> "Alpha" or "Beta".