### PR TITLE
Add operator keyword to Array<T> class for generics example

### DIFF
--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -186,8 +186,8 @@ A good example of this is `Array`:
 
 ```kotlin
 class Array<T>(val size: Int) {
-    fun get(index: Int): T { ... }
-    fun set(index: Int, value: T) { ... }
+    operator fun get(index: Int): T { ... }
+    operator fun set(index: Int, value: T) { ... }
 }
 ```
 


### PR DESCRIPTION
If I copy and paste the example, I get the exception

```
'operator' modifier is required on 'set' in 'Array'
```

To have a running example, the operator keyword needs to be added.