### PR TITLE
KTL-577 Kotlinlang - links on the main page lost hover state

### DIFF
--- a/static/js/components/kto-link.scss
+++ b/static/js/components/kto-link.scss
@@ -17,7 +17,7 @@
     content: '';
     width: 100%;
     height: 1px;
-    background: #fff;
+    background: #ffffff;
     position: absolute;
     bottom: -1px;
     left: 0;
@@ -44,11 +44,18 @@
 }
 
 @mixin kto-link-standalone {
-  text-decoration: underline;
+  border-bottom: 1px solid transparent;
+  &:hover {
+    color: #ffffff;
+    border-bottom: 1px solid #fff;
+  }
+}
 
+.kto-link-standalone {
+  color: #ffffff;
+  @include kto-link-standalone;
 }
 
 .kto-link_theme_dark {
   @include kto-link_theme_dark;
 }
-

--- a/static/js/page/index/kotlin-news-section.scss
+++ b/static/js/page/index/kotlin-news-section.scss
@@ -37,7 +37,7 @@
 }
 
 .kotlin-news-section__title {
-
+  @include kto-link-standalone;
 }
 
 .kotlin-news-section__item .kto-text_size_m {


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-577
https://branch-ktl-577-fix-link-hover-state.kotlin-web-site.labs.jb.gg 

Reverts [this chages](https://github.com/JetBrains/kotlin-web-site/pull/2573/commits/0408cfc820a612ee3768b284fd8472fda18f9ebd)