### PR TITLE
KTL-544: temporary strong version for pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ xmltodict==0.10.2
 git+https://github.com/pik-software/geocoder.git@yandex-api-key#egg=geocoder
 
 ruamel.yaml==0.17.9
+PyYAML==5.4.1
 algoliasearch==1.12.0
 google-api-python-client==1.6.2


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-544

Breaking changes in [pyyaml@6.0](https://github.com/yaml/pyyaml/releases/tag/6.0):
* [pyyaml#561](https://github.com/yaml/pyyaml/pull/561) -- always require `Loader` arg to `yaml.load()`
