### PR TITLE
update: 1.5.10 doc update

### DIFF
--- a/data/releases.yml
+++ b/data/releases.yml
@@ -1,6 +1,6 @@
 url: https://github.com/JetBrains/kotlin/releases
 
 latest:
-  version: 1.5.0
-  url: https://github.com/JetBrains/kotlin/releases/tag/v1.5.0
+  version: 1.5.10
+  url: https://github.com/JetBrains/kotlin/releases/tag/v1.5.10
 

--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -316,6 +316,14 @@ For browser targets, the Kotlin/JS plugin uses the widely known [webpack](https:
 
 The Kotlin/JS plugin uses webpack %webpackMajorVersion%.
 
+If you have projects created with plugin versions earlier than 1.5.0,
+you can temporarily switch back to webpack %webpackPreviousMajorVersion% used in these versions by adding the following line
+to the project's `gradle.properties`:
+
+```properties
+kotlin.js.webpack.major.version=4
+```
+
 ### webpack task
 
 The most common webpack adjustments can be made directly via the

--- a/docs/topics/releases.md
+++ b/docs/topics/releases.md
@@ -50,6 +50,27 @@ You can also use [preview versions of Kotlin](eap.md#build-details).
         <th>Recommended kotlinx library versions</th>
     </tr>
     <tr>
+        <td><strong>1.5.10</strong>
+            <p>Released: <strong>May 24, 2021</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v1.5.10" target="_blank">Release on GitHub</a></p>
+        </td>
+        <td>
+            <p>A bug fix release for Kotlin 1.5.0.</p>
+            <p>Learn more about <a href="https://blog.jetbrains.com/kotlin/2021/04/kotlin-1-5-0-released/" target="_blank">Kotlin 1.5.0</a>.</p>
+        </td>
+        <td>
+            <ul>
+                <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank"><strong>kotlinx.serialization</strong></a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.2.1" target="_blank">1.2.1</a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx.coroutines" target="_blank"><strong>kotlinx.coroutines</strong></a> version: <a href="https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.5.0" target="_blank">1.5.0</a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx.atomicfu" target="_blank"><strong>kotlinx.atomicfu</strong></a> version: <a href="https://github.com/Kotlin/kotlinx.atomicfu/releases/tag/0.16.1" target="_blank">0.16.1</a></li>          
+                <li><a href="https://ktor.io/" target="_blank"><strong>ktor</strong></a> version: <a href="https://github.com/ktorio/ktor/releases/tag/1.5.4" target="_blank">1.5.4</a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx.html" target="_blank"><strong>kotlinx.html</strong></a> version: <a href="https://github.com/Kotlin/kotlinx.html/releases/tag/0.7.2" target="_blank">0.7.2</a></li>
+                <li><a href="https://github.com/Kotlin/kotlinx-nodejs" target="_blank"><strong>kotlinx-nodejs</strong></a> version: <a href="https://bintray.com/kotlin/kotlinx/kotlinx.nodejs/0.0.7" target="_blank">0.0.7</a></li>
+            </ul>
+            <p>The versions of libraries from <code>kotlin-wrappers</code> (such as <code>kotlin-react</code>) can be found in the <a href="https://github.com/JetBrains/kotlin-wrappers" target="_blank">corresponding repository</a>.</p>
+        </td>
+    </tr>
+    <tr>
         <td><strong>1.5.0</strong>
             <p>Released: <strong>May 5, 2021</strong></p>
             <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v1.5.0" target="_blank">Release on GitHub</a></p>
@@ -81,7 +102,7 @@ You can also use [preview versions of Kotlin](eap.md#build-details).
             <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v1.4.32" target="_blank">Release on GitHub</a></p>
         </td>
         <td>
-            <p>A bug fix release for Kotlin 1.4.30</p>
+            <p>A bug fix release for Kotlin 1.4.30.</p>
             <p>Learn more about <a href="whatsnew1430.md" target="_blank">Kotlin 1.4.30</a>.</p>
         </td>
         <td>

--- a/docs/v.list
+++ b/docs/v.list
@@ -4,13 +4,13 @@
 
 <vars>
 
-    <var name="kotlinVersion" value="1.5.0" type="string"/>
+    <var name="kotlinVersion" value="1.5.10" type="string"/>
 
     <var name="kotlinEapVersion" value="1.5.0-RC" type="string"/>
 
-    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v1.5.0" type="string"/>
+    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v1.5.10" type="string"/>
 
-    <var name="kotlinReleaseDate" value="May 5, 2021" type="string"/>
+    <var name="kotlinReleaseDate" value="May 24, 2021" type="string"/>
 
     <var name="coroutinesVersion" value="1.5.0" type="string"/>
 


### PR DESCRIPTION
- Add 1.5.10 to the releases table
- Update version variables
- K/JS: Add instruction on fallback to webpack 4 (removed previously due to a bug in 1.5.0) 
cc @ilgonmic @dromanov-jb 