### PR TITLE
fix: KT-45522 Define an object expression vs. anonymous type

### DIFF
--- a/docs/topics/object-declarations.md
+++ b/docs/topics/object-declarations.md
@@ -5,7 +5,33 @@ Kotlin handles this case with *object expressions* and *object declarations*.
 
 ## Object expressions
 
-To create an object of an anonymous class that inherits from some type (or types), write:
+_Object expressions_ create objects of anonymous classes, that is, classes that aren't explicitly declared with the `class`
+declaration. Such classes are handy for one-time use. You can inherit them from existing classes or interfaces or define
+from scratch. Instances of anonymous classes are also called _anonymous objects_ because they are defined by an expression,
+not a name.
+
+Object expressions start with the `object` keyword.
+
+If you need just an object with no nontrivial supertypes, write its members in curly braces after `object`:
+
+```kotlin
+
+fun main() {
+//sampleStart
+    val helloWorld = object {
+        val hello = "Hello"
+        val world = "World"
+        // object expressions extend Any, so `override` is required on `toString()`
+        override fun toString() = "$hello $world" 
+    }
+//sampleEnd
+    print(helloWorld)
+}
+```
+{kotlin-runnable="true"}
+
+To create an object of an anonymous class that inherits from some type (or types), specify this type after `object` and
+colon (`:`). Then implement or override the members of this class as if you were [inheriting](inheritance.md) from it.
 
 ```kotlin
 window.addMouseListener(object : MouseAdapter() {
@@ -30,26 +56,14 @@ val ab: A = object : A(1), B {
 }
 ```
 
