### PR TITLE
Make clear copy executes init block

### DIFF
--- a/docs/topics/data-classes.md
+++ b/docs/topics/data-classes.md
@@ -77,8 +77,9 @@ fun main() {
 
 ## Copying
   
-To copy an object for changing _some_ of its properties, but keeping the rest unchanged, use  
-the `copy()` function. For the `User` class above, its implementation would be as follows:
+To copy an object for changing _some_ of its properties, but keeping the rest unchanged, use  the `copy()` function, which creates an new instance and also calls the `init` block. 
+
+For the `User` class above, its implementation would be as follows:
 
 ```kotlin
 fun copy(name: String = this.name, age: Int = this.age) = User(name, age)     


### PR DESCRIPTION
Make clear, copy is no "stupid" memory coping, but instead a shortcut for creating a new instance, calling the `init` block.

This would fail:
```kotlin
data class TestingCopy(val s: Int) {
    init {
        require(s != 42)
    }
}

val one = TestingCopy(s = 1)
val second = one.copy(s = 42)
```