### PR TITLE
Replace dependency on Node Buffer API

### DIFF
--- a/docs/topics/mpp/multiplatform-library.md
+++ b/docs/topics/mpp/multiplatform-library.md
@@ -7,7 +7,7 @@ This library converts raw data – strings and byte arrays – to the [Base64](h
 You will use different ways to implement the conversion to the Base64 format on different platforms:
 
 * For JVM – the [`java.util.Base64` class](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html).
-* For JS – the [`WindowOrWorkerGlobalScope.btoa()` API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/btoa).
+* For JS – the [`btoa()` function](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/btoa).
 * For Kotlin/Native – your own implementation.
 
 You will also test your code using common tests, and then publish the library to your local Maven repository.
@@ -100,7 +100,7 @@ The JS implementation will be very similar to the JVM one.
 
 1. In the `jsMain/kotlin` directory, create the `org.jetbrains.base64` package.
 2. Create the `Base64.kt` file in the new package.
-3. Provide a simple implementation of the `Base64Factory` object that delegates to the `WindowOrWorkerGlobalScope.btoa()` API:
+3. Provide a simple implementation of the `Base64Factory` object that delegates to the `btoa()` function.
 
     ```kotlin
     package org.jetbrains.base64

--- a/docs/topics/mpp/multiplatform-library.md
+++ b/docs/topics/mpp/multiplatform-library.md
@@ -7,7 +7,7 @@ This library converts raw data – strings and byte arrays – to the [Base64](h
 You will use different ways to implement the conversion to the Base64 format on different platforms:
 
 * For JVM – the [`java.util.Base64` class](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html).
-* For JS – the [Buffer API](https://nodejs.org/docs/latest/api/buffer.html).
+* For JS – the [`WindowOrWorkerGlobalScope.btoa()` API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/btoa).
 * For Kotlin/Native – your own implementation.
 
 You will also test your code using common tests, and then publish the library to your local Maven repository.
@@ -100,7 +100,7 @@ The JS implementation will be very similar to the JVM one.
 
 1. In the `jsMain/kotlin` directory, create the `org.jetbrains.base64` package.
 2. Create the `Base64.kt` file in the new package.
-3. Provide a simple implementation of the `Base64Factory` object that delegates to the NodeJS `Buffer` API:
+3. Provide a simple implementation of the `Base64Factory` object that delegates to the `WindowOrWorkerGlobalScope.btoa()` API:
 
     ```kotlin
     package org.jetbrains.base64
@@ -111,9 +111,9 @@ The JS implementation will be very similar to the JVM one.
     
     object JsBase64Encoder : Base64Encoder {
         override fun encode(src: ByteArray): ByteArray {
-            val buffer = js("Buffer").from(src)
-            val string = buffer.toString("base64") as String
-            return ByteArray(string.length) { string[it].toByte() }
+            val string = src.decodeToString()
+            val encodedString = js("btoa(string)") as String
+            return encodedString.encodeToByteArray()
         }
     }
     ```

--- a/docs/topics/mpp/multiplatform-library.md
+++ b/docs/topics/mpp/multiplatform-library.md
@@ -104,7 +104,9 @@ The JS implementation will be very similar to the JVM one.
 
     ```kotlin
     package org.jetbrains.base64
-   
+    
+    import kotlinx.browser.window
+    
     actual object Base64Factory {
         actual fun createEncoder(): Base64Encoder = JsBase64Encoder
     }
@@ -112,7 +114,7 @@ The JS implementation will be very similar to the JVM one.
     object JsBase64Encoder : Base64Encoder {
         override fun encode(src: ByteArray): ByteArray {
             val string = src.decodeToString()
-            val encodedString = js("btoa(string)") as String
+            val encodedString = window.btoa(string)
             return encodedString.encodeToByteArray()
         }
     }


### PR DESCRIPTION
This fixes an issue: https://kotlinlang.slack.com/archives/C0B8L3U69/p1628876549226400

The issue is likely cause by the project being created by IDEA, which produces

```
js(LEGACY) {
    browser {
        commonWebpackConfig {
            cssSupport.enabled = true
        }
    }
}
```

in build.gradle.kts. Note that this uses a `browser` instead of `nodejs` target. Because of this, running the tests as described in the document (before this commit) results in failure:

```
ReferenceError: Buffer is not defined
```

This commit fixes that issue by replacing the used Node API for a browser API: `btoa`.