### PR TITLE
Fixed typo in Doc of Object Declarations

### DIFF
--- a/pages/docs/reference/object-declarations.md
+++ b/pages/docs/reference/object-declarations.md
@@ -128,7 +128,7 @@ object DataProviderManager {
 </div>
 
 This is called an *object declaration*, and it always has a name following the *object*{: .keyword } keyword.
-Just like a variable declaration, an object declaration is not an expression, and cannot be used on the right hand side of an assignment statement.
+Unlike a variable declaration, an object declaration is not an expression, and cannot be used on the right hand side of an assignment statement.
 
 Object declaration's initialization is thread-safe and done at first access.
 


### PR DESCRIPTION
Noticed a slight mistake in the documentation of object declarations. It says just like and goes ahead to show differences. I feel it should use unlike or a similar synonym