### PR TITLE
Update list of native target platforms

### DIFF
--- a/docs/topics/native/native-overview.md
+++ b/docs/topics/native/native-overview.md
@@ -14,14 +14,16 @@ self-contained program that does not require an additional runtime or virtual ma
 ## Target platforms
 
 Kotlin/Native supports the following platforms:
-   * iOS (arm32, arm64, simulator x86_64)
-   * macOS (x86_64)
-   * watchOS (arm32, arm64, x86, x86_64)
-   * tvOS (arm64, x86_64)
-   * Android (arm32, arm64, x86, x86_64)
-   * Windows (mingw x86_64, x86)
-   * Linux (x86_64, arm32, arm64, MIPS, MIPS little endian)
-   * WebAssembly (wasm32)
+   * iOS
+   * macOS
+   * watchOS
+   * tvOS
+   * Android NDK
+   * Windows (MinGW)
+   * Linux
+
+The full list of supported targets is available [here](mpp-supported-platforms.md).
+
 
 ## Interoperability
 

--- a/docs/topics/native/native-overview.md
+++ b/docs/topics/native/native-overview.md
@@ -14,13 +14,10 @@ self-contained program that does not require an additional runtime or virtual ma
 ## Target platforms
 
 Kotlin/Native supports the following platforms:
-   * iOS
-   * macOS
-   * watchOS
-   * tvOS
-   * Android NDK
-   * Windows (MinGW)
+   * iOS, macOS, tvOS, watchOS
    * Linux
+   * Windows (MinGW)
+   * Android NDK
 
 The full list of supported targets is available [here](mpp-supported-platforms.md).
 

--- a/docs/topics/native/native-overview.md
+++ b/docs/topics/native/native-overview.md
@@ -14,7 +14,8 @@ self-contained program that does not require an additional runtime or virtual ma
 ## Target platforms
 
 Kotlin/Native supports the following platforms:
-   * iOS, macOS, tvOS, watchOS
+   * macOS
+   * iOS, tvOS, watchOS
    * Linux
    * Windows (MinGW)
    * Android NDK


### PR DESCRIPTION
* Remove explicit enumeration of targets. It is not actionable (doesn't answer the question of how to use them) and clutters the list. It will become even more cluttered when we add 4 more targets for Apple Silicon.
* Instead, add a link to the list of Gradle targets because it's the only "officially supported" way of using the compiler.
* Explicitly mention Android NDK to avoid confusion with usual Android development.
* Remove WebAssembly mention because it is going to be deprecated.