### PR TITLE
Update Moshi support status

### DIFF
--- a/docs/topics/ksp/ksp-overview.md
+++ b/docs/topics/ksp/ksp-overview.md
@@ -155,7 +155,7 @@ The table below includes a list of popular libraries on Android and their variou
 |Library|Status|Tracking issue for KSP|
 |---|---|---|
 |Room|[Experimentally supported](https://developer.android.com/jetpack/androidx/releases/room#2.3.0-beta02)|   |
-|Moshi|[Experimentally supported](https://github.com/ZacSweers/MoshiX/tree/main/moshi-ksp)|   |
+|Moshi|[Officially supported](https://github.com/square/moshi/)|   |
 |RxHttp|[Officially supported](https://github.com/liujingxing/rxhttp)|   |
 |Kotshi|[Officially supported](https://github.com/ansman/kotshi)|   |
 |Lyricist|[Officially supported](https://github.com/adrielcafe/lyricist)|   |


### PR DESCRIPTION
It is officially released now https://github.com/square/moshi/blob/master/CHANGELOG.md#version-1130