### PR TITLE
Correct function parameter naming notation

### DIFF
--- a/docs/topics/functions.md
+++ b/docs/topics/functions.md
@@ -24,7 +24,7 @@ Stream().read() // create instance of class Stream and call read()
 
 ### Parameters
 
-Function parameters are defined using Pascal notation - *name*: *type*. Parameters are separated using commas. Each 
+Function parameters are defined using lower camel case notation - *name*: *type*. Parameters are separated using commas. Each 
 parameter must be explicitly typed:
 
 ```kotlin


### PR DESCRIPTION
Function parameters start with a lowercase letter, but the documentation says they use Pascal notation, which is contradictory. Pascal notation starts with an uppercase letter. So my edit is to change the doc to say "lower camel case".