### PR TITLE
Add `value` in Modifiers order

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -344,7 +344,7 @@ vararg
 suspend
 inner
 enum / annotation / fun // as a modifier in `fun interface`companion
-inline
+inline / value
 infix
 operator
 data


### PR DESCRIPTION
`value` was introduced in `1.5` and because is very related with `inline` it seems reasonable to have the same priority.