### PR TITLE
Documentation updated

### DIFF
--- a/docs/topics/data-classes.md
+++ b/docs/topics/data-classes.md
@@ -20,6 +20,7 @@ To ensure consistency and meaningful behavior of the generated code, data classe
 * The primary constructor needs to have at least one parameter.
 * All primary constructor parameters need to be marked as `val` or `var`.
 * Data classes cannot be abstract, open, sealed, or inner.
+* Data classes should not have private properties in primary constructor and use them as backing fields in public property.
 
 Additionally, the generation of data class members follows these rules with regard to the members’ inheritance:
 


### PR DESCRIPTION
I think making property private for data class and allowing then access by public property using backing fields will print wrong output for componentN(), toString(), etc.

data class BatteryDemo(
    private val _level: Int,
    private val _temperature: Int,
    private val _voltage: Int,
) {
    val level get() = _level.toString()
    val temperature get() = _temperature.toString()
    val voltage get() = _voltage.toString()
}