### PR TITLE
Change iterate over a range example code section

### DIFF
--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -98,7 +98,7 @@ for (i in 1..100) { ... }  // closed range: includes 100
 for (i in 1 until 100) { ... } // half-open range: does not include 100
 for (x in 2..10 step 2) { ... }
 for (x in 10 downTo 1) { ... }
-if (x in 1..10) { ... }
+(1..10).forEach { ... }
 ```
 
 ## Lazy property


### PR DESCRIPTION
1. "if (x in 1..10) { ... }" isn't iteration example and shouldn't be placed at "iterate over a range" chapter.
2. I suggest one more consise iteration example.