### PR TITLE
A small addition to the docs for ZSH shell installs

### DIFF
--- a/pages/docs/tutorials/command-line.md
+++ b/pages/docs/tutorials/command-line.md
@@ -24,6 +24,11 @@ Simply run the following in a terminal and follow any instructions:
 ```bash
 $ curl -s https://get.sdkman.io | bash
 ```
+The above command works for ZSH shells as well. Following it up with the `source` linnking should get `sdkman` working in your current terminal shell
+
+```bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+```
 
 </div>
 


### PR DESCRIPTION
The SDKMan install step does not mention about anything about the ZSH shell installs, while this is documented in the main site. I just thought it would be helpful for other ZSH peeps coming this way to install Kotlin