### PR TITLE
Add example of suspend fun in fun interface

### DIFF
--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -61,6 +61,30 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.4"}
 
+In another example of a SAM conversion, the function `process()` uses a lambda instead of creating an anonymous object:
+
+```kotlin
+fun interface SuspendRunnable {
+   suspend fun invoke()
+}
+class Listener {
+   fun setOnClickListener(r: SuspendRunnable) {
+       GlobalScope.launch { r.invoke() }
+   }
+}
+class Button(private val listener: Listener) {
+   fun process() {
+       listener.setOnClickListener {
+           addText()
+       }
+   }
+   suspend fun addText() {
+       // ...
+   }
+}
+```
+{kotlin-runnable="true" kotlin-min-compiler-version="1.5"}
+
 You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conversions).
 
 ## Functional interfaces vs. type aliases


### PR DESCRIPTION
Restore the previously removed example of `suspend fun` in `fun interface` from [this PR](https://github.com/JetBrains/kotlin-web-site/pull/1756/files#diff-b6dc78a878c5aca3482e9b1a842f2ed509f67f6fa717e1a18db3c58f1cf12068R89-R115) because it becomes valid in 1.5 (issue: [KT-44787](https://youtrack.jetbrains.com/issue/KT-44787))