### PR TITLE
Fix in create anonymous objects and the supertype

### DIFF
--- a/pages/docs/reference/object-declarations.md
+++ b/pages/docs/reference/object-declarations.md
@@ -73,7 +73,7 @@ class C {
     }
 
     // Public function, so the return type is Any
-    fun publicFoo() = object {
+    fun publicFoo() = {
         val x: String = "x"
     }
 


### PR DESCRIPTION
To describe `ERROR: Unresolved reference 'x'` error you should remove `object` from the `publicFoo()` method.

Playground test based on wrong documentation:
```
https://pl.kotl.in/83dNsbq5e
```

Playground test based on new documentation:

```
https://pl.kotl.in/OjLcqFynC
```