### PR TITLE
fix: KT-33201 rewrite unusable sample of secondary constructor

### DIFF
--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -101,10 +101,11 @@ Learn more about [visibility modifiers](visibility-modifiers.md#constructors).
 The class can also declare _secondary constructors_, which are prefixed with `constructor`:
 
 ```kotlin
-class Person {
-    var children: MutableList<Person> = mutableListOf()
-    constructor(parent: Person) {
-        parent.children.add(this)
+class Person(val pets: MutableList<Pet> = mutableListOf())
+
+class Pet {
+    constructor(owner: Person) {
+        owner.pets.add(this) // adds this pet to the list of its owners pets
     }
 }
 ```


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/KT-33201