### PR TITLE
Corrected the broken link to the blog post.

### DIFF
--- a/docs/topics/whatsnew16.md
+++ b/docs/topics/whatsnew16.md
@@ -4,7 +4,7 @@ _[Release date: 16 November 2021](releases.md#release-details)_
 
 Kotlin 1.6.0 introduces new language features, optimizations and improvements to existing features, and a lot of improvements to the Kotlin standard library.
 
-You can also find an overview of the changes in the [release blog post](https://blog.jetbrains.com/kotlin/2021/11/kotlin-1-6-0-released/).
+You can also find an overview of the changes in the [release blog post](https://blog.jetbrains.com/kotlin/2021/11/kotlin-1-6-0-is-released/).
 
 ## Language
 


### PR DESCRIPTION
Hello! At https://kotlinlang.org/docs/whatsnew16.html
There is a link that leads to a blog post. It is not valid at the moment. I've fixed that.