### PR TITLE
fix: correct the wrong indentation in this-exp doc

### DIFF
--- a/docs/topics/this-expressions.md
+++ b/docs/topics/this-expressions.md
@@ -28,7 +28,7 @@ class A { // implicit label @A
                 val d = this // funLit's receiver
             }
 
-val funLit2 = { s: String ->
+            val funLit2 = { s: String ->
                 // foo()'s receiver, since enclosing lambda expression
                 // doesn't have any receiver
                 val d1 = this


### PR DESCRIPTION
Correcting the wrong code example indentation in this-expressions document.