### PR TITLE
update: rename basics.md to coroutines-basics.md

### DIFF
--- a/docs/cfg/buildprofiles.xml
+++ b/docs/cfg/buildprofiles.xml
@@ -5,7 +5,7 @@
         <enable-browser-edits>true</enable-browser-edits>
         <browser-edits-url>https://github.com/JetBrains/kotlin-web-site/edit/master/docs/</browser-edits-url>
         <browser-edits-url-override
-            for="coroutines-guide.md,basics.md,coroutines-basic-jvm.md,cancellation-and-timeouts.md,composing-suspending-functions.md,coroutine-context-and-dispatchers.md,flow.md,channels.md,exception-handling.md,shared-mutable-state-and-concurrency.md,select-expression.md,debug-coroutines-with-idea.md,debug-flow-with-idea.md">
+            for="coroutines-guide.md,coroutines-basics.md,coroutines-basic-jvm.md,cancellation-and-timeouts.md,composing-suspending-functions.md,coroutine-context-and-dispatchers.md,flow.md,channels.md,exception-handling.md,shared-mutable-state-and-concurrency.md,select-expression.md,debug-coroutines-with-idea.md,debug-flow-with-idea.md">
             https://github.com/Kotlin/kotlinx.coroutines/edit/master/docs/topics/
         </browser-edits-url-override>
         <kotlin-latest-url>%kotlinLatestUrl%</kotlin-latest-url>

--- a/docs/topics/coroutines-overview.md
+++ b/docs/topics/coroutines-overview.md
@@ -15,7 +15,7 @@ New to Kotlin? Take a look at the [Getting started](getting-started.md) page.
 ### Documentation
 
 - [Coroutines guide](coroutines-guide.md)
-- [Basics](basics.md)
+- [Basics](coroutines-basics.md)
 - [Channels](channels.md)
 - [Coroutine context and dispatchers](coroutine-context-and-dispatchers.md)
 - [Shared mutable state and concurrency](shared-mutable-state-and-concurrency.md)

--- a/docs/topics/lambdas.md
+++ b/docs/topics/lambdas.md
@@ -84,7 +84,7 @@ These types have a special notation that corresponds to the signatures of the fu
  return a value of `C`.
  [Function literals with receiver](#function-literals-with-receiver) are often used along with these types.
  
-* [Suspending functions](basics.md#extract-function-refactoring) belong to function types of a special kind, which have 
+* [Suspending functions](coroutines-basics.md#extract-function-refactoring) belong to function types of a special kind, which have 
 a *suspend* modifier in the notation, such as `suspend () -> Unit` or `suspend A.(B) -> C`.
  
 The function type notation can optionally include names for the function parameters: `(x: Int, y: Int) -> Point`.

--- a/docs/topics/whatsnew11.md
+++ b/docs/topics/whatsnew11.md
@@ -21,7 +21,7 @@ patterns. The key feature of Kotlin's design is that the implementation of corou
 not the language, so you aren't bound to any specific programming paradigm or concurrency library.
 
 A coroutine is effectively a light-weight thread that can be suspended and resumed later.
-Coroutines are supported through [*suspending functions*](basics.md#extract-function-refactoring):
+Coroutines are supported through [*suspending functions*](coroutines-basics.md#extract-function-refactoring):
 a call to such a function can potentially suspend a coroutine, and to start a new coroutine we usually use an anonymous suspending functions (i.e. suspending lambdas).  
 
 Let's look at `async`/`await` which is implemented in an external library, [kotlinx.coroutines](https://github.com/kotlin/kotlinx.coroutines): 


### PR DESCRIPTION
fixed for correct work of redirects