### PR TITLE
update: KT-44361 deprecate Gradle options noStdlib, noReflect

### DIFF
--- a/docs/topics/gradle.md
+++ b/docs/topics/gradle.md
@@ -543,8 +543,6 @@ The complete list of options for the Gradle tasks is the following:
 | `jdkHome` | Include a custom JDK from the specified location into the classpath instead of the default JAVA_HOME |  |  |
 | `jvmTarget` | Target version of the generated JVM bytecode | "1.6" (DEPRECATED), "1.8", "9", "10", "11", "12", "13", "14", "15", "16" | "%defaultJvmTargetVersion%" |
 | `noJdk` | Don't automatically include the Java runtime into the classpath |  | false |
-| `noReflect` | Don't automatically include Kotlin reflection into the classpath |  | true |
-| `noStdlib` | Don't automatically include the Kotlin/JVM stdlib and Kotlin reflection into the classpath |  | true |
 | `useIR` | Use the IR backend |  | false |
 
 ### Attributes specific for JS


### PR DESCRIPTION
[KT-44361 Gradle: deprecate options includeRuntime, noStdlib, noReflect](https://youtrack.jetbrains.com/issue/KT-44361)