### PR TITLE
KT-45870

### DIFF
--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -22,7 +22,7 @@ project, pass a compiler type to the `js` function in your Gradle build script:
 
 ```groovy
 kotlin {
-    js(IR) { // or: LEGACY, BOTH
+    js(IR) { // or: LEGACY
         // . . .
     }
     binaries.executable()

--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -22,10 +22,10 @@ project, pass a compiler type to the `js` function in your Gradle build script:
 
 ```groovy
 kotlin {
-    js(IR) { // or: LEGACY
-        // . . .
+    js(IR) { // or: LEGACY, BOTH
+        // ...
     }
-    binaries.executable()
+    // ...
 }
 ```
 
@@ -120,7 +120,7 @@ or can be set as one of the project-specific options inside your `js` block insi
 ```groovy
 kotlin {
     js(BOTH) {
-        // . . .
+        // ...
     }
 }
 ```


### PR DESCRIPTION
`binaries.executable()` can't be called for `BOTH`