### PR TITLE
feat: modifiers order in fun interface

### DIFF
--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -407,7 +407,7 @@ tailrec
 vararg
 suspend
 inner
-enum / annotation
+enum / annotation / fun // as a modifier in `fun interface`
 companion
 inline
 infix


### PR DESCRIPTION
add `fun` modifier in **coding conventions > modifiers order**.

https://youtrack.jetbrains.com/issue/KT-37781