### PR TITLE
Adding londogard-nlp-toolkit

### DIFF
--- a/docs/topics/data-science-overview.md
+++ b/docs/topics/data-science-overview.md
@@ -73,6 +73,8 @@ Lets-Plot is multiplatform and can be used not only with JVM, but also with JS a
 * [kravis](https://github.com/holgerbrandl/kravis) is another library for the visualization of tabular data inspired by
 Python's [ggplot](https://ggplot2.tidyverse.org/).
 
+* [londogard-nlp-toolkit](https://github.com/londogard/londogard-nlp-toolkit/) is a library that provides great utilities when working with natural language processing (nlp) such as word/subword/sentence embeddings, word-frequencies, stopwords, stemming & much more!
+
 ### Java libraries
 
 Since Kotlin provides first-class interop with Java, you can also use Java libraries for data science in your Kotlin code.

--- a/docs/topics/data-science-overview.md
+++ b/docs/topics/data-science-overview.md
@@ -73,7 +73,7 @@ Lets-Plot is multiplatform and can be used not only with JVM, but also with JS a
 * [kravis](https://github.com/holgerbrandl/kravis) is another library for the visualization of tabular data inspired by
 Python's [ggplot](https://ggplot2.tidyverse.org/).
 
-* [londogard-nlp-toolkit](https://github.com/londogard/londogard-nlp-toolkit/) is a library that provides great utilities when working with natural language processing (nlp) such as word/subword/sentence embeddings, word-frequencies, stopwords, stemming & much more!
+* [londogard-nlp-toolkit](https://github.com/londogard/londogard-nlp-toolkit/) is a library that provides utilities when working with natural language processing such as word/subword/sentence embeddings, word-frequencies, stopwords, stemming, and much more.
 
 ### Java libraries
 


### PR DESCRIPTION
Adding londogard-nlp-toolkit.
It's also available through kotlin jupyter notebook via `%use londogard-nlp-toolkit` (see: https://github.com/Kotlin/kotlin-jupyter#list-of-supported-libraries)