### PR TITLE
Unsigned types: removed Inline Class warning

### DIFF
--- a/docs/topics/basic-types.md
+++ b/docs/topics/basic-types.md
@@ -311,8 +311,6 @@ Unsigned types support most of the operations of their signed counterparts.
 >
 {type="note"}
 
-Unsigned types are implemented using feature that's not yet stable, namely [inline classes](inline-classes.md).
-
 #### Unsigned arrays and ranges 
 
 > Unsigned arrays and operations on them are in [Beta](components-stability.md). They can be changed incompatibly at any time.


### PR DESCRIPTION
In the section unsigned types of the basic types chapter there is a line that "Unsigned types are implemented using feature that's not yet stable, namely inline classes.".
I removed it because inline classes are stable as of Kotlin 1.5.10