### PR TITLE
fix: fixed the Mac Catalyst item in K/N in the roadmap

### DIFF
--- a/docs/topics/roadmap.md
+++ b/docs/topics/roadmap.md
@@ -127,7 +127,7 @@ Visit the [new roadmap board in our issue tracker ![YouTrack](youtrack-logo.png)
          </td>
         <td>
             <ul>
-                <li>⏸ Support ARM Mac and Catalyst</li>
+                <li>⏸ Support Mac Catalyst</li>
                 <li>⏸ Development with Kotlin/Native on Apple Silicon without Rosetta 2</li>
                 <li>⏸ Direct interoperability with Swift</li>
                 <li>⏸ Interoperability with C++</li>


### PR DESCRIPTION
Fixed the Mac Catalyst item in postponed for K/N in the roadmap