### PR TITLE
fix: remove part about java extension until KT-50115 is fixed

### DIFF
--- a/docs/topics/gradle.md
+++ b/docs/topics/gradle.md
@@ -220,16 +220,6 @@ kotlin {
 
 Note that setting a toolchain via the `kotlin` extension will update the toolchain for Java compile tasks as well.
 
-You can set a toolchain via the `java` extension, and Kotlin compilation tasks will use it:
-
-```kotlin
-java {
-    toolchain {
-      languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)) // "8" 
-    }
-}
-```
-
 To set any JDK (even local) for the specific task, use the Task DSL.
 
 ### Setting JDK version with the Task DSL


### PR DESCRIPTION
Can revert this after https://youtrack.jetbrains.com/issue/KT-50115 is fixed. The task for it https://youtrack.jetbrains.com/issue/KT-51104