### PR TITLE
Update to use the proper kotlinx-html jar reference

### DIFF
--- a/pages/docs/tutorials/javascript/typesafe-html-dsl.md
+++ b/pages/docs/tutorials/javascript/typesafe-html-dsl.md
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-js"))
-    implementation("org.jetbrains.kotlinx:kotlinx-html-js:0.7.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.1")
     // ...
 }
 ```


### PR DESCRIPTION
An app will not compile with the kotlinx-html-js reference. It fails in the 
compileKotlinJs step. Using kotlinx-html fixes the problem.