### PR TITLE
Typo fix

### DIFF
--- a/pages/docs/reference/js-ir-compiler.md
+++ b/pages/docs/reference/js-ir-compiler.md
@@ -22,8 +22,8 @@ The IR compiler backend is available starting with Kotlin 1.4.0 through the Kotl
 kotlin {
     js(IR) { // or: LEGACY, BOTH
         // . . .
+        binaries.executable()
     }
-    binaries.executable()
 }
 ```
 


### PR DESCRIPTION
I was going through this to build a library to be called from TypeScript/React. 
I got these errors. 

Unresolved reference: binaries
Please initialize the Kotlin/JS target. Use:
kotlin {
    js {
        // To build distributions for and run tests on browser or Node.js use one or both of:
        browser()
        nodejs()
    }
}


Moving binaries.executable to the js block fixed it. 
I may be wrong, but I thought it is a typo, so raising a PR for the same.