### PR TITLE
Improve documentation ToC organization

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -69,6 +69,7 @@
             <toc-element id="generics.md"/>
             <toc-element id="nested-classes.md"/>
             <toc-element id="enum-classes.md"/>
+            <toc-element id="annotations.md"/>
             <toc-element id="inline-classes.md"/>
             <toc-element id="object-declarations.md"/>
             <toc-element id="delegation.md"/>
@@ -79,18 +80,15 @@
             <toc-element id="functions.md"/>
             <toc-element id="lambdas.md" toc-title="Lambdas"/>
             <toc-element id="inline-functions.md"/>
+            <toc-element id="operator-overloading.md"/>
         </toc-element>
         <toc-element id="null-safety.md"/>
         <toc-element id="equality.md"/>
         <toc-element id="this-expressions.md"/>
-        <toc-element id="coroutines-overview.md"/>
-        <toc-element toc-title="DSL">
-            <toc-element id="type-safe-builders.md"/>
-            <toc-element id="operator-overloading.md"/>
-        </toc-element>
-        <toc-element id="annotations.md"/>
         <toc-element id="destructuring-declarations.md" accepts-web-file-names="multi-declarations.html"/>
+        <toc-element id="coroutines-overview.md"/>
         <toc-element id="reflection.md"/>
+        <toc-element id="type-safe-builders.md"/>
     </toc-element>
 
     <toc-element toc-title="Multiplatform programming">


### PR DESCRIPTION
I had trouble intuitively locating the Operator Overloading page under the new ToC organization. While operator overloading is useful for DSLs, it seems more of a core language feature with general applicability. I propose categorizing it under Functions, as overloads are defined via `operator fun`.

With Type-safe Builders being the only page left under the DSL category, it could be flattened.

The Annotations page is kind of off on its own, whereas it might make sense under the Classes category since they're defined via `annotation class` (similar to `enum class`).