### PR TITLE
Added info on jvm backends to compatibility guide

### DIFF
--- a/docs/topics/compatibility-guide-13.md
+++ b/docs/topics/compatibility-guide-13.md
@@ -77,7 +77,7 @@ Compatibility of Kotlin code from the other languages perspective (e.g. from Jav
 > **Deprecation cycle**:
 >
 > - <1.3: the compiler could miss such assertions when type inference was involved, allowing potential `null` propagation during compilation against binaries (see Issue for details).
-> - \>=1.3: the compiler generates missed assertions. This can case code which was (erroneously) passing `null`s here fail faster.  
+> - \>=1.3: the compiler generates missed assertions. This can cause code which was (erroneously) passing `null`s here fail faster.  
  `-XXLanguage:-StrictJavaNullabilityAssertions` can be used to temporarily return to the pre-1.3 behavior. Support for this flag will be removed in the next major release.
 
 ### Unsound smartcasts on enum members

--- a/docs/topics/compatibility-guide-15.md
+++ b/docs/topics/compatibility-guide-15.md
@@ -134,7 +134,7 @@ perspective
 >
 > - 1.4.20: introduce warning for the problematic references
 > - \>= 1.5: raise this warning to an error,
-    >  `-XXLanguage:-ForbidReferencingToUnderscoreNamedParameterOfCatchBlock` can be used to temporarily revert to pre-1.5 behavior
+>  `-XXLanguage:-ForbidReferencingToUnderscoreNamedParameterOfCatchBlock` can be used to temporarily revert to pre-1.5 behavior
 
 ### Change implementation strategy of SAM conversion from anonymous class-based to invokedynamic
 
@@ -150,6 +150,55 @@ perspective
 >
 > - 1.5: change implementation strategy of SAM conversion,
 >  `-Xsam-conversions=class` can be used to revert implementation scheme to the one that used before
+ 
+### Switch between JVM backends
+
+> **Issue**: [KT-48233](https://youtrack.jetbrains.com/issue/KT-48233)
+>
+> **Component**: Kotlin/JVM
+>
+> **Incompatible change type**: behavioral
+>
+> **Short summary**: Kotlin 1.5 uses the [IR-based backend](https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together/)
+> for the Kotlin/JVM compiler by default. The old backend is still used by default for earlier language versions.
+>
+> You might encounter some performance degradation issues using the new compiler in Kotlin 1.5. We are working on fixing
+> such cases.
+>
+> **Deprecation cycle**:
+>
+> - < 1.5: by default, the old JVM backend is used
+> - \>= 1.5: by default, the IR-based backend is used. If you need to use the old backend in Kotlin 1.5, add
+> the following lines to the project’s configuration file to temporarily revert to pre-1.5 behavior:
+>
+> In Gradle:
+>
+> <tabs>
+>
+> ```kotlin
+> tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile> {
+>  kotlinOptions.useOldBackend = true
+> }
+> ```
+>
+> ```groovy
+> tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile) {
+> kotlinOptions.useOldBackend = true
+> }
+> ```
+>
+> </tabs>
+>
+> In Maven:
+>
+>```xml
+> <configuration>
+>     <args>
+>         <arg>-Xuse-old-backend</arg>
+>     </args>
+> </configuration>
+> ```
+> Support for this flag will be removed in one of the future releases.
 
 ### Generate nullability assertion for delegated properties with a generic call in the delegate expression
 
@@ -335,52 +384,3 @@ perspective
 >      ```
 >      After excluding the testing framework, test your application. If it stopped working, rollback excluding changes, 
 > use the same testing framework as the library does, and exclude your testing framework.
-
-### Switch to JVM IR backend
-
-> **Issue**: [KT-48233](https://youtrack.jetbrains.com/issue/KT-48233)
->
-> **Component**: Kotlin/JVM
->
-> **Incompatible change type**: behavioral
->
-> **Short summary**: Kotlin 1.5 uses the [IR-based backend](https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together/)
-> for the Kotlin/JVM compiler by default. The old backend is still used by default for earlier language versions.
->
-> You might encounter some performance degradation issues using the new compiler in Kotlin 1.5. We are working on fixing
-> such cases.
->
-> **Deprecation cycle**:
->
-> - < 1.5: old behavior (see details in the issue)
-> - \>= 1.5: behavior changed, if you need to use the old backend in Kotlin 1.5, add the following lines to the project’s 
-> configuration file to temporarily revert to pre-1.5 behavior:
->
-> In Gradle:
->
-> <tabs>
->
-> ```kotlin
-> tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile> {
->  kotlinOptions.useOldBackend = true
-> }
-> ```
->
-> ```groovy
-> tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile) {
-> kotlinOptions.useOldBackend = true
-> }
-> ```
->
-> </tabs>
->
-> In Maven:
->
->```xml
-> <configuration>
->     <args>
->         <arg>-Xuse-old-backend</arg>
->     </args>
-> </configuration>
-> ```
-> Support for this flag will be removed in one of the future major releases.

--- a/docs/topics/compatibility-guide-15.md
+++ b/docs/topics/compatibility-guide-15.md
@@ -335,3 +335,52 @@ perspective
 >      ```
 >      After excluding the testing framework, test your application. If it stopped working, rollback excluding changes, 
 > use the same testing framework as the library does, and exclude your testing framework.
+
+### Switch to JVM IR backend
+
+> **Issue**: [KT-48233](https://youtrack.jetbrains.com/issue/KT-48233)
+>
+> **Component**: Kotlin/JVM
+>
+> **Incompatible change type**: behavioral
+>
+> **Short summary**: Kotlin 1.5 uses the [IR-based backend](https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together/)
+> for the Kotlin/JVM compiler by default. The old backend is still used by default for earlier language versions.
+>
+> You might encounter some performance degradation issues using the new compiler in Kotlin 1.5. We are working on fixing
+> such cases.
+>
+> **Deprecation cycle**:
+>
+> - < 1.5: old behavior (see details in the issue)
+> - \>= 1.5: behavior changed, if you need to use the old backend in Kotlin 1.5, add the following lines to the project’s 
+> configuration file to temporarily revert to pre-1.5 behavior:
+>
+> In Gradle:
+>
+> <tabs>
+>
+> ```kotlin
+> tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile> {
+>  kotlinOptions.useOldBackend = true
+> }
+> ```
+>
+> ```groovy
+> tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile) {
+> kotlinOptions.useOldBackend = true
+> }
+> ```
+>
+> </tabs>
+>
+> In Maven:
+>
+>```xml
+> <configuration>
+>     <args>
+>         <arg>-Xuse-old-backend</arg>
+>     </args>
+> </configuration>
+> ```
+> Support for this flag will be removed in one of the future major releases.

--- a/docs/topics/compatibility-guide-15.md
+++ b/docs/topics/compatibility-guide-15.md
@@ -168,8 +168,7 @@ perspective
 > **Deprecation cycle**:
 >
 > - < 1.5: by default, the old JVM backend is used
-> - \>= 1.5: by default, the IR-based backend is used. If you need to use the old backend in Kotlin 1.5, add
-> the following lines to the project’s configuration file to temporarily revert to pre-1.5 behavior:
+> - \>= 1.5: by default, the IR-based backend is used. If you need to use the old backend in Kotlin 1.5, add the following lines to the project’s configuration file to temporarily revert to pre-1.5 behavior:
 >
 > In Gradle:
 >
@@ -177,13 +176,13 @@ perspective
 >
 > ```kotlin
 > tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile> {
->  kotlinOptions.useOldBackend = true
+>   kotlinOptions.useOldBackend = true
 > }
 > ```
 >
 > ```groovy
 > tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile) {
-> kotlinOptions.useOldBackend = true
+>   kotlinOptions.useOldBackend = true
 > }
 > ```
 >
@@ -191,13 +190,14 @@ perspective
 >
 > In Maven:
 >
->```xml
+> ```xml
 > <configuration>
 >     <args>
 >         <arg>-Xuse-old-backend</arg>
 >     </args>
 > </configuration>
 > ```
+>
 > Support for this flag will be removed in one of the future releases.
 
 ### Generate nullability assertion for delegated properties with a generic call in the delegate expression


### PR DESCRIPTION
update: compatibility guide updated with a note about switching to the old jvm backend

