### PR TITLE
Java class and primitives

### DIFF
--- a/pages/docs/reference/java-interop.md
+++ b/pages/docs/reference/java-interop.md
@@ -706,6 +706,8 @@ To access static members of a Java type that is [mapped](#mapped-types) to a Kot
 
 Java reflection works on Kotlin classes and vice versa. As mentioned above, you can use `instance::class.java`,
 `ClassName::class.java` or `instance.javaClass` to enter Java reflection through `java.lang.Class`.
+Do not use `ClassName.javaClass` for this purpose because it refers to `ClassName`'s companion object class,
+which is the same as `ClassName.Companion::class.java` and not `ClassName::class.java`.
 You may also use `ClassName::class.javaObjectType` for getting primitive types wrappers.
 
 Other supported cases include acquiring a Java getter/setter method or a backing field for a Kotlin property, a `KProperty` for a Java field, a Java method or constructor for a `KFunction` and vice versa.

--- a/pages/docs/reference/java-interop.md
+++ b/pages/docs/reference/java-interop.md
@@ -708,7 +708,10 @@ Java reflection works on Kotlin classes and vice versa. As mentioned above, you 
 `ClassName::class.java` or `instance.javaClass` to enter Java reflection through `java.lang.Class`.
 Do not use `ClassName.javaClass` for this purpose because it refers to `ClassName`'s companion object class,
 which is the same as `ClassName.Companion::class.java` and not `ClassName::class.java`.
-You may also use `ClassName::class.javaObjectType` for getting primitive types wrappers.
+For each primitive type, there are two different Java classes, and Kotlin provides ways to get both. For
+example, `Int::class.java` will return the class instance representing the primitive type itself,
+corresponding to `Integer.TYPE` in Java. To get the class of the corresponding wrapper type, use
+`Int::class.javaObjectType`, which is equivalent of Java's `Integer.class`.
 
 Other supported cases include acquiring a Java getter/setter method or a backing field for a Kotlin property, a `KProperty` for a Java field, a Java method or constructor for a `KFunction` and vice versa.
 


### PR DESCRIPTION
Three separate things in a single PR because they are small enough, and yet, I believe they are important.

First, the fact that `ClassName.javaClass` is *not* the same as `ClassName::class.java`.

Second, the difference between `Integer::class.java` and `Int::class.javaObjectType` (and the same similar primitive wrapper types).

Third, the difference between `Int::class.java` and `Int::class.javaObjectType` (the previous change to this section only explained the latter).