### PR TITLE
Add Extension properties ordering

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -72,6 +72,8 @@ Do not sort the method declarations alphabetically or by visibility, and do not 
 from extension methods. Instead, put related stuff together, so that someone reading the class from top to bottom can 
 follow the logic of what's happening. Choose an order (either higher-level stuff first, or vice versa) and stick to it.
 
+Extension properties are effectively methods, thus in terms of order they are treated as methods.
+
 Put nested classes next to the code that uses those classes. If the classes are intended to be used externally and aren't
 referenced inside the class, put them in the end, after the companion object.
 


### PR DESCRIPTION
I've noticed that detekt is treating extension properties as regular properties.
Opened issue on detekt: https://github.com/detekt/detekt/issues/3532
Lead to proposal: https://github.com/detekt/detekt/pull/3559

Yet that change would be unclear as this is not part of the spec at all. Thus proposing the following change.