### PR TITLE
Update type-safe-builders.md

### DIFF
--- a/docs/topics/type-safe-builders.md
+++ b/docs/topics/type-safe-builders.md
@@ -110,14 +110,14 @@ The `head` and `body` functions in the `HTML` class are defined similarly to `ht
 The only difference is that they add the built instances to the `children` collection of the enclosing `HTML` instance:
 
 ```kotlin
-fun head(init: Head.() -> Unit) : Head {
+fun head(init: Head.() -> Unit): Head {
     val head = Head()
     head.init()
     children.add(head)
     return head
 }
 
-fun body(init: Body.() -> Unit) : Body {
+fun body(init: Body.() -> Unit): Body {
     val body = Body()
     body.init()
     children.add(body)


### PR DESCRIPTION
Fix inconsistency involving the use of colons to define function return types.