### PR TITLE
fix parameter `i` never used.

### DIFF
--- a/pages/docs/reference/classes.md
+++ b/pages/docs/reference/classes.md
@@ -193,7 +193,7 @@ class Constructors {
     }
 
     constructor(i: Int) {
-        println("Constructor")
+        println("Constructor $i")
     }
 }
 //sampleEnd


### PR DESCRIPTION
fix parameter `i` never used.

### before

<img width="907" alt="スクリーンショット 2021-02-08 21 58 03" src="https://user-images.githubusercontent.com/16476224/107222813-bae26e80-6a58-11eb-939c-2c40118141dd.png">

## after

https://pl.kotl.in/OBRfEPLzs