### PR TITLE
Fix a typo in "Conditions and loops"

### DIFF
--- a/docs/topics/control-flow.md
+++ b/docs/topics/control-flow.md
@@ -21,7 +21,7 @@ if (a > b) {
 val max = if (a > b) a else b
 ```
 
-Branches of `if` branches can be blocks. In this case, the last expression is the value of a block:
+Branches of an `if` expression can be blocks. In this case, the last expression is the value of a block:
 
 ```kotlin
 val max = if (a > b) {


### PR DESCRIPTION
By the way, I found it a little confusing that we declare that "If is an expression", and then show an example where it is used as a statement. Probably it's worth explaining that it can be used in both ways.

For example, compare that with `when`:

> `when` can be used either as an expression or as a statement.