### PR TITLE
Clarify that specific checks on the left side are required to cast an expression on the right side of `&&` or `||`

### DIFF
--- a/docs/topics/typecasts.md
+++ b/docs/topics/typecasts.md
@@ -37,7 +37,7 @@ if (x !is String) return
 print(x.length) // x is automatically cast to String
 ```
 
-or if it is on the right-hand side of `&&` or `||`:
+or if it is on the right-hand side of `&&` or `||` and the proper check (regular or negative) is on the left side:
 
 ```kotlin
 // x is automatically cast to String on the right-hand side of `||`

--- a/docs/topics/typecasts.md
+++ b/docs/topics/typecasts.md
@@ -37,7 +37,7 @@ if (x !is String) return
 print(x.length) // x is automatically cast to String
 ```
 
-or if it is on the right-hand side of `&&` or `||` and the proper check (regular or negative) is on the left side:
+or if it is on the right-hand side of `&&` or `||` and the proper check (regular or negative) is on the left-hand side:
 
 ```kotlin
 // x is automatically cast to String on the right-hand side of `||`


### PR DESCRIPTION
The original text talks about a negative check triggering a cast on on example, then mentions "it" is also triggered on `&&` or `||`, but in this case, "it" can be either a regular or a negative check. The code example clarifies it, but rewriting in these lines may avoid the confusion in the first place, what do you think?

---

(this is my first Kotlin/docs PR 🙂; it seems to abide to the [guidelines](https://docs.google.com/document/d/1mUuxK4xwzs3jtDGoJ5_zwYLaSEl13g_SuhODdFuh2Dc/edit#heading=h.2a2byea1lufz), happy to amend/improve if needed! 🙇)
