### PR TITLE
Add Kotlin2JsCompile snippet to enable lazy property init for K/JS

### DIFF
--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -83,7 +83,15 @@ lazily. This way, the application loads without initializing all the top-level p
 only the ones needed at startup; other properties receive their values later when the code that uses them actually runs. 
 
 As an experimental feature, lazy initialization of top-level properties requires an opt-in. To use the lazy initialization
-of top-level properties, add the `-Xir-property-lazy-initialization` option when compiling the code with the JS IR compiler.
+of top-level properties, add the `-Xir-property-lazy-initialization` option when compiling the code with the JS IR compiler:
+
+```kotlin
+tasks.withType<KotlinJsIrLink> {
+   kotlinOptions {
+     freeCompilerArgs += "-Xir-property-lazy-initialization"
+   }
+}
+```
 
 ## Preview: generation of TypeScript declaration files (d.ts)
 

--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -86,7 +86,7 @@ As an experimental feature, lazy initialization of top-level properties requires
 of top-level properties, add the `-Xir-property-lazy-initialization` option when compiling the code with the JS IR compiler:
 
 ```kotlin
-tasks.withType<KotlinJsIrLink> {
+tasks.withType<Kotlin2JsCompile> {
    kotlinOptions {
      freeCompilerArgs += "-Xir-property-lazy-initialization"
    }

--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -85,6 +85,16 @@ only the ones needed at startup; other properties receive their values later whe
 As an experimental feature, lazy initialization of top-level properties requires an opt-in. To use the lazy initialization
 of top-level properties, add the `-Xir-property-lazy-initialization` option when compiling the code with the JS IR compiler:
 
+<tabs>
+    
+```groovy
+tasks.withType(Kotlin2JsCompile) {
+   kotlinOptions {
+     freeCompilerArgs += "-Xir-property-lazy-initialization"
+   }
+}
+```
+
 ```kotlin
 tasks.withType<Kotlin2JsCompile> {
    kotlinOptions {
@@ -92,6 +102,8 @@ tasks.withType<Kotlin2JsCompile> {
    }
 }
 ```
+
+</tabs>
 
 ## Preview: generation of TypeScript declaration files (d.ts)
 


### PR DESCRIPTION
As per @ilgonmic's recommendation, and as pointed out by @sashache.