### PR TITLE
Fix example

### DIFF
--- a/pages/docs/reference/control-flow.md
+++ b/pages/docs/reference/control-flow.md
@@ -147,7 +147,7 @@ If no argument is supplied, the branch conditions are simply boolean expressions
 when {
     x.isOdd() -> print("x is odd")
     y.isEven() -> print("y is even")
-    else -> print("x+y is even.")
+    else -> print("x+y is odd.")
 }
 ```
 


### PR DESCRIPTION
In the example it should be that `x+y` is odd.

In order to get to the `else` clause `x` must even and `y` must be odd, so `x+y` is odd. 
Example `x=2; y=1; x+y=3`.
