### PR TITLE
Fix sample in when 'else if' documentation

### DIFF
--- a/docs/topics/control-flow.md
+++ b/docs/topics/control-flow.md
@@ -109,7 +109,7 @@ If no argument is supplied, the branch conditions are simply boolean expressions
 ```kotlin
 when {
     x.isOdd() -> print("x is odd")
-    x.isEven() -> print("y is even")
+    y.isEven() -> print("y is even")
     else -> print("x+y is odd")
 }
 ```


### PR DESCRIPTION
The sample uses `x` for both odd and even checks
where as the even check should be for `y`