### PR TITLE
fix: remove aux ids from KMM topics

### DIFF
--- a/docs/topics/kmm/kmm-add-dependencies.md
+++ b/docs/topics/kmm/kmm-add-dependencies.md
@@ -1,5 +1,4 @@
 [//]: # (title: Add dependencies to KMM modules)
-[//]: # (auxiliary-id: Add_dependencies_to_KMM_modules)
 
 Every application requires a set of libraries in order to operate successfully. 
 A KMM application can depend on multiplatform libraries that work on both iOS and Android, and it can depend on platform-specific iOS and Android libraries. 

--- a/docs/topics/kmm/kmm-concurrency-and-coroutines.md
+++ b/docs/topics/kmm/kmm-concurrency-and-coroutines.md
@@ -1,5 +1,4 @@
 [//]: # (title: Concurrency and coroutines)
-[//]: # (auxiliary-id: Concurrency_and_Coroutines)
 
 When working with mobile platforms, you may need to write multithreaded code that runs in parallel. For this, 
 you can use the [standard](#coroutines) `kotlinx.coroutines` library or its [multithreaded version](#multithreaded-coroutines) 

--- a/docs/topics/kmm/kmm-concurrency-overview.md
+++ b/docs/topics/kmm/kmm-concurrency-overview.md
@@ -1,5 +1,4 @@
 [//]: # (title: Concurrency overview)
-[//]: # (auxiliary-id: Concurrency_Overview)
 
 When you extend your development experience from Android to Kotlin Multiplatform Mobile, you will encounter a different state 
 and concurrency model for iOS. This is a Kotlin/Native model. [Kotlin/Native](native-overview.md) 

--- a/docs/topics/kmm/kmm-concurrent-mutability.md
+++ b/docs/topics/kmm/kmm-concurrent-mutability.md
@@ -1,5 +1,4 @@
 [//]: # (title: Concurrent mutability)
-[//]: # (auxiliary-id: Concurrent_Mutability)
 
 When it comes to working with iOS, [Kotlin/Native's state and concurrency model](kmm-concurrency-overview.md) has [two simple rules](kmm-concurrency-overview.md#rules-for-state-sharing).
 

--- a/docs/topics/kmm/kmm-configure-sqldelight-for-data-storage.md
+++ b/docs/topics/kmm/kmm-configure-sqldelight-for-data-storage.md
@@ -1,5 +1,4 @@
 [//]: # (title: Configure SQLDelight for data storage)
-[//]: # (auxiliary-id: Configure_SQLDelight_for_data_storage)
 
 In the world of mobile development, databases are often used for local data storage on client devices. One of the options
 for working with databases in Kotlin Mobile Multiplatform (*KMM*) projects is the

--- a/docs/topics/kmm/kmm-connect-to-platform-specific-apis.md
+++ b/docs/topics/kmm/kmm-connect-to-platform-specific-apis.md
@@ -1,5 +1,4 @@
 [//]: # (title: Connect to platform-specific APIs)
-[//]: # (auxiliary-id: Connect_to_Platform-Specific_APIs)
 
 If you’re developing mobile applications for different platforms with Kotlin Multiplatform Mobile and need to access 
 platform-specific APIs that implement required functionality (for example, generating a UUID), 

--- a/docs/topics/kmm/kmm-create-first-app.md
+++ b/docs/topics/kmm/kmm-create-first-app.md
@@ -1,5 +1,4 @@
 [//]: # (title: Create your first multiplatform application – tutorial)
-[//]: # (auxiliary-id: Create_your_first_multiplatform_application)
 
 Here you will learn how to create and run your first KMM application.
 

--- a/docs/topics/kmm/kmm-getting-started.md
+++ b/docs/topics/kmm/kmm-getting-started.md
@@ -1,5 +1,4 @@
 [//]: # (title: Getting started)
-[//]: # (auxiliary-id: Getting_started)
 
 ## Get familiar with KMM
 

--- a/docs/topics/kmm/kmm-integrate-in-existing-app.md
+++ b/docs/topics/kmm/kmm-integrate-in-existing-app.md
@@ -1,5 +1,4 @@
 [//]: # (title: Make your Android application work on iOS – tutorial)
-[//]: # (auxiliary-id: Make_your_Android_application_work_on_iOS_tutorial)
 
 Here you can learn how to make your existing Android application cross-platform so that it works both on Android and iOS.
 You'll be able to write code and test it for both Android and iOS only once, in one place.

--- a/docs/topics/kmm/kmm-introduce-your-team.md
+++ b/docs/topics/kmm/kmm-introduce-your-team.md
@@ -1,5 +1,4 @@
 [//]: # (title: Introduce your team to KMM)
-[//]: # (auxiliary-id: Introduce_your_team_to_KMM)
 
 These recommendations will help you introduce your team to KMM:
 

--- a/docs/topics/kmm/kmm-plugin-releases.md
+++ b/docs/topics/kmm/kmm-plugin-releases.md
@@ -1,5 +1,4 @@
 [//]: # (title: KMM plugin releases)
-[//]: # (auxiliary-id: KMM_plugin_releases)
 
 Since KMM is now in [Alpha](kotlin-evolution.md), we are working on stabilizing the [KMM plugin for Android Studio](https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile) 
 and will be regularly releasing new versions that include new features, improvements, and bug fixes. 

--- a/docs/topics/kmm/kmm-publish-apps.md
+++ b/docs/topics/kmm/kmm-publish-apps.md
@@ -1,5 +1,4 @@
 [//]: # (title: Publish KMM apps)
-[//]: # (auxiliary-id: Publish_KMM_apps)
 
 Once your mobile apps are ready for release, it’s time to deliver them to the users by publishing them in app stores.
 Multiple stores are available for each platform. However, in this article we’ll focus on the official ones:

--- a/docs/topics/kmm/kmm-samples.md
+++ b/docs/topics/kmm/kmm-samples.md
@@ -1,5 +1,4 @@
 [//]: # (title: Samples)
-[//]: # (auxiliary-id: Samples)
 
 This is a curated list of Kotlin Multiplatform Mobile (KMM) samples.
 

--- a/docs/topics/kmm/kmm-setup.md
+++ b/docs/topics/kmm/kmm-setup.md
@@ -1,5 +1,4 @@
 [//]: # (title: Set up an environment for KMM development)
-[//]: # (auxiliary-id: Set_up_an_environment_for_KMM_development)
 
 Before you begin [creating your first application](kmm-create-first-app.md) to work on both iOS and Android, start by setting up an environment for Kotlin Multiplatform Mobile (KMM) development:
 

--- a/docs/topics/kmm/kmm-understand-project-structure.md
+++ b/docs/topics/kmm/kmm-understand-project-structure.md
@@ -1,5 +1,4 @@
 [//]: # (title: Understand the KMM project structure)
-[//]: # (auxiliary-id: Understand_the_KMM_project_structure)
 
 The purpose of the Kotlin Multiplatform Mobile (_KMM_) technology is unifying the development of applications with common 
 logic for Android and iOS platforms. To make this possible, KMM uses a mobile-specific structure of

--- a/docs/topics/kmm/kmm-use-ktor-for-networking.md
+++ b/docs/topics/kmm/kmm-use-ktor-for-networking.md
@@ -1,5 +1,4 @@
 [//]: # (title: Use Ktor for networking)
-[//]: # (auxiliary-id: Use_Ktor_for_networking)
 
 Conventionally, modern applications with client-server architecture use the HTTP protocol for transferring data between the server and the client. If your mobile app has a server to exchange data with, an HTTP client is an essential part of this app that enables its interaction with the server.
 

--- a/docs/topics/whats-new-in-kotlin-for-kmm.md
+++ b/docs/topics/whats-new-in-kotlin-for-kmm.md
@@ -1,5 +1,4 @@
 [//]: # (title: What's new in Kotlin for KMM)
-[//]: # (auxiliary-id: Whats_new_in_Kotlin_for_KMM)
 
 KMM is part of the larger Kotlin ecosystem and leverages Kotlin features and improvements for a better mobile developer experience. 
 [Every Kotlin release](releases.md#release-details) brings features and improvements that are helpful for mobile developers like you. 


### PR DESCRIPTION
Old auxiliay IDs on KMM pages break build with new Supernova