### PR TITLE
fix: match the function value parameter

### DIFF
--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -25,7 +25,7 @@ sealed interface Error
 
 sealed class IOError(): Error
 
-class FileReadError(val f: File): IOError()
+class FileReadError(val file: File): IOError()
 class DatabaseError(val source: DataSource): IOError()
 
 object RuntimeError : Error


### PR DESCRIPTION
the following reference `file` and more clear.

```kotlin
    is FileReadError -> { println("Error while reading file ${e.file}") }
```