### PR TITLE
fixed Kotlin DSL example for pre-installed Node.js

### DIFF
--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -480,7 +480,7 @@ To use the pre-installed Node.js instance, add the following lines to your `buil
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java> {
+rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java) {
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().download = false
     // or true for default behavior
 }

--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -480,7 +480,7 @@ To use the pre-installed Node.js instance, add the following lines to your `buil
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java) {
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().download = false
     // or true for default behavior
 }
@@ -531,7 +531,7 @@ To use the pre-installed Yarn instance, add the following lines to your `build.g
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin::class.java> {
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin> {
     rootProject.the<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension>().download = false
     // or true for default behavior
 }

--- a/docs/topics/whatsnew16.md
+++ b/docs/topics/whatsnew16.md
@@ -365,7 +365,7 @@ To disable downloading external components, add the following lines to your `bui
     <tab title="Kotlin" group-key="kotlin">
     
     ```kotlin
-    rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin::class.java> {
+    rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin> {
         rootProject.the<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension>().download = false // or true for default behavior
     }
     ```
@@ -388,7 +388,7 @@ To disable downloading external components, add the following lines to your `bui
     <tab title="Kotlin" group-key="kotlin">
     
     ```kotlin
-    rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java> {
+    rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
         rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().download = false // or true for default behavior
     }
      


### PR DESCRIPTION
The current example syntax is not working.

Got the right one from: https://youtrack.jetbrains.com/issue/KT-39106 