### PR TITLE
Change parseInt (deprecated) to .toInt()

### DIFF
--- a/docs/topics/control-flow.md
+++ b/docs/topics/control-flow.md
@@ -76,7 +76,7 @@ You can use arbitrary expressions (not only constants) as branch conditions
 
 ```kotlin
 when (x) {
-    parseInt(s) -> print("s encodes x")
+    s.toInt() -> print("s encodes x")
     else -> print("s does not encode x")
 }
 ```

--- a/docs/topics/exceptions.md
+++ b/docs/topics/exceptions.md
@@ -36,7 +36,7 @@ However, at least one `catch` or `finally` block is required.
 `try` is an expression, which means it can have a return value:
 
 ```kotlin
-val a: Int? = try { parseInt(input) } catch (e: NumberFormatException) { null }
+val a: Int? = try { input.toInt() } catch (e: NumberFormatException) { null }
 ```
 
 The returned value of a `try` expression is either the last expression in the `try` block or the


### PR DESCRIPTION
Following [api](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.js/parse-int.html) parseInt is deprecated and .toInt() should be used in place 