### PR TITLE
Promote IR-based Kotlin/JS compiler to Beta

### DIFF
--- a/docs/topics/components-stability.md
+++ b/docs/topics/components-stability.md
@@ -45,7 +45,7 @@ kotlin-stdlib (JVM)|Stable|1.0| |
 Coroutines|Stable|1.3| |
 kotlin-reflect (JVM)|Beta|1.0| |
 Kotlin/JS (Classic back-end)|Stable|1.3| |
-Kotlin/JVM (IR-based)|Alpha|1.4| |
+Kotlin/JVM (IR-based)|Beta|1.5| |
 Kotlin/JS (IR-based)|Alpha|1.4| |
 Kotlin/Native Runtime|Beta|1.3| |
 KLib binaries|Alpha|1.4| |

--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -1,6 +1,6 @@
 [//]: # (title: Kotlin/JS IR compiler)
 
-> The Kotlin/JS IR compiler is in [Alpha](components-stability.md). It may change incompatibly and require manual migration
+> The Kotlin/JS IR compiler is in [Beta](components-stability.md). It may change incompatibly and require manual migration
 >in the future. We appreciate your feedback on it in [YouTrack](https://youtrack.jetbrains.com/issues/KT).
 >
 {type="warning"}


### PR DESCRIPTION
Per https://blog.jetbrains.com/kotlin/2021/05/kotlin-1-5-0-released/#kotlin-js