### PR TITLE
Fix broken formatting and typo

### DIFF
--- a/pages/docs/reference/compatibility-guide-14.md
+++ b/pages/docs/reference/compatibility-guide-14.md
@@ -348,8 +348,8 @@ Remember that those definitions are given only for pure Kotlin. Compatibility of
 > - \>= 1.4: behavior changed,
 > `-XXLanguage:-NewInference` can be used to temporarily revert to pre-1.4 behavior. Note that this flag will also
 > disable several new language features.
->
-### Prohibit `tailrec` modifier on`open` functions
+
+### Prohibit `tailrec` modifier on `open` functions
 
 > **Issue**: [KT-18541](https://youtrack.jetbrains.com/issue/KT-18541)
 > 


### PR DESCRIPTION
Fixes this glitch and spacing between word and keyword.

![image](https://user-images.githubusercontent.com/2906988/93756644-4fa91480-fbfd-11ea-96ea-581a7282bcc9.png)
