### PR TITLE
KT-47068: Allow specifying positions for user groups

### DIFF
--- a/data/schemas/user-groups.json
+++ b/data/schemas/user-groups.json
@@ -23,6 +23,26 @@
             },
             "url": {
               "type": "string"
+            },
+            "position": {
+              "type": "object",
+              "properties": {
+                "lat": {
+                  "type": "number",
+                  "minimum": -90,
+                  "maximum": 90
+                },
+                "lng": {
+                  "type": "number",
+                  "minimum": -180,
+                  "maximum": 180
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "lat",
+                "lng"
+              ]
             }
           },
           "additionalProperties": false,

--- a/data/user-groups.yml
+++ b/data/user-groups.yml
@@ -184,6 +184,9 @@
     - name: Tricity Kotlin User Group
       country: Poland
       url: https://www.facebook.com/groups/2519853351660362/
+      position:
+        lat: 54.3992731
+        lng: 18.5742013
     - name: Utrecht Kotlin User Group
       country: Netherlands
       url: https://www.meetup.com/meetup-group-YgJEOzCn/


### PR DESCRIPTION
Issue: https://youtrack.jetbrains.com/issue/KT-47068

After this change, it's possible to specify positions for each user
group and it's recommended to do for newly added groups. Backfill for
existing user groups will be done in a separate change.

Names of the new fields were inspired by what's already in
`kotlinconf.yml`, for consistency.

Tricity Kotlin User Group was augmented with position as an example.

FYI @TinaNEs @zoobestik @meilalina (frequent committers around KUGs data)