-If you need just an object, with no nontrivial supertypes, write:
-
-```kotlin
-fun foo() {
-    val adHoc = object {
-        var x: Int = 0
-        var y: Int = 0
-    }
-    print(adHoc.x + adHoc.y)
-}
-```
-
-Note that anonymous objects can be used as types only in local and [private](visibility-modifiers.md#packages) declarations. If you use an anonymous object as a
-return type of a public function or the type of a public property, the actual type of that function or property
-will be the declared supertype of the anonymous object, or `Any` if you haven't declared any supertype. Members added
-in the anonymous object will not be accessible.
+Anonymous objects can be used as types only in local and [private](visibility-modifiers.md#packages) declarations.
+If you use an anonymous object as a return type of a public function or the type of a public property, the actual type
+of that function or property will be the declared supertype of the anonymous object, or `Any` if you haven't declared
+any supertype. Members added in the anonymous object will not be accessible.
 
 ```kotlin
 class C {
-    // Private function, so the return type is the anonymous object type
+    // Private function, so the return type is the type of the anonymous object
     private fun foo() = object {
         val x: String = "x"
     }
@@ -61,7 +75,7 @@ class C {
 
     fun bar() {
         val x1 = foo().x        // Works
-        val x2 = publicFoo().x  // ERROR: Unresolved reference 'x'
+        // val x2 = publicFoo().x  // ERROR: Unresolved reference 'x'
     }
 }
 ```

--- a/docs/topics/object-declarations.md
+++ b/docs/topics/object-declarations.md
@@ -6,9 +6,9 @@ Kotlin handles this case with *object expressions* and *object declarations*.
 ## Object expressions
 
 _Object expressions_ create objects of anonymous classes, that is, classes that aren't explicitly declared with the `class`
-declaration. Such classes are handy for one-time use. You can inherit them from existing classes or interfaces or define
-from scratch. Instances of anonymous classes are also called _anonymous objects_ because they are defined by an expression,
-not a name.
+declaration. Such classes are handy for one-time use. You can define them from scratch, inherit from existing classes,
+or implement interfaces. Instances of anonymous classes are also called _anonymous objects_ because they are defined by
+an expression, not a name.
 
 ### Creating anonymous objects from scratch
 
@@ -83,7 +83,7 @@ If this function or property is public or private inline, its actual type is:
 * the explicitly declared type if there is more than one declared supertype
 
 In all these cases, members added in the anonymous object are not accessible. Overriden members are accessible if they 
-are declared in the actual type of the function or property.
+are declared in the actual type of the function or property:
 
 ```kotlin
 interface A {

--- a/docs/topics/object-declarations.md
+++ b/docs/topics/object-declarations.md
@@ -10,6 +10,8 @@ declaration. Such classes are handy for one-time use. You can inherit them from 
 from scratch. Instances of anonymous classes are also called _anonymous objects_ because they are defined by an expression,
 not a name.
 
+### Creating anonymous objects from scratch
+
 Object expressions start with the `object` keyword.
 
 If you need just an object with no nontrivial supertypes, write its members in curly braces after `object`:
@@ -29,6 +31,8 @@ fun main() {
 }
 ```
 {kotlin-runnable="true"}
+
+### Inheriting anonymous objects from supertypes
 
 To create an object of an anonymous class that inherits from some type (or types), specify this type after `object` and
 colon (`:`). Then implement or override the members of this class as if you were [inheriting](inheritance.md) from it.
@@ -56,29 +60,58 @@ val ab: A = object : A(1), B {
 }
 ```
 
-Anonymous objects can be used as types only in local and [private](visibility-modifiers.md#packages) declarations.
-If you use an anonymous object as a return type of a public function or the type of a public property, the actual type
-of that function or property will be the declared supertype of the anonymous object, or `Any` if you haven't declared
-any supertype. Members added in the anonymous object will not be accessible.
+### Using anonymous object as return and value types
+
+When an anonymous object is used as a type of a local or [private](visibility-modifiers.md#packages) but not [inline](inline-functions.md)
+declaration (function or property), all its members are accessible via this function or property:
 
 ```kotlin
 class C {
-    // Private function, so the return type is the type of the anonymous object
-    private fun foo() = object {
+    private fun getObject() = object {
         val x: String = "x"
     }
 
-    // Public function, so the return type is Any
-    fun publicFoo() = object {
-        val x: String = "x"
-    }
-
-    fun bar() {
-        val x1 = foo().x        // Works
-        // val x2 = publicFoo().x  // ERROR: Unresolved reference 'x'
+    fun printX() {
+        println(getObject().x)
     }
 }
 ```
+
+If this function or property is public or private inline, its actual type is:
+* `Any` if the anonymous object doesn't have a declared supertype
+* the declared supertype of the anonymous object if there is exactly one such type 
+* the explicitly declared type if there is more than one declared supertype
+
+In all these cases, members added in the anonymous object are not accessible. Overriden members are accessible if they 
+are declared in the actual type of the function or property.
+
+```kotlin
+interface A {
+    fun funFromA() {}
+}
+interface B
+
+class C {
+    // The return type is Any. x is not accessible
+    fun getObject() = object {
+        val x: String = "x"
+    }
+
+    // The return type is A; x is not accessible 
+    fun getObjectA() = object: A {
+        override fun funFromA() {}
+        val x: String = "x"
+    }
+
+    // The return type is B; funFromA() and x are not accessible
+    fun getObjectB(): B = object: A, B { // explicit return type is required
+        override fun funFromA() {}
+        val x: String = "x"
+    }
+}
+```
+
+### Accessing variables from anonymous objects 
 
 The code in object expressions can access variables from the enclosing scope.
 

--- a/docs/topics/object-declarations.md
+++ b/docs/topics/object-declarations.md
@@ -35,7 +35,7 @@ fun main() {
 ### Inheriting anonymous objects from supertypes
 
 To create an object of an anonymous class that inherits from some type (or types), specify this type after `object` and
-colon (`:`). Then implement or override the members of this class as if you were [inheriting](inheritance.md) from it.
+colon (`:`). Then implement or override the members of this class as if you were [inheriting](inheritance.md) from it:
 
 ```kotlin
 window.addMouseListener(object : MouseAdapter() {

--- a/docs/topics/object-declarations.md
+++ b/docs/topics/object-declarations.md
@@ -113,7 +113,7 @@ class C {
 
 ### Accessing variables from anonymous objects 
 
-The code in object expressions can access variables from the enclosing scope.
+The code in object expressions can access variables from the enclosing scope:
 
 ```kotlin
 fun countClicks(window: JComponent) {


### PR DESCRIPTION
Doc improvement per feedback in https://youtrack.jetbrains.com/issue/KT-45522