### PR TITLE
update: clarify propagation of `copy` function

### DIFF
--- a/pages/docs/reference/data-classes.md
+++ b/pages/docs/reference/data-classes.md
@@ -119,6 +119,28 @@ val olderJack = jack.copy(age = 2)
 
 </div>
 
+Note that the `copy()` call performs shallow copy, meaning that it doesn't propagate recursively through attributes:
+
+<div class="sample" markdown="1" theme="idea" data-highlight-only>
+
+```kotlin
+data class User(var name : String)
+
+data class Address(var user: User, var city: String)
+
+var userJack = User(name="jack")
+var address = Address(user = userJack, city = "London")
+var addressCopy = address.copy()
+
+address.city = "New York"
+address.user.name = "john"
+
+println(addressCopy.city)  // prints "London"
+println(addressCopy.user.name)  // prints "john", because `address.user === addressCopy.user`
+```
+
+</div>
+
 ## Data Classes and Destructuring Declarations
 
 _Component functions_ generated for data classes enable their use in [destructuring declarations](multi-declarations.html):

--- a/pages/docs/reference/data-classes.md
+++ b/pages/docs/reference/data-classes.md
@@ -119,7 +119,7 @@ val olderJack = jack.copy(age = 2)
 
 </div>
 
-Note that the `copy()` call performs shallow copy, meaning that it doesn't propagate recursively through attributes:
+Note that the `copy()` call performs a shallow copy, meaning that the copy's reference properties point to the _same objects_ as the original object's references. However, the copy has its own primitive properties not linked to the original.
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 

--- a/pages/docs/reference/data-classes.md
+++ b/pages/docs/reference/data-classes.md
@@ -121,22 +121,27 @@ val olderJack = jack.copy(age = 2)
 
 Note that the `copy()` call performs a shallow copy, meaning that the copy's reference properties point to the _same objects_ as the original object's references. However, the copy has its own primitive properties not linked to the original.
 
-<div class="sample" markdown="1" theme="idea" data-highlight-only>
+<div class="sample" markdown="1" theme="idea">
 
 ```kotlin
 data class User(var name : String)
 
 data class Address(var user: User, var city: String)
 
-var userJack = User(name="jack")
-var address = Address(user = userJack, city = "London")
-var addressCopy = address.copy()
+fun main() {
+//sampleStart
 
-address.city = "New York"
-address.user.name = "john"
+    var userJack = User(name="Jack")
+    var address = Address(user = userJack, city = "London")
+    var addressCopy = address.copy()
 
-println(addressCopy.city)  // prints "London"
-println(addressCopy.user.name)  // prints "john", because `address.user === addressCopy.user`
+    addressCopy.city = "New York"
+    addressCopy.user.name = "John"  // Propagates to `address.user` because they both point to userJack.
+
+//sampleEnd
+    println("address.city is ${address.city}")  // Prints "London"
+    println("address.user.name is ${address.user.name}")  // Prints "John"
+}
 ```
 
 </div>


### PR DESCRIPTION
Clarify that the default `copy` implementation performs a shallow copy.

For people coming from some languages this might not be immediately clear (in C++ the copy constructor usually performs a deep copy, in python there are `copy` and `deepcopy`).

Perhaps the example code is not needed, but I decided to include it in the pull request.