### PR TITLE
fix: simple writing error

### DIFF
--- a/docs/topics/kotlin-mascot.md
+++ b/docs/topics/kotlin-mascot.md
@@ -63,6 +63,6 @@ Use the mascot anywhere you think they fit — in your blog post and videos, on 
 **Don't**
 * Change the proportions
 * Change the colors
-* Use a contrasting background
+* Use a low contrast background
 
 ![Kotlin mascot misuses](mascot-misuse.png){width=700}


### PR DESCRIPTION
Changed "Don't use a contrasting background" to "Don't use a low contrast background".

Rather than moving the bullet point to the "Do" list, changing the wording and keeping it here keeps it close to the misuse examples image.