### PR TITLE
Fix extension method call in example

### DIFF
--- a/docs/topics/extensions.md
+++ b/docs/topics/extensions.md
@@ -221,7 +221,7 @@ class Connection(val host: Host, val port: Int) {
 
 fun main() {
     Connection(Host("kotl.in"), 443).connect()
-    //Host("kotl.in").printConnectionString(443)  // error, the extension function is unavailable outside Connection
+    //Host("kotl.in").printConnectionString()  // error, the extension function is unavailable outside Connection
 }
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3"}


### PR DESCRIPTION
In the example code in section **Declaring extensions as members**, `printConnectionString()` does not accept any arguments.