### PR TITLE
Update zip() transformation function description

### DIFF
--- a/docs/topics/collection-transformations.md
+++ b/docs/topics/collection-transformations.md
@@ -64,7 +64,7 @@ _Zipping_ transformation is building pairs from elements with the same positions
 In the Kotlin standard library, this is done by the [`zip()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/zip.html)
 extension function.
 
-When called on a collection or an array with another collection (array) as an argument, `zip()` returns the `List` of 
+When called on a collection or an array with another collection (or array) as an argument, `zip()` returns the `List` of 
 `Pair` objects. The elements of the receiver collection are the first elements in these pairs.
 
 If the collections have different sizes, the result of the `zip()` is the smaller size; the last elements of the larger


### PR DESCRIPTION
Collections and arrays are different concepts in Kotlin, writing `collection (array)` gives the reader the implication that collections and arrays are one and the same.
Updated it to `collection (or array)` for better reflection.