### PR TITLE
De-capitalize "interoperability"

### DIFF
--- a/docs/topics/jvm/java-interop.md
+++ b/docs/topics/jvm/java-interop.md
@@ -1,6 +1,6 @@
 [//]: # (title: Calling Java from Kotlin)
 
-Kotlin is designed with Java Interoperability in mind. Existing Java code can be called from Kotlin in a natural way,
+Kotlin is designed with Java interoperability in mind. Existing Java code can be called from Kotlin in a natural way,
 and Kotlin code can be used from Java rather smoothly as well.
 In this section, we describe some details about calling Java code from Kotlin.
 


### PR DESCRIPTION
There doesn't seem to be a reason why we're capitalizing this on https://kotlinlang.org/docs/java-interop.html.