### PR TITLE
Added missing `override` modifiers

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -465,7 +465,7 @@ Inside an inner class, accessing the superclass of the outer class is done with 
 
 ```kotlin
 class FilledRectangle: Rectangle() {
-    fun draw() { /* ... */ }
+    override fun draw() { /* ... */ }
     val borderColor: String get() = "black"
     
     inner class Filler {


### PR DESCRIPTION
Added missing `overrde` modifiers in [Classes and Inheritance](https://kotlinlang.org/docs/reference/classes.html) page