### PR TITLE
move `binaries` to be in `js {}`

### DIFF
--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -24,8 +24,8 @@ project, pass a compiler type to the `js` function in your Gradle build script:
 kotlin {
     js(IR) { // or: LEGACY, BOTH
         // ...
+        binaries.executable() // not applicable to BOTH, see details below
     }
-    binaries.executable() // not applicable to BOTH, see details below
 }
 ```
 


### PR DESCRIPTION
error: 
![image](https://user-images.githubusercontent.com/897017/147760776-22af3cf0-f71f-40ef-93d6-6662f35bb99c.png)

works: 
![image](https://user-images.githubusercontent.com/897017/147760818-9d16d183-6adf-4f10-98a0-418fa3de8f5d.png)

