### PR TITLE
Remove dataclass comment about generating setters

### DIFF
--- a/kotlin-features/concise.md
+++ b/kotlin-features/concise.md
@@ -1,7 +1,7 @@
 <div class="sample" markdown="1" mode="kotlin" theme="idea" data-highlight-only="1" auto-indent="false">
 ```kotlin
 /*
- Create a POJO with getters, setters, `equals()`, `hashCode()`,
+ Create a POJO with getters, `equals()`, `hashCode()`,
  `toString()` and `copy()` in a single line:
 */
 


### PR DESCRIPTION
The code below doesn't actually generate setters, because it uses `val`:
https://pl.kotl.in/puHlJh3AI

If I try to use setters: 

```
    val c = Customer("Alice", "alice@bob.com", "Jetbrains")
    c.setName("Bob")
    c.name = "Bob"
```

I get errors:

```
Unresolved reference: setName
Val cannot be reassigned
```