### PR TITLE
Update idioms.md Fixed a typo in line 406."toolwindow" to "tool window"

### DIFF
--- a/pages/docs/reference/idioms.md
+++ b/pages/docs/reference/idioms.md
@@ -403,5 +403,5 @@ There's also an overload that accepts a reason parameter:
 fun calcTaxes(): BigDecimal = TODO("Waiting for feedback from accounting")
 ```
 
-IntelliJ IDEA's kotlin plugin understands the semantics of `TODO()` and automatically adds a code pointer in the TODO toolwindow. 
+IntelliJ IDEA's kotlin plugin understands the semantics of `TODO()` and automatically adds a code pointer in the TODO tool window. 
 


### PR DESCRIPTION
Fixed a typo in Line 406. 'toolwindow' to 'tool window'.