### PR TITLE
doc: update protocol to https for jcenter repo

### DIFF
--- a/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
+++ b/pages/docs/tutorials/coroutines/coroutines-basic-jvm.md
@@ -99,7 +99,7 @@ This library is published to Bintray JCenter repository, so let us add it:
     ...
     <repository>
         <id>central</id>
-        <url>http://jcenter.bintray.com</url>
+        <url>https://jcenter.bintray.com</url>
     </repository>
 </repositories>
 ```


### PR DESCRIPTION
This PR updates URL protocol (http -> https) in maven repository section.

Starting January 2020, JCenter only supports HTTPS user interface and REST API requests: https://jfrog.com/blog/secure-jcenter-with-https/.
