### PR TITLE
Fix inverted directory path in documentation

### DIFF
--- a/pages/docs/tutorials/native/using-gradle.md
+++ b/pages/docs/tutorials/native/using-gradle.md
@@ -81,7 +81,7 @@ From the root project folder, execute the build by running
 
 `gradle nativeBinaries`
 
-This should create a folder `build/native/bin` with two subfolders `debugExecutable` and `releaseExecutable` with the corresponding binary.
+This should create a folder `build/bin/native` with two subfolders `debugExecutable` and `releaseExecutable` with the corresponding binary.
 By default, the binary is named the same as the project folder. 
 
 


### PR DESCRIPTION
Result of `gradle nativeBinaries` is actually `build/bin/native` and not `build/native/bin`. This pull request changes that.