### PR TITLE
Fix broken link to java.lang.Record documentation

### DIFF
--- a/docs/topics/jvm/jvm-records.md
+++ b/docs/topics/jvm/jvm-records.md
@@ -8,7 +8,7 @@ They have a concise syntax in Java and save you from having to write boilerplate
 public record Person (String name, int age) {}
 ```
 
-The compiler automatically generates a final class inherited from [`java.lang.Record`](https://download.java.net/java/early_access/jdk16/docs/api/java.base/java/lang/Record.html) with the following members:
+The compiler automatically generates a final class inherited from [`java.lang.Record`](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/Record.html) with the following members:
 * a private final field for each record component
 * a public constructor with parameters for all fields
 * a set of methods to implement structural equality: `equals()`, `hashCode()`, `toString()`


### PR DESCRIPTION
The JVM records tutorial links to the Java documentation for `java.lang.Record`, but that link no longer works. This change updates the link to the current JDK 16 documentation.

(This change does not update the link to point to newer JDK versions' documentation, so that it keeps with the original intention of this page. JVM records came out in JDK 16.)