### PR TITLE
update: stable sealed interfaces and inheritance

### DIFF
--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -8,7 +8,7 @@ Thus, each instance of a sealed class has a type from a limited set that is know
 The same works for sealed interfaces and their implementations: once a module with a sealed interface is compiled,
 no new implementations can appear.
 
-In some sense, sealed classes are similar to [`enum` classes](enum-classes.md): the set of values
+In some sense, sealed classes are similar to [`enum`](enum-classes.md) classes: the set of values
 for an enum type is also restricted, but each enum constant exists only as a _single instance_, whereas a subclass
 of a sealed class can have _multiple_ instances, each with its own state.
 
@@ -31,7 +31,7 @@ Sealed classes are not allowed to have non-`private` constructors (their constru
 ## Location of direct subclasses
 
 Direct subclasses of sealed classes and interfaces must be declared in the same package. They may be top-level or nested
-inside any number of other named classes, named interfaces, or named objects. Subclasses can have any [visibility](visibility-modifiers.html)
+inside any number of other named classes, named interfaces, or named objects. Subclasses can have any [visibility](visibility-modifiers.md)
 as long as they are compatible with normal inheritance rules in Kotlin.
 
 Subclasses of sealed classes must have a proper qualified name. They can't be local nor anonymous objects.
@@ -42,7 +42,8 @@ Subclasses of sealed classes must have a proper qualified name. They can't be lo
 
 ## Sealed classes and when expression
 
-The key benefit of using sealed classes comes into play when you use them in a [`when` expression](control-flow.md#when-expression). 
+The key benefit of using sealed classes comes into play when you use them in a [`when`](control-flow.md#when-expression)
+expression. 
 If it's possible to verify that the statement covers all cases, you don't need to add an `else` clause to the statement. 
 However, this works only if you use `when` as an expression (using the result) and not as a statement.
 

--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -26,7 +26,17 @@ object NotANumber : Expr
 
 A sealed class is [abstract](classes.md#abstract-classes) by itself, it cannot be instantiated directly and can have `abstract` members.
 
-Sealed classes are not allowed to have non-`private` constructors (their constructors are `private` by default).
+Constructors of sealed classes can have one of two [visibilities](visibility-modifiers.md): `protected` (by default) or
+`private`.
+
+```kotlin
+sealed class MathExpr {
+    constructor() { /*...*/ } // protected by default
+    private constructor(vararg operands: Number): this() { /*...*/ } // private is OK
+    // public constructor(s: String): this() {} // Error: public and internal are not allowed
+}
+```
+
 
 ## Location of direct subclasses
 

--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -1,37 +1,18 @@
 [//]: # (title: Sealed classes)
 
-_Sealed_ classes represent restricted class hierarchies that provide more control over inheritance.
+_Sealed_ classes and interfaces represent restricted class hierarchies that provide more control over inheritance.
 All subclasses of a sealed class are known at compile time. No other subclasses may appear after
 a module with the sealed class is compiled. For example, third-party clients can't extend your sealed class in their code.
 Thus, each instance of a sealed class has a type from a limited set that is known when this class is compiled.
+
+The same works for sealed interfaces and their implementations: once a module with a sealed interface is compiled,
+no new implementations can appear.
 
 In some sense, sealed classes are similar to [`enum` classes](enum-classes.md): the set of values
 for an enum type is also restricted, but each enum constant exists only as a _single instance_, whereas a subclass
 of a sealed class can have _multiple_ instances, each with its own state.
 
-To declare a sealed class, put the `sealed` modifier before its name.
-
-```kotlin
-sealed class Expr
-data class Const(val number: Double) : Expr()
-data class Sum(val e1: Expr, val e2: Expr) : Expr()
-object NotANumber : Expr()
-```
-
-A sealed class is [abstract](classes.md#abstract-classes) by itself, it cannot be instantiated directly and can have `abstract` members.
-
-Sealed classes are not allowed to have non-`private` constructors (their constructors are `private` by default).
-
-## Sealed interfaces
-
-> Sealed interfaces are [Experimental](components-stability.md). They may be dropped or changed at any time.
-> Opt-in is required (see the details [below](#try-sealed-interfaces-and-package-wide-hierarchies-of-sealed-classes)), and you should use them only for evaluation purposes.  We would appreciate your feedback on them in [YouTrack](https://youtrack.jetbrains.com/issue/KT-42433).
->
-{type="warning"}
-
-Interfaces can be declared `sealed` as well as classes. The `sealed` modifier works on interfaces the same way:
-all implementations of a sealed interface are known at compile time. Once a module with a sealed interface is compiled,
-no new implementations can appear.
+To declare a sealed class or interface, put the `sealed` modifier before its name.
 
 ```kotlin
 sealed interface Expr
@@ -43,17 +24,11 @@ data class Sum(val e1: Expr, val e2: Expr) : MathExpr()
 object NotANumber : Expr
 ```
 
+A sealed class is [abstract](classes.md#abstract-classes) by itself, it cannot be instantiated directly and can have `abstract` members.
+
+Sealed classes are not allowed to have non-`private` constructors (their constructors are `private` by default).
+
 ## Location of direct subclasses
-
-All direct subclasses of a sealed class must be declared in the same file as this class itself. Classes that extend
-direct subclasses of a sealed class (indirect inheritors) can be placed anywhere, not necessarily in the same file.
-
-### Additional location: the same package
-
-> Package-wide hierarchies of sealed classes are [Experimental](components-stability.md). They may be dropped or changed at any time.
-> Opt-in is required (see the details [below](#try-sealed-interfaces-and-package-wide-hierarchies-of-sealed-classes)), and you should use them only for evaluation purposes.  We would appreciate your feedback on them in [YouTrack](https://youtrack.jetbrains.com/issue/KT-42433).
->
-{type="warning"}
 
 Direct subclasses of sealed classes and interfaces must be declared in the same package. They may be top-level or nested
 inside any number of other named classes, named interfaces, or named objects. Subclasses can have any [visibility](visibility-modifiers.html)
@@ -80,15 +55,8 @@ fun eval(expr: Expr): Double = when(expr) {
 }
 ```
 
-## Try sealed interfaces and package-wide hierarchies of sealed classes
-
-[Sealed interfaces](#sealed-interfaces) and [package-wide hierarchies](#additional-location-the-same-package) are [Experimental](components-stability.md).
-To be able to use them in your code, switch to the language version `1.5`:
-
-* In Gradle, add the [compiler option](gradle.md#attributes-common-for-jvm-and-js) `languageVersion` with the value `1.5`.
-
-  ```groovy
-  kotlinOptions.languageVersion = "1.5"
-  ```
-  
-* In the command-line compiler, add the option `-language-version 1.5`.
+> `when` expressions on [`expect`](mpp-connect-to-apis.md) sealed classes in the common code of multiplatform projects still 
+> require an `else` branch. This happens because subclasses of `actual` platform implementations aren't known in the 
+> common code.
+>
+{type="note"}

--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -12,7 +12,7 @@ In some sense, sealed classes are similar to [`enum`](enum-classes.md) classes: 
 for an enum type is also restricted, but each enum constant exists only as a _single instance_, whereas a subclass
 of a sealed class can have _multiple_ instances, each with its own state.
 
-To declare a sealed class or interface, put the `sealed` modifier before its name.
+To declare a sealed class or interface, put the `sealed` modifier before its name:
 
 ```kotlin
 sealed interface Expr
@@ -27,7 +27,7 @@ object NotANumber : Expr
 A sealed class is [abstract](classes.md#abstract-classes) by itself, it cannot be instantiated directly and can have `abstract` members.
 
 Constructors of sealed classes can have one of two [visibilities](visibility-modifiers.md): `protected` (by default) or
-`private`.
+`private`:
 
 ```kotlin
 sealed class MathExpr {
@@ -55,7 +55,7 @@ Subclasses of sealed classes must have a proper qualified name. They can't be lo
 The key benefit of using sealed classes comes into play when you use them in a [`when`](control-flow.md#when-expression)
 expression. 
 If it's possible to verify that the statement covers all cases, you don't need to add an `else` clause to the statement. 
-However, this works only if you use `when` as an expression (using the result) and not as a statement.
+However, this works only if you use `when` as an expression (using the result) and not as a statement:
 
 ```kotlin
 fun eval(expr: Expr): Double = when(expr) {

--- a/docs/topics/whatsnew1430.md
+++ b/docs/topics/whatsnew1430.md
@@ -95,7 +95,7 @@ To try the preview version of sealed interfaces, add the compiler option `-langu
 version, you’ll be able to use the `sealed` modifier on interfaces. We’d be very grateful if you would share your feedback
 with us using this [YouTrack ticket](https://youtrack.jetbrains.com/issue/KT-42433).
 
-[Learn more about sealed interfaces](sealed-classes.md#sealed-interfaces).
+[Learn more about sealed interfaces](sealed-classes.md).
 
 ### Package-wide sealed class hierarchies
 
@@ -113,7 +113,7 @@ The subclasses of a sealed class must have a name that is properly qualified –
 To try package-wide hierarchies of sealed classes, add the compiler option `-language-version 1.5`. We’d be very grateful
 if you would share your feedback with us using this [YouTrack ticket](https://youtrack.jetbrains.com/issue/KT-42433).
 
-[Learn more about package-wide hierarchies of sealed classes](sealed-classes.md#additional-location-the-same-package).
+[Learn more about package-wide hierarchies of sealed classes](sealed-classes.md#location-of-direct-subclasses).
 
 ### Improved inline classes
 


### PR DESCRIPTION
Doc update reflecting the sealed class changes in 1.5.0:
- Sealed interfaces are stable
- package-wide sealed hierarchies by default
- `when` on `expect sealed` classes is not exhaustive