### PR TITLE
Improve Gradle Kotlin example for lombok plugin

### DIFF
--- a/docs/topics/lombok.md
+++ b/docs/topics/lombok.md
@@ -48,8 +48,8 @@ plugins {
 
 ```kotlin
 plugins {
-    id ("org.jetbrains.kotlin.plugin.lombok") version "%kotlinVersion%"
-    id ("io.freefair.lombok") version "5.3.0"
+    kotlin("plugin.lombok") version "%kotlinVersion%"
+    id("io.freefair.lombok") version "5.3.0"
 }
 ```
 


### PR DESCRIPTION
The rest of the Kotlin documentation uses the built-in `PluginDependencySpec.kotlin()` method to add Kotlin plugins the lombok plugin should do this too.
Also it's more common to not place a space between the `id` and the arguments as seen in the official Gradle plugin portal 