### PR TITLE
update: K/N compiler caches and Windows cross compilation

### DIFF
--- a/docs/topics/mpp/mpp-supported-platforms.md
+++ b/docs/topics/mpp/mpp-supported-platforms.md
@@ -72,7 +72,7 @@ Kotlin supports the following platforms and provides target presets for each pla
     <tr>
         <td>Windows</td>
         <td><code>mingwX64</code>, <code>mingwX86</code></td>
-        <td>Requires a Windows host.</td>
+        <td></td>
     </tr>
     <tr>
         <td>WebAssembly</td>

--- a/docs/topics/native/native-improving-compilation-time.md
+++ b/docs/topics/native/native-improving-compilation-time.md
@@ -61,16 +61,6 @@ Here are some recommendations for configuring Gradle for better compilation perf
     * **Local build cache**: Add `org.gradle.caching=true` to your `gradle.properties` or run with `--build-cache` on the command line.
     * **Remote build cache** in continuous integration environments. Learn how to [configure the remote build cache](https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure_remote).
 
-* **Use the compiler caches**. Starting from 1.5.0-M1, `linuxX64` and `iosArm64` targets have experimental opt-in support
-  for compiler caches. They improve compilation times for debug builds (for `linuxX64`, this feature is only available on Linux hosts).
-  To enable the compiler caches, add `kotlin.native.cacheKind.linuxX64=static` or `kotlin.native.cacheKind.iosArm64=static` to `gradle.properties`.
-
-  The following targets already have the compiler caches enabled by default:
-  * `iosX64`
-  * `iosSimulatorArm64`
-  * `macosX64`
-  * `macosArm64`
-
 * **Enable previously disabled features of Kotlin/Native**. There are properties that disable the Gradle daemon and compiler
   caches – `kotlin.native.disableCompilerDaemon=true` and `kotlin.native.cacheKind=none`. If you had issues with these
   features before and added these lines to your `gradle.properties` or Gradle arguments, remove them and check whether


### PR DESCRIPTION
- compiler caches by default for `linuxX64` and `iosArm64`
- Windows as a cross-compilation target