### PR TITLE
Fix typo in control-flow.md

### DIFF
--- a/docs/topics/control-flow.md
+++ b/docs/topics/control-flow.md
@@ -145,7 +145,7 @@ for (item: Int in ints) {
 
 As mentioned before, `for` iterates through anything that provides an iterator. This means that it:
 
-* has a member or an extension-function `iterator()` and the return type of `iterator()`:
+* has a member or an extension-function `iterator()` and the return type of `Iterator<>`:
   * has a member or an extension-function `next()`
   * has a member or an extension-function `hasNext()` that returns `Boolean`.
 


### PR DESCRIPTION
iterator function should return `Iterator<>` instead.