### PR TITLE
Fix: minor typo

### DIFF
--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -58,7 +58,7 @@ But then, you would not be able to do the following (which is perfectly safe):
 // Java
 void copyAll(Collection<Object> to, Collection<String> from) {
     to.addAll(from);
-    // !!! Would not compile with the naive declaration of addAll:
+    // !!! Would not compile with the native declaration of addAll:
     // Collection<String> is not a subtype of Collection<Object>
 }
 ```


### PR DESCRIPTION
The third Variance code fence used to be
```java
// Java
void copyAll(Collection<Object> to, Collection<String> from) {
    to.addAll(from);
    // !!! Would not compile with the naive declaration of addAll:
    // Collection<String> is not a subtype of Collection<Object>
}
```
Notice the first comment line. As such, I changed the `naive` to `native`, as that makes more sense in context.