### PR TITLE
fix: missing article on heading

### DIFF
--- a/docs/topics/jvm/java-to-kotlin-collections-guide.md
+++ b/docs/topics/jvm/java-to-kotlin-collections-guide.md
@@ -57,7 +57,7 @@ In Kotlin, there are many operations on collections that look exactly the same a
 | Take a sublist | `subList()` | |
 | Replace an element or elements | `set()`,  `replaceAll()` | Use the indexing operator instead of `set()`: `list[index] = value`. |
 
-## Operations differ a bit
+## Operations that differ a bit
 
 ### Operations on any collection type
 


### PR DESCRIPTION
This makes the 2nd level headings consistent with each other (L20: "Operations that are the same in Java and Kotlin﻿" and L92: "Operations that don't exist in Java's standard library") and fixes the grammar of the expression.