### PR TITLE
Add "Add support for a new target platform" page

### DIFF
--- a/pages/docs/reference/mpp-add-new-target-platform.md
+++ b/pages/docs/reference/mpp-add-new-target-platform.md
@@ -1,0 +1,9 @@
+---
+type: doc
+layout: reference
+title: "Add support for a new target platform"
+---
+
+# Add support for a new target platform
+
+TODO

--- a/pages/docs/reference/mpp-supported-platforms.md
+++ b/pages/docs/reference/mpp-supported-platforms.md
@@ -89,3 +89,5 @@ Kotlin supports the following platforms and provides target presets for each pla
 
 > A target that is not supported by the current host is ignored during building and therefore not published.
 {:.note}
+
+If you'd like to contribute to Kotlin and add support for a new platform, see [Add support for a new target platform](mpp-add-new-target-platform.html).


### PR DESCRIPTION
Hi Kotlin Team!

This PR is just a stub of what I'm planning to add, seeking initial feedback from you. Not ready to merge. Read on for some context.

I'm now working on adding Python backend, see https://discuss.kotlinlang.org/t/idea-python-backend/19852. I have to dig through the code and learn how things work. I thought it would be beneficial to create a page in the docs that summarizes the most important information, both to help with my Python backend effort, and to encourage contributions for other platforms.

In the new docs page, with your help, I'm planning to add info like:
* overview of pieces that have to be implemented, with examples using existing officially supported target platforms
* current state of compiler's internals and interfaces (e.g. maybe right now it's not the best moment to integrate because there are plans to heavily rework compiler's internal APIs?)
* how to implement mapping from Kotlin IR to a specific language
* guidelines, e.g. going though an Abstract Syntax Tree for a given language, and not directly IR -> code
* guidelines on integrating with existing target platform's ecosystem, dos and donts

Best,
Piotr