### PR TITLE
Add return type to the Documentation Comment section examples

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -794,14 +794,14 @@ directly into the documentation comment, and add links to parameters wherever th
  * @param number The number to return the absolute value for.
  * @return The absolute value.
  */
-fun abs(number: Int) { /*...*/ }
+fun abs(number: Int): Int { /*...*/ }
 
 // Do this instead:
 
 /**
  * Returns the absolute value of the given [number].
  */
-fun abs(number: Int) { /*...*/ }
+fun abs(number: Int): Int { /*...*/ }
 ```
 
 ## Avoid redundant constructs


### PR DESCRIPTION
The documentation example explicitly talks about how to document return types but the code examples fail to include any return type when one should exist.  Just hoping to clean that up and avoid any confusion