### PR TITLE
fix: Use correct syntax for cinterops in build.gradle

### DIFF
--- a/docs/topics/native/native-app-with-c-and-libcurl.md
+++ b/docs/topics/native/native-app-with-c-and-libcurl.md
@@ -160,11 +160,11 @@ entry to the `build.gradle(.kts)` file:
 
 ```kotlin
 nativeTarget.apply {
-    compilations.main { // NL
-        cinterops {     // NL
-            libcurl     // NL
-        }               // NL
-    }                   // NL
+    compilations.getByName("main") {    // NL
+        cinterops {                     // NL
+            val libcurl by creating     // NL
+        }                               // NL
+    }                                   // NL
     binaries {
         executable {
             entryPoint = "main"


### PR DESCRIPTION
When trying to follow this part of the tutorial, I was getting the following error after applying the `compilations.main` section to my `build.gradle.kts`:

```
build.gradle.kts:20:22: Unresolved reference: main
```

After looking up some code samples, I found this as a working solution.