### PR TITLE
Missing version keyword for Gradle plugin

### DIFF
--- a/pages/docs/reference/serialization.md
+++ b/pages/docs/reference/serialization.md
@@ -66,7 +66,7 @@ in the Kotlin Gradle DSL).
     ```groovy
     plugins {
         id 'org.jetbrains.kotlin.jvm' version '{{ site.data.releases.latest.version }}'
-        id 'org.jetbrains.kotlin.plugin.serialization' '{{ site.data.releases.latest.version }}'  
+        id 'org.jetbrains.kotlin.plugin.serialization' version '{{ site.data.releases.latest.version }}'  
     }
     ```
     


### PR DESCRIPTION
Missing `version` keyword.