### PR TITLE
feat: target shortcuts and apple silicon

### DIFF
--- a/docs/topics/mpp/mpp-share-on-platforms.md
+++ b/docs/topics/mpp/mpp-share-on-platforms.md
@@ -111,6 +111,56 @@ kotlin {
 ```
 
 </tabs>
+
+#### Target shortcuts and ARM64 (Apple Silicon) simulators
+
+The target shortcuts `ios`, `watchos` and `tvos` don't include the simulator targets for ARM64 (Apple Silicon) platforms:
+`iosSimulatorArm64`, `watchosSimulatorArm64`, and `tvosSimulatorArm64`. If you use the target shortcuts and want to build 
+the project for an Apple Silicon simulator, adjust the build script the following way:
+
+1. Add the `*SimulatorArm64` simulator target you need.
+2. Connect the simulator target with the shortcut using the source set dependencies (`dependsOn`).
+
+<tabs>
+
+```groovy
+kotlin {
+    ios()
+    // Add the ARM64 simulator target
+    iosSimulatorArm64()
+
+    // Set up dependencies between the source sets
+    sourceSets {
+        // ...
+        iosSimulatorArm64Main {
+            dependsOn(iosMain)
+        }
+        iosSimulatorArm64MainTest {
+            dependsOn(iosTest)
+        }
+    }
+}
+```
+
+```kotlin
+kotlin {
+    ios()
+    // Add the ARM64 simulator target
+    iosSimulatorArm64()
+    
+    val iosMain by sourceSets.getting
+    val iosTest by sourceSets.getting
+    val iosSimulatorArm64Main by sourceSets.getting
+    val iosSimulatorArm64Test by sourceSets.getting
+
+    // Set up dependencies between the source sets
+    iosSimulatorArm64Main.dependsOn(iosMain)
+    iosSimulatorArm64Test.dependsOn(iosTest)
+}
+```
+
+</tabs>
+
  
 ### Configure the hierarchical structure manually
 

--- a/docs/topics/mpp/mpp-share-on-platforms.md
+++ b/docs/topics/mpp/mpp-share-on-platforms.md
@@ -135,7 +135,7 @@ kotlin {
         iosSimulatorArm64Main {
             dependsOn(iosMain)
         }
-        iosSimulatorArm64MainTest {
+        iosSimulatorArm64Test {
             dependsOn(iosTest)
         }
     }

--- a/docs/topics/mpp/mpp-share-on-platforms.md
+++ b/docs/topics/mpp/mpp-share-on-platforms.md
@@ -114,7 +114,7 @@ kotlin {
 
 #### Target shortcuts and ARM64 (Apple Silicon) simulators
 
-The target shortcuts `ios`, `watchos` and `tvos` don't include the simulator targets for ARM64 (Apple Silicon) platforms:
+The target shortcuts `ios`, `watchos`, and `tvos` don't include the simulator targets for ARM64 (Apple Silicon) platforms:
 `iosSimulatorArm64`, `watchosSimulatorArm64`, and `tvosSimulatorArm64`. If you use the target shortcuts and want to build 
 the project for an Apple Silicon simulator, adjust the build script the following way:
 

--- a/docs/topics/native/native-improving-compilation-time.md
+++ b/docs/topics/native/native-improving-compilation-time.md
@@ -65,7 +65,11 @@ Here are some recommendations for configuring Gradle for better compilation perf
   for compiler caches. They improve compilation times for debug builds (for `linuxX64`, this feature is only available on Linux hosts).
   To enable the compiler caches, add `kotlin.native.cacheKind.linuxX64=static` or `kotlin.native.cacheKind.iosArm64=static` to `gradle.properties`.
 
-  `iosX64` and `macosX64` targets already have the compiler caches enabled by default.
+  The following targets already have the compiler caches enabled by default:
+  * `iosX64`
+  * `iosSimulatorArm64`
+  * `macosX64`
+  * `macosArm64`
 
 * **Enable previously disabled features of Kotlin/Native**. There are properties that disable the Gradle daemon and compiler
   caches – `kotlin.native.disableCompilerDaemon=true` and `kotlin.native.cacheKind=none`. If you had issues with these


### PR DESCRIPTION
Explain how to use new arm64 simulator targets with existing [target shortcuts](https://kotlinlang.org/docs/mpp-share-on-platforms.html#use-target-shortcuts).