### PR TITLE
Fix link titles referring to the "Properties" page

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -129,7 +129,7 @@ reference:
         - url: /docs/reference/classes.html
           title: Classes and Inheritance
         - url: /docs/reference/properties.html
-          title: Properties and Fields
+          title: Properties
         - url: /docs/reference/interfaces.html
           title: Interfaces
         - url: /docs/reference/fun-interfaces.html

--- a/pages/docs/reference/basic-syntax.md
+++ b/pages/docs/reference/basic-syntax.md
@@ -182,7 +182,7 @@ fun main() {
 
 </div>
 
-See also [Properties And Fields](properties.html).
+See also [Properties](properties.html).
 
 
 ## Comments


### PR DESCRIPTION
After we changed the target page title in the merge request #1931 (based on the discussion here: https://discuss.kotlinlang.org/t/property-vs-field/8179/10?u=yvolk ), I noticed that we forgot to change titles of the links to that page.
The target page is: https://kotlinlang.org/docs/reference/properties.html