### PR TITLE
import as instead of private typealias

### DIFF
--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -875,6 +875,9 @@ typealias PersonIndex = Map<String, Person>
 
 </div>
 
+If you use a private or internal type alias for avoiding name collision, prefer the `import … as …` mentionned in 
+[Packages and Imports](packages.html).
+
 ### Lambda parameters
 
 In lambdas which are short and not nested, it's recommended to use the `it` convention instead of declaring the parameter


### PR DESCRIPTION
because "import ... as ..." can remain unknown when using "typealias".