### PR TITLE
Fix broken newline

### DIFF
--- a/pages/docs/reference/java-interop.md
+++ b/pages/docs/reference/java-interop.md
@@ -490,8 +490,8 @@ They are not related to the `Array` class and are compiled down to Java's primit
 
 Suppose there is a Java method that accepts an int array of indices:
 
-
 <div class="sample" markdown="1" theme="idea" mode="java">
+
 ``` java
 public class JavaArrayExample {
 


### PR DESCRIPTION
The [official website](https://kotlinlang.org/docs/reference/java-interop.html#java-arrays) is correct, but the [markdown format](https://github.com/JetBrains/kotlin-web-site/blob/master/pages/docs/reference/java-interop.md#java-arrays) is broken.