### PR TITLE
Improve the convention on expresion bodies

### DIFF
--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -517,14 +517,14 @@ fun foo() = 1        // good
 
 ### Expression body formatting
 
-If the function has an expression body that doesn't fit in the same line as the declaration, put the `=` sign on the first line.
-Indent the expression body by four spaces.
+If the function has an expression body whose first line doesn't fit on the same line as the declaration, put the `=` sign on the first line,
+and indent the expression body by four spaces.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only auto-indent="false">
 
 ```kotlin
-fun f(x: String) =
-    x.length
+fun f(x: String, y: String, z: String) =
+    veryLongFunctionCallWithManyWords(andLongParametersToo(), x, y, z)
 ```
 
 </div>


### PR DESCRIPTION
Replace the previous snippet with a better example,
and specify that we're talking about the first line of the expression body.

See misinterpretation of the previous convention wording in this PR: https://github.com/LouisCAD/kotlin-libraries-playground/pull/68#discussion_r505742093