### PR TITLE
update: added Kotlin Releases page

### DIFF
--- a/pages/eap/index.md
+++ b/pages/eap/index.md
@@ -29,7 +29,7 @@ In this channel, you can also get notifications about new EAP builds.
 If you have already installed the EAP version and want to work on projects that were created previously, 
 check [our instructions on how to configure your build to support this version](configure-build-for-eap.html). 
 
-# Build details
+## Build details
 
 <table>
     <tr>

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -35,6 +35,8 @@ If you are migrating to the new feature release, Kotlin plugin's migration tools
 
 The following table lists details of latest Kotlin releases.
 
+You can also use [preview versions of Kotlin](eap/index.html#build-details).
+
 <table>
     <tr>
         <th>Build info</th>

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -39,7 +39,7 @@ The following table lists details of latest Kotlin releases.
     <tr>
         <th>Build info</th>
         <th>Build highlights</th>
-        <th>kotlinx library versions</th>
+        <th>Recommended kotlinx library versions</th>
     </tr>
     <tr>
         <td><strong>1.4.0</strong>
@@ -100,3 +100,7 @@ The following table lists details of latest Kotlin releases.
         </td>
     </tr>    
 </table>
+
+> On the JVM, you usually can use library versions other than the recommended ones. However, we don't guarantee the compatibility
+>in such cases. 
+{:.note}

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -15,8 +15,8 @@ performance improvements, and bug fixes.
 For example, for the feature release 1.3 we had several incremental releases including 1.3.10, 1.3.20, and 1.3.70.
 For 1.3.70, we had 2 bug fix releases – 1.3.71 and 1.3.72.
 
-For each incremental and feature release, we also ship several [preview versions](eap/index.html) that allow you to try 
-new features before they are released (Early Access Preview).
+For each incremental and feature release, we also ship several preview (_EAP_) versions for you to try 
+new features before they are released. See [Early Access Preview](eap/index.html) for details.
 
 Learn more about [types of Kotlin releases and their compatiblity](docs/reference/evolution/kotlin-evolution.html#feature-releases-and-incremental-releases). 
 

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -61,7 +61,7 @@ You can also use [preview versions of Kotlin](eap/index.html#build-details).
         <td>
             <ul>
                 <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank"><strong>kotlinx.serialization</strong>
-                </a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/releases/tag/1.0.0-RC" target="_blank">1.0.0-rc</a></li>
+                </a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/releases/tag/1.0.0-RC" target="_blank">1.0.0-RC</a></li>
                 <li><a href="https://github.com/Kotlin/kotlinx.coroutines" target="_blank"><strong>kotlinx.coroutines</strong></a>
                 version: <a href="https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.9" target="_blank">1.3.9
                 </a></li>

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -59,15 +59,15 @@ The following table lists details of latest Kotlin releases.
         <td>
             <ul>
                 <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank"><strong>kotlinx.serialization</strong>
-                </a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.serialization.runtime/1.0.0-rc" target="_blank">1.0.0-rc</a></li>
+                </a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md#100-rc--2020-08-17" target="_blank">1.0.0-rc</a></li>
                 <li><a href="https://github.com/Kotlin/kotlinx.coroutines" target="_blank"><strong>kotlinx.coroutines</strong></a>
-                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.coroutines/1.3.9" target="_blank">1.3.9
+                version: <a href="https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.9" target="_blank">1.3.9
                 </a></li>
                 <li><a href="https://github.com/Kotlin/kotlinx.atomicfu" target="_blank"><strong>kotlinx.atomicfu</strong></a>
-                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.atomicfu/0.14.4" target="_blank">0.14.4
+                version: <a href="https://github.com/Kotlin/kotlinx.atomicfu/releases/tag/0.14.4" target="_blank">0.14.4
                 </a></li>          
-                 <li><a href="https://ktor.io/" target="_blank"><strong>ktor</strong></a> version: <a href="https://bintray.com/kotlin/ktor/ktor/1.4.0" target="_blank">1.4.0</a></li>
-                 <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.html/0.7.2" target="_blank">0.7.2</a></li>
+                 <li><a href="https://ktor.io/" target="_blank"><strong>ktor</strong></a> version: <a href="https://github.com/ktorio/ktor/releases/tag/1.4.0" target="_blank">1.4.0</a></li>
+                 <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://github.com/Kotlin/kotlinx.html/releases/tag/0.7.2" target="_blank">0.7.2</a></li>
                  <li><a href="https://github.com/Kotlin/kotlinx-nodejs" target="_blank"><strong>kotlinx-nodejs</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.nodejs/0.0.6" target="_blank">0.0.6</a></li>
             </ul>
             <p>The versions of libraries from <code>kotlin-wrappers</code> (such as <code>kotlin-react</code>) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
@@ -85,15 +85,15 @@ The following table lists details of latest Kotlin releases.
         <td>
             <ul>
                 <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank"><strong>kotlinx.serialization</strong>
-                </a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.serialization.runtime/0.20.0" target="_blank">0.20.0</a></li>
+                </a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md#0200--2020-03-04" target="_blank">0.20.0</a></li>
                 <li><a href="https://github.com/Kotlin/kotlinx.coroutines" target="_blank"><strong>kotlinx.coroutines</strong></a>
-                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.coroutines/1.3.8" target="_blank">1.3.8
+                version: <a href="https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.8" target="_blank">1.3.8
                 </a></li>
                 <li><a href="https://github.com/Kotlin/kotlinx.atomicfu" target="_blank"><strong>kotlinx.atomicfu</strong></a>
-                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.atomicfu/0.14.2" target="_blank">0.14.2
+                version: <a href="https://github.com/Kotlin/kotlinx.atomicfu/releases/tag/0.14.2" target="_blank">0.14.2
                 </a></li>          
-                 <li><a href="https://ktor.io/" target="_blank"><strong>ktor</strong></a> version: <a href="https://bintray.com/kotlin/ktor/ktor/1.3.2" target="_blank">1.3.2</a></li>
-                 <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.html/0.7.1" target="_blank">0.7.1</a></li>
+                 <li><a href="https://ktor.io/" target="_blank"><strong>ktor</strong></a> version: <a href="https://github.com/ktorio/ktor/releases/tag/1.3.2" target="_blank">1.3.2</a></li>
+                 <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://github.com/Kotlin/kotlinx.html/releases/tag/0.7.1" target="_blank">0.7.1</a></li>
                  <li><a href="https://github.com/Kotlin/kotlinx-nodejs" target="_blank"><strong>kotlinx-nodejs</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.nodejs/0.0.3" target="_blank">0.0.3</a></li>
             </ul>
             <p>The versions of libraries from <code>kotlin-wrappers</code> (such as <code>kotlin-react</code>) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: Kotlin Releases
+---
+
+# Kotlin Releases
+
+We ship different types of releases:
+
+* _Feature releases_ (1._x_) that bring major changes in the language.
+* _Incremental releases_ (1._x_._y_) that are shipped between feature releases and include updates in the tooling, 
+performance improvements, and bug fixes.
+* _Bug fix releases_ (1._x_._yz_) that include bug fixes for incremental releases.
+
+For example, for the feature release 1.3 we had several incremental releases including 1.3.10, 1.3.20, and 1.3.70.
+For 1.3.70, we had 2 bug fix releases – 1.3.71 and 1.3.72.
+
+For each incremental and feature release, we also ship several [preview versions](eap/index.html) that allow you to try 
+new features before they are released (Early Access Preview).
+
+Learn more about [types of Kotlin releases and their compatiblity](docs/reference/evolution/kotlin-evolution.html#feature-releases-and-incremental-releases). 
+
+## Updating to a new release
+
+IntelliJ IDEA and Android Studio suggest updating to a new release once it is out. When you accept the suggestion,
+it automatically updates the Kotlin plugin to the new version. You can check the Kotlin version in **Tools** \| **Kotlin** 
+\| **Configure Plugin Updates**.
+
+If you have projects created with earlier Kotlin versions, change the Kotlin version in your projects and update kotlinx
+libraries if necessary – check [compatible versions](#release-details).
+
+If you are migrating to the new feature release, Kotlin plugin's migration tools will help you with the migration. Learn more
+about [migrating to Kotlin 1.4](docs/reference/whatsnew14.html#migrating-to-kotlin-14).
+
+## Release details
+
+The following table lists details of latest Kotlin releases.
+
+<table>
+    <tr>
+        <th>Build info</th>
+        <th>Build highlights</th>
+        <th>kotlinx library versions</th>
+    </tr>
+    <tr>
+        <td><strong>1.4.0</strong>
+            <p> Released: <strong>August 17, 2020</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v1.4.0" target="_blank">Release on GitHub</a></p>
+        </td>
+        <td>
+            <p>A feature release with many features and improvements that mostly focus on quality and performance.</p>
+            <p>Learn more in:</p>
+            <ul>
+                <li><a href="http://blog.jetbrains.com/kotlin/2020/08/kotlin-1-4-released-with-a-focus-on-quality-and-performance/" target="_blank">Release blog post</a></li>
+                <li><a href="docs/reference/whatsnew14.html" target="_blank">What's new in Kotlin 1.4.0</a></li>
+                <li><a href="docs/reference/compatibility-guide-14.html" target="_blank">Compatibility Guide</a></li>
+            </ul>
+         </td>
+        <td>
+            <ul>
+                <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank"><strong>kotlinx.serialization</strong>
+                </a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.serialization.runtime/1.0.0-rc" target="_blank">1.0.0-rc</a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx.coroutines" target="_blank"><strong>kotlinx.coroutines</strong></a>
+                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.coroutines/1.3.9" target="_blank">1.3.9
+                </a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx.atomicfu" target="_blank"><strong>kotlinx.atomicfu</strong></a>
+                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.atomicfu/0.14.4" target="_blank">0.14.4
+                </a></li>          
+                 <li><a href="https://ktor.io/" target="_blank"><strong>ktor</strong></a> version: <a href="https://bintray.com/kotlin/ktor/ktor/1.4.0" target="_blank">1.4.0</a></li>
+                 <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.html/0.7.2" target="_blank">0.7.2</a></li>
+                 <li><a href="https://github.com/Kotlin/kotlinx-nodejs" target="_blank"><strong>kotlinx-nodejs</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.nodejs/0.0.6" target="_blank">0.0.6</a></li>
+            </ul>
+            <p>The versions of libraries from `kotlin-wrappers` (`kotlin-react` etc.) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
+        </td>
+    </tr>       
+    <tr>
+        <td><strong>1.3.72</strong>
+            <p> Released: <strong>April 15, 2020</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v1.3.72" target="_blank">Release on GitHub</a></p>
+        </td>
+        <td>
+            <p>A bug fix release for Kotlin 1.3.70.</p>
+            <p>Learn more about <a href="hhttps://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/" target="_blank">Kotlin 1.3.70</a>.</p>
+         </td>
+        <td>
+            <ul>
+                <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank"><strong>kotlinx.serialization</strong>
+                </a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.serialization.runtime/0.20.0" target="_blank">0.20.0</a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx.coroutines" target="_blank"><strong>kotlinx.coroutines</strong></a>
+                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.coroutines/1.3.8" target="_blank">1.3.8
+                </a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx.atomicfu" target="_blank"><strong>kotlinx.atomicfu</strong></a>
+                version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.atomicfu/0.14.2" target="_blank">0.14.2
+                </a></li>          
+                 <li><a href="https://ktor.io/" target="_blank"><strong>ktor</strong></a> version: <a href="https://bintray.com/kotlin/ktor/ktor/1.3.2" target="_blank">1.3.2</a></li>
+                 <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.html/0.7.1" target="_blank">0.7.1</a></li>
+                 <li><a href="https://github.com/Kotlin/kotlinx-nodejs" target="_blank"><strong>kotlinx-nodejs</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.nodejs/0.0.3" target="_blank">0.0.3</a></li>
+            </ul>
+            <p>The versions of libraries from `kotlin-wrappers` (`kotlin-react` etc.) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
+        </td>
+    </tr>    
+</table>

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -61,7 +61,7 @@ You can also use [preview versions of Kotlin](eap/index.html#build-details).
         <td>
             <ul>
                 <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank"><strong>kotlinx.serialization</strong>
-                </a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md#100-rc--2020-08-17" target="_blank">1.0.0-rc</a></li>
+                </a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/releases/tag/1.0.0-RC" target="_blank">1.0.0-rc</a></li>
                 <li><a href="https://github.com/Kotlin/kotlinx.coroutines" target="_blank"><strong>kotlinx.coroutines</strong></a>
                 version: <a href="https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.9" target="_blank">1.3.9
                 </a></li>

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -27,7 +27,7 @@ it automatically updates the Kotlin plugin to the new version. You can check the
 \| **Configure Plugin Updates**.
 
 If you have projects created with earlier Kotlin versions, change the Kotlin version in your projects and update kotlinx
-libraries if necessary – check [compatible versions](#release-details).
+libraries if necessary – check the [recommended versions](#release-details).
 
 If you are migrating to the new feature release, Kotlin plugin's migration tools will help you with the migration.
 

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -29,8 +29,7 @@ it automatically updates the Kotlin plugin to the new version. You can check the
 If you have projects created with earlier Kotlin versions, change the Kotlin version in your projects and update kotlinx
 libraries if necessary – check [compatible versions](#release-details).
 
-If you are migrating to the new feature release, Kotlin plugin's migration tools will help you with the migration. Learn more
-about [migrating to Kotlin 1.4](docs/reference/whatsnew14.html#migrating-to-kotlin-14).
+If you are migrating to the new feature release, Kotlin plugin's migration tools will help you with the migration.
 
 ## Release details
 
@@ -54,6 +53,7 @@ The following table lists details of latest Kotlin releases.
                 <li><a href="http://blog.jetbrains.com/kotlin/2020/08/kotlin-1-4-released-with-a-focus-on-quality-and-performance/" target="_blank">Release blog post</a></li>
                 <li><a href="docs/reference/whatsnew14.html" target="_blank">What's new in Kotlin 1.4.0</a></li>
                 <li><a href="docs/reference/compatibility-guide-14.html" target="_blank">Compatibility Guide</a></li>
+                <li><a href="docs/reference/whatsnew14.html#migrating-to-kotlin-14" target="_blank">Migrating to Kotlin 1.4.0</a></li>
             </ul>
          </td>
         <td>
@@ -70,7 +70,7 @@ The following table lists details of latest Kotlin releases.
                  <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.html/0.7.2" target="_blank">0.7.2</a></li>
                  <li><a href="https://github.com/Kotlin/kotlinx-nodejs" target="_blank"><strong>kotlinx-nodejs</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.nodejs/0.0.6" target="_blank">0.0.6</a></li>
             </ul>
-            <p>The versions of libraries from `kotlin-wrappers` (`kotlin-react` etc.) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
+            <p>The versions of libraries from <code>kotlin-wrappers</code> (such as <code>kotlin-react</code>) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
         </td>
     </tr>       
     <tr>
@@ -96,7 +96,7 @@ The following table lists details of latest Kotlin releases.
                  <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.html/0.7.1" target="_blank">0.7.1</a></li>
                  <li><a href="https://github.com/Kotlin/kotlinx-nodejs" target="_blank"><strong>kotlinx-nodejs</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.nodejs/0.0.3" target="_blank">0.0.3</a></li>
             </ul>
-            <p>The versions of libraries from `kotlin-wrappers` (`kotlin-react` etc.) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
+            <p>The versions of libraries from <code>kotlin-wrappers</code> (such as <code>kotlin-react</code>) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
         </td>
     </tr>    
 </table>

--- a/pages/releases.md
+++ b/pages/releases.md
@@ -101,6 +101,5 @@ The following table lists details of latest Kotlin releases.
     </tr>    
 </table>
 
-> On the JVM, you usually can use library versions other than the recommended ones. However, we don't guarantee the compatibility
->in such cases. 
+> On the JVM, you usually can use library versions other than the recommended ones.
 {:.note}

--- a/templates/inc/footer.html
+++ b/templates/inc/footer.html
@@ -24,6 +24,8 @@
                         <p class="terms-para"><a class="terms-kit"
                               href="/contribute.html">Contributing to Kotlin</a></p>
                     <p class="terms-para"><a class="terms-kit"
+                                             href="/releases.html">Releases</a></p>
+                    <p class="terms-para"><a class="terms-kit"
                                              href="/eap/">Early Access Preview</a></p>
                     <p class="terms-para"><a class="terms-kit"
                                              href="/security.html">Security</a></p>

--- a/templates/inc/footer.html
+++ b/templates/inc/footer.html
@@ -26,8 +26,6 @@
                     <p class="terms-para"><a class="terms-kit"
                                              href="/releases.html">Releases</a></p>
                     <p class="terms-para"><a class="terms-kit"
-                                             href="/eap/">Early Access Preview</a></p>
-                    <p class="terms-para"><a class="terms-kit"
                                              href="/security.html">Security</a></p>
                         <p class="terms-para"><a class="terms-kit"
                               href={{ url_for('asset', path='kotlin-media-kit.pdf') }}>Press kit</a></p>


### PR DESCRIPTION
Added a Kotlin Releases page with a general description of releases and details of latest releases. The page is included in the footer for now.