### PR TITLE
Add missing X on opt-in compiler argument

### DIFF
--- a/docs/topics/opt-in-requirements.md
+++ b/docs/topics/opt-in-requirements.md
@@ -150,7 +150,7 @@ If you build your module with Gradle, you can add arguments like this:
 
 ```kotlin
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions.freeCompilerArgs += "-opt-in=org.mylibrary.OptInAnnotation"
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=org.mylibrary.OptInAnnotation"
 }
 ```
 
@@ -160,7 +160,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 ```groovy
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        freeCompilerArgs += "-opt-in=org.mylibrary.OptInAnnotation"
+        freeCompilerArgs += "-Xopt-in=org.mylibrary.OptInAnnotation"
     }
 }
 ```
@@ -209,7 +209,7 @@ For Maven, it would be:
             <executions>...</executions>
             <configuration>
                 <args>
-                    <arg>-opt-in=org.mylibrary.OptInAnnotation</arg>                    
+                    <arg>-Xopt-in=org.mylibrary.OptInAnnotation</arg>                    
                 </args>
             </configuration>
         </plugin>
@@ -304,6 +304,6 @@ the compiler raises warnings when compiling the code with these annotations:
 
 ```This class can only be used with the compiler argument '-opt-in=kotlin.RequiresOptIn'```
 
-To remove the warnings, add the compiler argument `-opt-in=kotlin.RequiresOptIn`.
+To remove the warnings, add the compiler argument `-Xopt-in=kotlin.RequiresOptIn`.
 
 Learn more about recent changes to opt-in requirements in [this KEEP](https://github.com/Kotlin/KEEP/blob/d7287626dd4c40c6c89877e266044b83fca38bcd/proposals/opt-in.md).


### PR DESCRIPTION
After copying and pasting the snippet to opt in to using an API in a module, I noticed (well not me, but the compiler :) ) that there was some missing X