### PR TITLE
Update operator-overloading.md

### DIFF
--- a/pages/docs/reference/operator-overloading.md
+++ b/pages/docs/reference/operator-overloading.md
@@ -69,7 +69,7 @@ The compiler performs the following steps for resolution of an operator in the *
 The effect of computing the expression is:
 
 * Store the initial value of `a` to a temporary storage `a0`;
-* Assign the result of `a.inc()` to `a`;
+* Assign the result of `a0.inc()` to `a`;
 * Return `a0` as a result of the expression.
 
 For `a--` the steps are completely analogous.


### PR DESCRIPTION
This matches what's actually generated by the compiler, at least for the JVM backend (didn't verify on other backends). Using `a.inc()` would be incorrect because `a` could be an expression with side-effects and hence would be evaluated twice: Once during initialization of `a0`, and then again in that step.