### PR TITLE
Use configuration avoidance APIs

### DIFF
--- a/docs/topics/gradle.md
+++ b/docs/topics/gradle.md
@@ -816,12 +816,9 @@ val service = project.extensions.getByType<JavaToolchainService>()
 val customLauncher = service.launcherFor {
     it.languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)) // "8"
 }
-project.tasks
-    .withType<KotlinJvmCompile>()
-    .configureEach {
-        if (this !is UsesKotlinJavaToolchain) return@configureEach
-        kotlinJavaToolchain.toolchain.use(customLauncher)
-    }
+project.tasks.withType<UsesKotlinJavaToolchain>().configureEach {
+    kotlinJavaToolchain.toolchain.use(customLauncher)
+}
 ```
 
 </tab>
@@ -832,13 +829,9 @@ JavaToolchainService service = project.getExtensions().getByType(JavaToolchainSe
 Provider<JavaLauncher> customLauncher = service.launcherFor {
     it.languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)) // "8"
 }
-project.tasks
-    .withType(KotlinJvmCompile::class)
-    .configureEach { task ->
-        if (task instanceof UsesKotlinJavaToolchain) {
-            task.kotlinJavaToolchain.toolchain.use(customLauncher)
-        }
-    }
+tasks.withType(UsesKotlinJavaToolchain::class).configureEach { task ->
+    task.kotlinJavaToolchain.toolchain.use(customLauncher)
+}
 ```
 
 </tab>
@@ -847,15 +840,12 @@ project.tasks
 Or you can specify the path to your local JDK and replace the placeholder `<LOCAL_JDK_VERSION>` with this JDK version:
 
 ```kotlin
-project.tasks
-    .withType<KotlinJvmCompile>()
-    .configureEach {
-        if (this !is UsesKotlinJavaToolchain) return@configureEach
-        kotlinJavaToolchain.jdk.use(
-            "/path/to/local/jdk", // Put a path to your JDK
-            JavaVersion.<LOCAL_JDK_VERSION> // For example, JavaVersion.17
-        )
-    }
+tasks.withType<UsesKotlinJavaToolchain>().configureEach {
+    kotlinJavaToolchain.jdk.use(
+        "/path/to/local/jdk", // Put a path to your JDK
+        JavaVersion.<LOCAL_JDK_VERSION> // For example, JavaVersion.17
+    )
+}
 ```
 
 ## Generating documentation
@@ -939,11 +929,8 @@ Each of the options in the following list overrides the ones that came before it
   <tab title="Kotlin" group-key="kotlin">
   
   ```kotlin
-  tasks
-      .withType<KotlinJvmCompile>()
-      .configureEach {
-          if (this !is CompileUsingKotlinDaemon) return@configureEach
-          kotlinDaemonJvmArguments.set(listOf("-Xmx486m", "-Xms256m", "-XX:+UseParallelGC"))
+  tasks.withType<CompileUsingKotlinDaemon>().configureEach {
+      kotlinDaemonJvmArguments.set(listOf("-Xmx486m", "-Xms256m", "-XX:+UseParallelGC"))
       }
   ```
   
@@ -951,13 +938,9 @@ Each of the options in the following list overrides the ones that came before it
   <tab title="Groovy" group-key="groovy">
 
   ```groovy
-  tasks
-      .withType(KotlinJvmCompile::class)
-      .configureEach { task ->
-          if (task instanceof CompileUsingKotlinDaemon) {
-              task.kotlinDaemonJvmArguments.set(["-Xmx1g", "-Xms512m"])
-          }
-      }
+  tasks.withType(CompileUsingKotlinDaemon::class).configureEach { task ->
+      task.kotlinDaemonJvmArguments.set(["-Xmx1g", "-Xms512m"])
+   }
   ```
   
   </tab>

--- a/docs/topics/gradle.md
+++ b/docs/topics/gradle.md
@@ -817,9 +817,10 @@ val customLauncher = service.launcherFor {
     it.languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)) // "8"
 }
 project.tasks
-    .matching { it is UsesKotlinJavaToolchain && it.name == "compileKotlin" }
+    .withType<KotlinJvmCompile>()
     .configureEach {
-        it.kotlinJavaToolchain.toolchain.use(customLauncher)
+        if (this !is UsesKotlinJavaToolchain) return@configureEach
+        kotlinJavaToolchain.toolchain.use(customLauncher)
     }
 ```
 
@@ -832,9 +833,11 @@ Provider<JavaLauncher> customLauncher = service.launcherFor {
     it.languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)) // "8"
 }
 project.tasks
-    .matching { it instanceof UsesKotlinJavaToolchain && it.name == 'compileKotlin' }
-    .configureEach {
-        it.kotlinJavaToolchain.toolchain.use(customLauncher)
+    .withType(KotlinJvmCompile::class)
+    .configureEach { task ->
+        if (task instanceof UsesKotlinJavaToolchain) {
+            task.kotlinJavaToolchain.toolchain.use(customLauncher)
+        }
     }
 ```
 
@@ -845,9 +848,10 @@ Or you can specify the path to your local JDK and replace the placeholder `<LOCA
 
 ```kotlin
 project.tasks
-    .matching { it is UsesKotlinJavaToolchain && it.name == "compileKotlin" }
+    .withType<KotlinJvmCompile>()
     .configureEach {
-        it.kotlinJavaToolchain.jdk.use(
+        if (this !is UsesKotlinJavaToolchain) return@configureEach
+        kotlinJavaToolchain.jdk.use(
             "/path/to/local/jdk", // Put a path to your JDK
             JavaVersion.<LOCAL_JDK_VERSION> // For example, JavaVersion.17
         )
@@ -936,9 +940,10 @@ Each of the options in the following list overrides the ones that came before it
   
   ```kotlin
   tasks
-      .matching { it.name == "compileKotlin" && it is CompileUsingKotlinDaemon }
-      .configureEach { 
-          (this as CompileUsingKotlinDaemon).kotlinDaemonJvmArguments.set(listOf("-Xmx486m", "-Xms256m", "-XX:+UseParallelGC"))
+      .withType<KotlinJvmCompile>()
+      .configureEach {
+          if (this !is CompileUsingKotlinDaemon) return@configureEach
+          kotlinDaemonJvmArguments.set(listOf("-Xmx486m", "-Xms256m", "-XX:+UseParallelGC"))
       }
   ```
   
@@ -947,9 +952,11 @@ Each of the options in the following list overrides the ones that came before it
 
   ```groovy
   tasks
-      .matching { it.name == "compileKotlin" && it instanceof CompileUsingKotlinDaemon }
-      .configureEach {
-          kotlinDaemonJvmArguments.set(["-Xmx1g", "-Xms512m"])
+      .withType(KotlinJvmCompile::class)
+      .configureEach { task ->
+          if (task instanceof CompileUsingKotlinDaemon) {
+              task.kotlinDaemonJvmArguments.set(["-Xmx1g", "-Xms512m"])
+          }
       }
   ```
   


### PR DESCRIPTION
The `matching` method unfortunately causes all tasks to be "realized", which impacts the builds where these tasks don't need to be run for the given module.

This commit uses `withType()` along with `configureEach` to avoid this issue.

@melix Did I do this right?