### PR TITLE
Backing field: Adding error as example if actual property name is use…

### DIFF
--- a/docs/topics/properties.md
+++ b/docs/topics/properties.md
@@ -100,7 +100,9 @@ in the accessors using the `field` identifier:
 ```kotlin
 var counter = 0 // the initializer assigns the backing field directly
     set(value) {
-        if (value >= 0) field = value
+        if (value >= 0)
+            field = value
+            // counter = value // ERROR StackOverflow: Using actual name 'counter' would make setter recursive
     }
 ```
 


### PR DESCRIPTION
…d instead of backing field inside setter.