### PR TITLE
Fix typo from SMT32 to STM32

### DIFF
--- a/pages/docs/tutorials/native/using-command-line-compiler.md
+++ b/pages/docs/tutorials/native/using-command-line-compiler.md
@@ -15,7 +15,7 @@ date: 2020-01-15
 
 The Kotlin/Native compiler is available for macOS, Linux, and Windows. It is available as a command line tool and ships as part of the standard Kotlin distribution and can be downloaded from [GitHub Releases]({{ site.data.releases.latest.url }}). It supports
 different targets including iOS (arm32, arm64, simulator x86_64), Windows (mingw32 and x86_64),
-Linux (x86_64, arm64, MIPS), macOS (x86_64), Raspberry PI, SMT32, WASM. For the full list of targets please see the [Kotlin/Native overview](/docs/reference/native-overview.html). 
+Linux (x86_64, arm64, MIPS), macOS (x86_64), Raspberry PI, STM32, WASM. For the full list of targets please see the [Kotlin/Native overview](/docs/reference/native-overview.html). 
 
 While cross-platform compilation is possible, which means using one platform to compile for a different one, 
 in this case we'll be targeting the same platform we're compiling on.  


### PR DESCRIPTION
Dearest,

I just fixed it to get more impact in the search engines on the Web.

Regards.