### PR TITLE
Fix args for main()

### DIFF
--- a/pages/docs/tutorials/command-line.md
+++ b/pages/docs/tutorials/command-line.md
@@ -67,7 +67,7 @@ $ sudo snap install --classic kotlin
    <div class="sample" markdown="1" theme="idea">
 
    ```kotlin
-   fun main(args: Array<String>) {
+   fun main() {
        println("Hello, World!")
    }
    ```


### PR DESCRIPTION
Removing unnecessary args from the sample "Hello, world" - generates a warning that may confuse newbies