### PR TITLE
fix: adhere to coding conventions in tailrec example

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -462,8 +462,8 @@ When a function is marked with the `tailrec` modifier and meets the required for
 ```kotlin
 val eps = 1E-10 // "good enough", could be 10^-15
 
-tailrec fun findFixPoint(x: Double = 1.0): Double
-        = if (Math.abs(x - Math.cos(x)) < eps) x else findFixPoint(Math.cos(x))
+tailrec fun findFixPoint(x: Double = 1.0): Double =
+    if (Math.abs(x - Math.cos(x)) < eps) x else findFixPoint(Math.cos(x))
 ```
 </div>
 


### PR DESCRIPTION
Make tailrec example function definition adhere to the ["Expression Body Formatting" from the coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#expression-body-formatting)