### PR TITLE
Fix "if expression" idiom example returning Unit

### DIFF
--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -225,14 +225,13 @@ fun test() {
 ## if expression
 
 ```kotlin
-fun foo(param: Int) =
-    if (param == 1) {
-        "one"
-    } else if (param == 2) {
-        "two"
-    } else {
-        "three"
-    }
+val y = if (x == 1) {
+    "one"
+} else if (x == 2) {
+    "two"
+} else {
+    "other"
+}
 ```
 
 ## Builder-style usage of methods that return Unit

--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -225,15 +225,14 @@ fun test() {
 ## if expression
 
 ```kotlin
-fun foo(param: Int) {
-    val result = if (param == 1) {
+fun foo(param: Int) =
+    if (param == 1) {
         "one"
     } else if (param == 2) {
         "two"
     } else {
         "three"
     }
-}
 ```
 
 ## Builder-style usage of methods that return Unit


### PR DESCRIPTION
`foo` is composed of a single assignment statement, and the `result` value is never used.

I think the intent was to demonstrate with a single-expression function.