### PR TITLE
Use the correct version for serialization compiler plugin on the serialization feature page

### DIFF
--- a/pages/docs/reference/serialization.md
+++ b/pages/docs/reference/serialization.md
@@ -66,7 +66,7 @@ in the Kotlin Gradle DSL).
     ```groovy
     plugins {
         id 'org.jetbrains.kotlin.jvm' version '{{ site.data.releases.latest.version }}'
-        id 'org.jetbrains.kotlin.plugin.serialization' '{{ site.data.releases.latest.serialization.version }}'  
+        id 'org.jetbrains.kotlin.plugin.serialization' '{{ site.data.releases.latest.version }}'  
     }
     ```
     
@@ -79,7 +79,7 @@ in the Kotlin Gradle DSL).
     ```kotlin
     plugins {
         kotlin("jvm") version "{{ site.data.releases.latest.version }}"
-        kotlin("plugin.serialization") version "{{ site.data.releases.latest.serialization.version }}"
+        kotlin("plugin.serialization") version "{{ site.data.releases.latest.version }}"
     }
     ```
     


### PR DESCRIPTION
According to the documentation of https://github.com/Kotlin/kotlinx.serialization, the version of the compiler plugin is still aligned with the Kotlin version. Additionally, version "1.0.0-RC" does not exist for the plugin. Therefore I assume that this is a mistake on the website.

I couldn't find any contribution guidelines so please let me know if there is anything else I should do.