### PR TITLE
Fixed compilation error in Kotlin coding guidelines example

### DIFF
--- a/pages/docs/reference/coding-conventions.md
+++ b/pages/docs/reference/coding-conventions.md
@@ -490,7 +490,7 @@ If the function signature doesn't fit on a single line, use the following syntax
 ```kotlin
 fun longMethodName(
     argument: ArgumentType = defaultValue,
-    argument2: AnotherArgumentType,
+    argument2: AnotherArgumentType
 ): ReturnType {
     // body
 }


### PR DESCRIPTION
Updated the function formatting code example - the last parameter of a function must be followed by a closing bracket - a comma is not valid here.