### PR TITLE
Add a simple example of abstract classes

### DIFF
--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -217,7 +217,7 @@ abstract class Polygon {
     abstract fun draw()
 }
 
-class Rectangle : Polygon {
+class Rectangle : Polygon() {
     override fun draw() {
         // draw the rectangle
     }
@@ -233,7 +233,7 @@ open class Polygon {
     }
 }
 
-abstract class WildShape : Polygon {
+abstract class WildShape : Polygon() {
     // Classes that inherit WildShape need to provide their own
     // draw method instead of using the default on Polygon
     abstract override fun draw()

--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -212,14 +212,30 @@ A class and some of its members may be declared `abstract`.
 An abstract member does not have an implementation in its class.
 You don't need to annotate an abstract class or function with `open`.
 
+```kotlin
+abstract class Polygon {
+    abstract fun draw()
+}
+
+class Rectangle : Polygon {
+    override fun draw() {
+        // draw the rectangle
+    }
+}
+```
+
 You can override a non-abstract `open` member with an abstract one.
 
 ```kotlin
 open class Polygon {
-    open fun draw() {}
+    open fun draw() {
+        // some default polygon drawing method
+    }
 }
 
-abstract class Rectangle : Polygon() {
+abstract class WildShape : Polygon {
+    // Classes that inherit WildShape need to provide their own
+    // draw method instead of using the default on Polygon
     abstract override fun draw()
 }
 ```


### PR DESCRIPTION
The current documentation has no simple example for abstract base classes and instead jumps directly into the syntax for overriding an open method in an open class to convert it to abstract in an inheriting classes.

This can confuse users experience for users new to the language especially since the example showed a rectangle class overriding and abstracting a method in the Polygon class.

This change introduces

1. A simple example for an abstract base class
2. A modified version of overriding and converting to abstract an open method in an open class.

This provides a more simple example to abstract classes for newer users.