### PR TITLE
Unify executable creation for the browser target

### DIFF
--- a/pages/docs/reference/javascript-dce.md
+++ b/pages/docs/reference/javascript-dce.md
@@ -43,8 +43,8 @@ kotlin {
             dceTask {
                 keep("myKotlinJSModule.org.example.getName", "myKotlinJSModule.org.example.User" )
             }
-            binaries.executable()
         }
+        binaries.executable()
     }
 }
 ```


### PR DESCRIPTION
The idiomatic way to create JS binaries seems to be after the browser block instead of inside it.