### PR TITLE
Fix linkText(visibility) 404 not found

### DIFF
--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -56,7 +56,7 @@ direct subclasses of a sealed class (indirect inheritors) can be placed anywhere
 {type="warning"}
 
 Direct subclasses of sealed classes and interfaces must be declared in the same package. They may be top-level or nested
-inside any number of other named classes, named interfaces, or named objects. Subclasses can have any [visibility](visibility-modifiers.html)
+inside any number of other named classes, named interfaces, or named objects. Subclasses can have any [visibility](visibility-modifiers.md)
 as long as they are compatible with normal inheritance rules in Kotlin.
 
 Subclasses of sealed classes must have a proper qualified name. They can't be local nor anonymous objects.


### PR DESCRIPTION
# Problem
The following link text is invalid.

https://kotlinlang.org/docs/sealed-classes.html#additional-location-the-same-package
<img width="832" alt="スクリーンショット 2021-03-05 16 29 35" src="https://user-images.githubusercontent.com/16476224/110082035-2a394d00-7dd0-11eb-833b-d1cca6ba58ac.png">


# Before
https://github.com/Kotlin/kotlinx.coroutines/blob/master/visibility-modifiers.html

# After
https://kotlinlang.org/docs/visibility-modifiers.html