### PR TITLE
Fix broken sample in mixing named - position args section

### DIFF
--- a/pages/docs/reference/whatsnew14.md
+++ b/pages/docs/reference/whatsnew14.md
@@ -208,13 +208,13 @@ arguments. Moreover, you can mix positional and named arguments any way you like
 fun reformat(
     str: String,
     uppercaseFirstLetter: Boolean = true,
-    wordSeparator: Character = ' '
+    wordSeparator: Char = ' '
 ) {
     // ...
 }
 
 //Function call with a named argument in the middle
-reformat('This is a String!', uppercaseFirstLetter = false , '-')
+reformat("This is a String!", uppercaseFirstLetter = false , '-')
 ```
 
 </div>


### PR DESCRIPTION
The code sample shown in [mixing named and positional arguments section](https://kotlinlang.org/docs/reference/whatsnew14.html#mixing-named-and-positional-arguments) is broken.

Updated the code with the following changes to fix it:
* Replace single quote with double quote for first parameter in `reformat` function
* Replace type of 3rd parameter `Character` to `kotlin.Char`