### PR TITLE
fix link text(IEEE 754) 404 Not Found.

### DIFF
--- a/docs/topics/equality.md
+++ b/docs/topics/equality.md
@@ -37,7 +37,7 @@ true if and only if `a` and `b` point to the same object. For values represented
 ## Floating-point numbers equality
 
 When an equality check operands are statically known to be `Float` or `Double` (nullable or not), the check follows the 
-[IEEE 754 Standard for Floating-Point Arithmetic]((https://en.wikipedia.org/wiki/IEEE_754)). 
+[IEEE 754 Standard for Floating-Point Arithmetic](https://en.wikipedia.org/wiki/IEEE_754). 
 
 Otherwise, the structural equality is used, which disagrees with the standard so that `NaN` is equal to itself, and `-0.0` is not equal to `0.0`.
 


### PR DESCRIPTION
# before

https://kotlinlang.org/docs/(https://en.wikipedia.org/wiki/IEEE_754)/

<img width="1410" alt="スクリーンショット 2021-03-03 15 26 09" src="https://user-images.githubusercontent.com/16476224/109763015-c9294200-7c34-11eb-8d15-0b6ea4c70d8c.png">


# after

https://en.wikipedia.org/wiki/IEEE_754

<img width="1427" alt="スクリーンショット 2021-03-03 15 26 34" src="https://user-images.githubusercontent.com/16476224/109763046-d80ff480-7c34-11eb-9a00-2db443b6c3b2.png">