### PR TITLE
Update examples for list and set

### DIFF
--- a/docs/topics/collections-overview.md
+++ b/docs/topics/collections-overview.md
@@ -13,10 +13,11 @@ calculate their average age.
 The  following collection types are relevant for Kotlin:
 
 * _List_ is an ordered collection with access to elements by indices – integer numbers that reflect their position. 
-Elements can occur more than once in a list. An example of a list is a sentence: it's a group of words, their order is 
-important, and they can repeat. 
+Elements can occur more than once in a list. An example of a list is a telephone number: it's a group of numbers, their
+order is important, and they can repeat. 
 * _Set_ is a collection of unique elements. It reflects the mathematical abstraction of set: a group of objects without 
-repetitions. Generally, the order of set elements has no significance. For example, an alphabet is a set of letters. 
+repetitions. Generally, the order of set elements has no significance. For example, the numbers on a lottery ticket are a
+set: they are unique, and the order is not important.
 * _Map_ (or _dictionary_) is a set of key-value pairs. Keys are unique, and each of them maps to exactly one value. The
  values can be duplicates. Maps are useful for storing logical connections between objects, for example, an employee's ID 
  and their position.

--- a/docs/topics/collections-overview.md
+++ b/docs/topics/collections-overview.md
@@ -13,11 +13,11 @@ calculate their average age.
 The  following collection types are relevant for Kotlin:
 
 * _List_ is an ordered collection with access to elements by indices – integer numbers that reflect their position. 
-Elements can occur more than once in a list. An example of a list is a telephone number: it's a group of numbers, their
+Elements can occur more than once in a list. An example of a list is a telephone number: it's a group of digits, their
 order is important, and they can repeat. 
 * _Set_ is a collection of unique elements. It reflects the mathematical abstraction of set: a group of objects without 
-repetitions. Generally, the order of set elements has no significance. For example, the numbers on a lottery ticket are a
-set: they are unique, and the order is not important.
+repetitions. Generally, the order of set elements has no significance. For example, the numbers on lottery tickets form a
+set: they are unique, and their order is not important.
 * _Map_ (or _dictionary_) is a set of key-value pairs. Keys are unique, and each of them maps to exactly one value. The
  values can be duplicates. Maps are useful for storing logical connections between objects, for example, an employee's ID 
  and their position.


### PR DESCRIPTION
This PR updates the examples given for a list and a set in this article: https://kotlinlang.org/docs/collections-overview.html

I think that an alphabet is a bad example for a set, because an alphabet is ordered. We even have the term _alphabetical order_. So I changed it to a lottery ticket.

I also changed the example for list, because while a sentence is a collection of words, it also has spaces and punctuation, so I think that example was unclear. I used the example of a telephone number instead, which is just a collection of ordered numbers.

I'm happy to change the examples here,  these were just the better examples I thought of. The main thing that I think should change is the usage of an alphabet as an example of a set.