### PR TITLE
fix: indentation in safe.md

### DIFF
--- a/kotlin-features/safe.md
+++ b/kotlin-features/safe.md
@@ -15,7 +15,7 @@ fun main() {
       println(message.uppercase())             // the compiler will smart-cast it for you
    }
 
-val nonNull: String =                             // If the null-case throws an error,
+   val nonNull: String =                             // If the null-case throws an error,
    reply(condition = true) ?: error()             // Kotlin can infer that the result is non-null
    println(nonNull)
 }

--- a/kotlin-features/safe.md
+++ b/kotlin-features/safe.md
@@ -12,8 +12,8 @@ fun main() {
    // println(message.uppercase())             // This line doesn't compile
    println(message?.replace("fine", "okay"))   // Access a nullable value in a safe manner
    if (message != null) {                      // If you check that the type is right,
-   println(message.uppercase())                // the compiler will smart-cast it for you
-}
+      println(message.uppercase())             // the compiler will smart-cast it for you
+   }
 
 val nonNull: String =                             // If the null-case throws an error,
    reply(condition = true) ?: error()             // Kotlin can infer that the result is non-null


### PR DESCRIPTION
Hello, I noticed the indentation in the "safe" feature tab is a little off, it should be better like this