### PR TITLE
fix: fixed a link to serialization guide and Java example

### DIFF
--- a/pages/docs/reference/whatsnew14.md
+++ b/pages/docs/reference/whatsnew14.md
@@ -622,7 +622,7 @@ which is the way you’d naturally expect it to work.
 ```java
 // FILE: A.java
 public class A {
-    public void static foo(Runnable r1, Runnable r2) {}
+    public static void foo(Runnable r1, Runnable r2) {}
 }
 ```
 
@@ -1673,7 +1673,7 @@ stable. Libraries for other serialization formats remain experimental, along wit
 We have significantly reworked the API for JSON serialization to make it more consistent and easier to use. From now on,
 we'll continue developing the JSON serialization API in a backward-compatible manner.
 However, if you have used previous versions of it, you'll need to rewrite some of your code when migrating to 1.0.0-RC.
-To help you with this, we also offer the [Kotlin Serialization Guide](https://github.com/Kotlin/kotlinx.serialization/docs/serialization-guide.md) –
+To help you with this, we also offer the [Kotlin Serialization Guide](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md) –
 the complete set of documentation for `kotlinx.serialization`. It will guide you through the process of using the most
 important features and it can help you address any issues that you might face.
 


### PR DESCRIPTION
Fixed a link to serialization guide and Java example in What's new in Kotlin 1.4.0