### PR TITLE
Fix broken link to Kotlin serialization guide

### DIFF
--- a/pages/docs/reference/whatsnew14.md
+++ b/pages/docs/reference/whatsnew14.md
@@ -1673,7 +1673,7 @@ stable. Libraries for other serialization formats remain experimental, along wit
 We have significantly reworked the API for JSON serialization to make it more consistent and easier to use. From now on,
 we'll continue developing the JSON serialization API in a backward-compatible manner.
 However, if you have used previous versions of it, you'll need to rewrite some of your code when migrating to 1.0.0-RC.
-To help you with this, we also offer the [Kotlin Serialization Guide](https://github.com/Kotlin/kotlinx.serialization/docs/serialization-guide.md) –
+To help you with this, we also offer the [Kotlin Serialization Guide](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md) –
 the complete set of documentation for `kotlinx.serialization`. It will guide you through the process of using the most
 important features and it can help you address any issues that you might face.
 


### PR DESCRIPTION
The link to the Kotlin serialization guide was broken as it didn't include the branch in the path.