### PR TITLE
MutableLists should be stored in vals, not vars

### DIFF
--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -119,7 +119,7 @@ done using the `this` keyword:
 
 ```kotlin
 class Person(val name: String) {
-    var children: MutableList<Person> = mutableListOf()
+    val children: MutableList<Person> = mutableListOf()
     constructor(name: String, parent: Person) : this(name) {
         parent.children.add(this)
     }


### PR DESCRIPTION
Mutation to MutableLists should be done not by reassigning the property, but by modifying the list.  Otherwise, you can get nasty ambiguity errors with e.g. +=.