### PR TITLE
Adapt `Compatibility flags` section to new release cadence

### DIFF
--- a/docs/topics/kotlin-evolution.md
+++ b/docs/topics/kotlin-evolution.md
@@ -128,7 +128,7 @@ As legacy features get removed and bugs fixed, the source language changes, and 
 
 ### Compatibility flags
 
-We provide the -language-version and -api-version flags that make a new version emulate the behavior of an old one, for compatibility purposes. Normally, at least one previous version is supported. This effectively leaves a time span of two full feature release cycles for migration (which usually amounts to about two years). Using an older kotlin-stdlib or kotlin-reflect with a newer compiler without specifying compatibility flags is not recommended, and the compiler will report a [warning](compatibility-modes.md) when this happens.
+We provide the -language-version and -api-version flags that make a new version emulate the behavior of an old one, for compatibility purposes. Normally, at least one previous version is supported. This effectively leaves a time span of two full feature release cycles for migration (which usually amounts to about one year). Using an older kotlin-stdlib or kotlin-reflect with a newer compiler without specifying compatibility flags is not recommended, and the compiler will report a [warning](compatibility-modes.md) when this happens.
 
 Actively maintained code bases can benefit from getting bug fixes ASAP, without waiting for a full deprecation cycle to complete. Currently such project can enable the -progressive flag and get such fixes enabled even in incremental releases.
 


### PR DESCRIPTION
Feature release now happen twice a year so 2 cycles are ~1 year

https://blog.jetbrains.com/kotlin/2020/10/new-release-cadence-for-kotlin-and-the-intellij-kotlin-plugin