### PR TITLE
Fix JVM record code showing Kotlin property usage

### DIFF
--- a/docs/topics/jvm/jvm-records.md
+++ b/docs/topics/jvm/jvm-records.md
@@ -22,8 +22,8 @@ You can use record classes with components that are declared in Java the same wa
 To access the record component, just use its name like you do for [Kotlin properties](properties.md):
 
 ```kotlin
-var newPerson = Person("Kotlin", 10)
-var firstName = newPerson.name
+val newPerson = Person("Kotlin", 10)
+val firstName = newPerson.name
 ```
 
 ## Declare records in Kotlin

--- a/docs/topics/jvm/jvm-records.md
+++ b/docs/topics/jvm/jvm-records.md
@@ -22,7 +22,8 @@ You can use record classes with components that are declared in Java the same wa
 To access the record component, just use its name like you do for [Kotlin properties](properties.md):
 
 ```kotlin
-val firstName = person.name
+var newPerson = Person("Kotlin", 10)
+var firstName = newPerson.name
 ```
 
 ## Declare records in Kotlin

--- a/docs/topics/jvm/jvm-records.md
+++ b/docs/topics/jvm/jvm-records.md
@@ -22,7 +22,7 @@ You can use record classes with components that are declared in Java the same wa
 To access the record component, just use its name like you do for [Kotlin properties](properties.md):
 
 ```kotlin
-val firstName = Person.name
+val firstName = person.name
 ```
 
 ## Declare records in Kotlin


### PR DESCRIPTION
The usage example currently shows the Kotlin property for a record being accessed at the class-level (as if it were static) instead of at the object-level. This change fixes that typo so that the Kotlin property is called on the object-level, since the properties would be at the object-level.