### PR TITLE
chore: fix formatting of control flow statements

### DIFF
--- a/pages/docs/reference/exceptions.md
+++ b/pages/docs/reference/exceptions.md
@@ -31,11 +31,9 @@ To catch an exception, use the *try*{: .keyword }-expression:
 ```kotlin
 try {
     // some code
-}
-catch (e: SomeException) {
+} catch (e: SomeException) {
     // handler
-}
-finally {
+} finally {
     // optional finally block
 }
 ```
@@ -78,8 +76,7 @@ So it results in this kind of code all over the place:
 ```kotlin
 try {
     log.append(message)
-}
-catch (IOException e) {
+} catch (IOException e) {
     // Must be safe
 }
 ```

--- a/pages/docs/reference/inline-functions.md
+++ b/pages/docs/reference/inline-functions.md
@@ -28,8 +28,7 @@ Instead of creating a function object for the parameter and generating a call, t
 l.lock()
 try {
     foo()
-}
-finally {
+} finally {
     l.unlock()
 }
 ```

--- a/pages/docs/reference/java-to-kotlin-interop.md
+++ b/pages/docs/reference/java-to-kotlin-interop.md
@@ -566,8 +566,7 @@ And we want to call it from Java and catch the exception:
 // Java
 try {
   demo.Example.writeToFile();
-}
-catch (IOException e) { // error: writeToFile() does not declare IOException in the throws list
+} catch (IOException e) { // error: writeToFile() does not declare IOException in the throws list
   // ...
 }
 ```

--- a/pages/docs/reference/typecasts.md
+++ b/pages/docs/reference/typecasts.md
@@ -20,8 +20,7 @@ if (obj is String) {
 
 if (obj !is String) { // same as !(obj is String)
     print("Not a String")
-}
-else {
+} else {
     print(obj.length)
 }
 ```


### PR DESCRIPTION
Fix formatting to adhere to https://kotlinlang.org/docs/reference/coding-conventions.html#formatting-control-flow-statements