### PR TITLE
minor change in introduction to variance

### DIFF
--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -82,7 +82,7 @@ In other words, the wildcard with an _extends_\-bound (_upper_ bound) makes the 
 The key to understanding why this trick works is rather simple: if you can only _take_ items from a collection, 
 then using a collection of `String`s and reading `Object`s from it is fine. Conversely, if you can only _put_ items 
 into the collection, it's OK to take a collection of `Object`s and put `String`s into it: there is 
-`List<? super String>` in Java, a _supertype_ of `List<Object>`.
+`List<? super String>` in Java, a _supertype_ of `List<String>`.
  
 The latter is called _contravariance_, and you can only call methods that take `String` as an argument on `List<? super String>` 
 (for example, you can call `add(String)` or `set(int, String)`).  If you call something that returns `T` in `List<T>`, 


### PR DESCRIPTION
List<? super String> accepts objects of type List of either String type, or supertype of String type, but not a supertype of the object type. But it is written in such a way that it accepts supertype of Object which is fundamentally wrong. So, it should be "List< String >" instead of "List< Object >". That is "List<? super String>" is a supertype of "List< String >".