### PR TITLE
feat: Kotlin for py redirects

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -493,16 +493,6 @@ tutorials:
           title: Learning Kotlin with EduTools plugin
         - url: /docs/tutorials/edu-tools-educator.html
           title: Teaching Kotlin with EduTools plugin
-    - title: Migrating from Python
-      external:
-        path: kotlin-for-python-developers
-        nav: kotlinlang.org.yaml
-        base: /docs/tutorials/kotlin-for-py
-        branch: master
-        repo: https://github.com/Khan/kotlin-for-python-developers
-        type: tutorial
-        wrap_code_snippets: True
-        github_edit_page: README.md
 
 foundation:
   content:

--- a/pages/docs/tutorials/kotlin-for-py/annotations.md
+++ b/pages/docs/tutorials/kotlin-for-py/annotations.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#annotations
+---

--- a/pages/docs/tutorials/kotlin-for-py/classes.md
+++ b/pages/docs/tutorials/kotlin-for-py/classes.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#classes
+---

--- a/pages/docs/tutorials/kotlin-for-py/collections.md
+++ b/pages/docs/tutorials/kotlin-for-py/collections.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#collections
+---

--- a/pages/docs/tutorials/kotlin-for-py/compiling-and-running.md
+++ b/pages/docs/tutorials/kotlin-for-py/compiling-and-running.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#compiling-and-running
+---

--- a/pages/docs/tutorials/kotlin-for-py/conditionals.md
+++ b/pages/docs/tutorials/kotlin-for-py/conditionals.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#conditionals
+---

--- a/pages/docs/tutorials/kotlin-for-py/declaring-variables.md
+++ b/pages/docs/tutorials/kotlin-for-py/declaring-variables.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#declaring-variables
+---

--- a/pages/docs/tutorials/kotlin-for-py/documentation.md
+++ b/pages/docs/tutorials/kotlin-for-py/documentation.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#documentation
+---

--- a/pages/docs/tutorials/kotlin-for-py/exceptions.md
+++ b/pages/docs/tutorials/kotlin-for-py/exceptions.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#exceptions
+---

--- a/pages/docs/tutorials/kotlin-for-py/extension-functionsproperties.md
+++ b/pages/docs/tutorials/kotlin-for-py/extension-functionsproperties.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#extensions-functionsproperties
+---

--- a/pages/docs/tutorials/kotlin-for-py/extension-functionsproperties.md
+++ b/pages/docs/tutorials/kotlin-for-py/extension-functionsproperties.md
@@ -1,3 +1,3 @@
 ---
-redirect_path: https://khan.github.io/kotlin-for-python-developers/#extensions-functionsproperties
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#extension-functionsproperties
 ---

--- a/pages/docs/tutorials/kotlin-for-py/file-io.md
+++ b/pages/docs/tutorials/kotlin-for-py/file-io.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#file-io
+---

--- a/pages/docs/tutorials/kotlin-for-py/functional-programming.md
+++ b/pages/docs/tutorials/kotlin-for-py/functional-programming.md
@@ -1,3 +1,3 @@
 ---
-redirect_path: https://khan.github.io/kotlin-for-python-developers/#functional-progrmming
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#functional-programming
 ---

--- a/pages/docs/tutorials/kotlin-for-py/functional-programming.md
+++ b/pages/docs/tutorials/kotlin-for-py/functional-programming.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#functional-progrmming
+---

--- a/pages/docs/tutorials/kotlin-for-py/functions.md
+++ b/pages/docs/tutorials/kotlin-for-py/functions.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#functions
+---

--- a/pages/docs/tutorials/kotlin-for-py/generics.md
+++ b/pages/docs/tutorials/kotlin-for-py/generics.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#generics
+---

--- a/pages/docs/tutorials/kotlin-for-py/hello-world.md
+++ b/pages/docs/tutorials/kotlin-for-py/hello-world.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#hello-world
+---

--- a/pages/docs/tutorials/kotlin-for-py/inheritance.md
+++ b/pages/docs/tutorials/kotlin-for-py/inheritance.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#inheritance
+---

--- a/pages/docs/tutorials/kotlin-for-py/introduction.md
+++ b/pages/docs/tutorials/kotlin-for-py/introduction.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/
+---

--- a/pages/docs/tutorials/kotlin-for-py/loops.md
+++ b/pages/docs/tutorials/kotlin-for-py/loops.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#loops
+---

--- a/pages/docs/tutorials/kotlin-for-py/member-references-and-reflection.md
+++ b/pages/docs/tutorials/kotlin-for-py/member-references-and-reflection.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#member-references-and-reflection
+---

--- a/pages/docs/tutorials/kotlin-for-py/null-safety.md
+++ b/pages/docs/tutorials/kotlin-for-py/null-safety.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#null-safety
+---

--- a/pages/docs/tutorials/kotlin-for-py/objects-and-companion-objects.md
+++ b/pages/docs/tutorials/kotlin-for-py/objects-and-companion-objects.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#objects-and-companion-objects
+---

--- a/pages/docs/tutorials/kotlin-for-py/packages-and-imports.md
+++ b/pages/docs/tutorials/kotlin-for-py/packages-and-imports.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#packages-and-imports
+---

--- a/pages/docs/tutorials/kotlin-for-py/primitive-data-types-and-their-limitations.md
+++ b/pages/docs/tutorials/kotlin-for-py/primitive-data-types-and-their-limitations.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#primitive-data-types-and-their-limitations
+---

--- a/pages/docs/tutorials/kotlin-for-py/scoped-resource-usage.md
+++ b/pages/docs/tutorials/kotlin-for-py/scoped-resource-usage.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#scoped-resource-usage
+---

--- a/pages/docs/tutorials/kotlin-for-py/strings.md
+++ b/pages/docs/tutorials/kotlin-for-py/strings.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#strings
+---

--- a/pages/docs/tutorials/kotlin-for-py/visibility-modifiers.md
+++ b/pages/docs/tutorials/kotlin-for-py/visibility-modifiers.md
@@ -1,0 +1,3 @@
+---
+redirect_path: https://khan.github.io/kotlin-for-python-developers/#visibility-modifiers
+---


### PR DESCRIPTION
Added stub pages for kotlin-for-py tutorial redirects.
Removed kotlin-for-py from navigation.