### PR TITLE
Add note about inlining of const vals

### DIFF
--- a/docs/topics/properties.md
+++ b/docs/topics/properties.md
@@ -146,7 +146,26 @@ Such a property needs to fulfil the following requirements:
 * It must be initialized with a value of type `String` or a primitive type
 * It cannot be a custom getter
 
-Such properties can be used in annotations:
+The compiler will inline usages of the constant, but will not remove the field (this can be useful when using [reflection](reflection.md)). For example, this Kotlin code compiles to the following Java code:
+
+```kotlin
+const val MESSAGE: String = "Hello, World!"
+
+fun main() {
+    println(MESSAGE)
+}
+```
+{kotlin-runnable="true"}
+
+```java
+public static final String MESSAGE = "Hello, World!";
+
+public static void main(String[] args) {
+    System.out.println("Hello, World!");
+}
+```
+
+Such properties can also be used in annotations:
 
 ```kotlin
 const val SUBSYSTEM_DEPRECATED: String = "This subsystem is deprecated"

--- a/docs/topics/properties.md
+++ b/docs/topics/properties.md
@@ -146,24 +146,7 @@ Such a property needs to fulfil the following requirements:
 * It must be initialized with a value of type `String` or a primitive type
 * It cannot be a custom getter
 
-The compiler will inline usages of the constant, but will not remove the field (this can be useful when using [reflection](reflection.md)). For example, this Kotlin code compiles to the following Java code:
-
-```kotlin
-const val MESSAGE: String = "Hello, World!"
-
-fun main() {
-    println(MESSAGE)
-}
-```
-{kotlin-runnable="true"}
-
-```java
-public static final String MESSAGE = "Hello, World!";
-
-public static void main(String[] args) {
-    System.out.println("Hello, World!");
-}
-```
+The compiler will inline usages of the constant, replacing the reference to the constant with its actual value. However, the field will not be removed and therefore can be interacted with using [reflection](reflection.md).
 
 Such properties can also be used in annotations:
 


### PR DESCRIPTION
The current docs state what the limitations are and the ability to use constants in annotations, but nothing is said about what actually happens to them in regular code usages (which I think are much common). Having an outright statement in the docs would settle confusion that can arise from outdated/unclear YouTrack Issues and posts in Kotlin Discussions that slightly contradict.