### PR TITLE
KT-47068: Add schema for data/user-groups.yml

### DIFF
--- a/.github/workflows/validate-user-groups-data.yml
+++ b/.github/workflows/validate-user-groups-data.yml
@@ -1,0 +1,19 @@
+name: Validate user groups data
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  validate_user_groups_data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: chrisdickinson/setup-yq@latest
+        with:
+          yq-version: 'v4.9.5'
+      - run: |
+         jsonschema -i <(yq eval --tojson -j data/user-groups.yml) data/schemas/user-groups.json
+         echo "User groups data is valid!"

--- a/data/schemas/user-groups.json
+++ b/data/schemas/user-groups.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "section": {
+        "type": "string"
+      },
+      "anchorId": {
+        "type": "string"
+      },
+      "groups": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "country": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "country",
+            "url"
+          ]
+        }
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "section",
+      "anchorId",
+      "groups"
+    ]
+  }
+}


### PR DESCRIPTION
Issue: https://youtrack.jetbrains.com/issue/KT-47068

It helps ensuring that the data is valid to some extent, e.g. helps
avoid typos in field names or missing fields.

After this commit, it's possible to e.g. point IntelliJ IDEA to use
this schema when editing `data/user-groups.yml` and the IDE will show
warnings in case something's wrong. The second commit also adds a
GitHub action that validates the data on each PR and push to master.

# Testing

I removed a required property of some user group and checked how it's reported:

via command line:

```
> jsonschema -i <(yq eval --tojson -j data/user-groups.yml) data/schemas/user-groups.json
{'name': 'Athens Kotlin User Group', 'url': 'https://www.meetup.com/Kotlin-Athens/'}: 'country' is a required property
```

in IntelliJ IDEA:

![image](https://user-images.githubusercontent.com/3110813/121789487-951bd080-cbd6-11eb-9c3f-48ef588d1123.png)

![image](https://user-images.githubusercontent.com/3110813/121789491-af55ae80-cbd6-11eb-86d0-971b58a36812.png)

in GitHub actions (different kind of error introduced):

![image](https://user-images.githubusercontent.com/3110813/122996265-f5ff9180-d3aa-11eb-8263-26bbbc205fdf.png)

