### PR TITLE
Added a comma between "In Kotlin" and "functions"

### DIFF
--- a/pages/docs/reference/functions.md
+++ b/pages/docs/reference/functions.md
@@ -362,7 +362,7 @@ class MyStringCollection {
 
 ## Function scope
 
-In Kotlin functions can be declared at top level in a file, meaning you do not need to create a class to hold a function, which you are required to do in languages such as Java, C# or Scala. In addition
+In Kotlin, functions can be declared at top level in a file, meaning you do not need to create a class to hold a function, which you are required to do in languages such as Java, C# or Scala. In addition
 to top level functions, Kotlin functions can also be declared local, as member functions and extension functions.
 
 ### Local functions


### PR DESCRIPTION
Fixed a grammatical error where there should be a comma between "In Kotlin" and "functions."