### PR TITLE
Typo: missing 'd'

### DIFF
--- a/docs/topics/collection-parts.md
+++ b/docs/topics/collection-parts.md
@@ -122,7 +122,7 @@ fun main() {
 
 `windowed()` provides more flexibility with optional parameters:
 
-* `step` defines a distance between first elements of two adjacent windows. By default the value is 1, so the result contains windows starting from all elements. If you increase the step to 2, you will receive only windows starting from odd elements: first, third, an so on.
+* `step` defines a distance between first elements of two adjacent windows. By default the value is 1, so the result contains windows starting from all elements. If you increase the step to 2, you will receive only windows starting from odd elements: first, third, and so on.
 * `partialWindows` includes windows of smaller sizes that start from the elements at the end of the collection. For example, if you request windows of three elements, you can't build them for the last two elements. Enabling `partialWindows` in this case includes two more lists of sizes 2 and 1.
 
 Finally, you can apply a transformation to the returned ranges right away.


### PR DESCRIPTION
'an' -> 'and'.