### PR TITLE
Doc 1 6 20 method references to fun interface constructors (#2838)

### DIFF
--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -83,7 +83,7 @@ interface Printer {
 fun Printer(block: () -> Unit): Printer = object : Printer { override fun print() = block() }
 ```
 
-Functional interfaces make the same code more concise. To migrate this code to the functional interface `Printer`, use the following code:
+With callable references to functional interface constructors enabled, this code can be replaced with just a functional interface declaration:
 
 ```kotlin
 fun interface Printer { 

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -91,7 +91,7 @@ fun interface Printer {
 }
 ```
 
-With callable references to functional interface constructors enabled, any code using the `::Printer` function reference will compile. For example:
+Its constructor will be created implicitly,  and any code using the `::Printer` function reference will compile. For example:
 
 ```kotlin
 documentsStorage.addPrinter(::Printer)

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -91,7 +91,7 @@ fun interface Printer {
 }
 ```
 
-Its constructor will be created implicitly,  and any code using the `::Printer` function reference will compile. For example:
+Its constructor will be created implicitly, and any code using the `::Printer` function reference will compile. For example:
 
 ```kotlin
 documentsStorage.addPrinter(::Printer)

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -63,7 +63,7 @@ fun main() {
 
 You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conversions).
 
-## Migration from interface with constructor function to functional interface
+## Migration from an interface with constructor function to a functional interface
 
 > Support for callable references to functional interface constructors is [Experimental](components-stability.md).
 > It may be dropped or changed at any time. Opt-in is required (see details below), and you should use it only for evaluation purposes.
@@ -71,9 +71,9 @@ You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conve
 >
 {type="warning"}
 
-Starting from 1.6.20, Kotlin supports callable references to functional interface constructors.
-This support adds a source-compatible way to migrate from an interface with a constructor function to a functional interface.
-Consider this "legacy" code:
+Starting from 1.6.20, Kotlin supports callable references to functional interface constructors, which
+adds a source-compatible way to migrate from an interface with a constructor function to a functional interface.
+Consider this code:
 
 ```kotlin
 interface KRunnable { 
@@ -83,7 +83,7 @@ interface KRunnable {
 fun KRunnable(block: () -> Unit): KRunnable = object : KRunnable { override fun invoke() = block() }
 ```
 
-To migrate this code to the functional interface `KRunnable`, use the following code:
+Functional interfaces make the same code more concise. To migrate this code to the functional interface `KRunnable`, use the following code:
 
 ```kotlin
 fun interface KRunnable { 
@@ -96,7 +96,7 @@ Preserve the binary compatibility by marking the legacy function `KRunnable` wit
 annotation with `DeprecationLevel.HIDDEN`:
 
 ```kotlin
-@Deprecated(message = "Your message about the depreciation", level = DeprecationLevel.HIDDEN)
+@Deprecated(message = "Your message about the deprecation", level = DeprecationLevel.HIDDEN)
 fun KRunnable(...) {...}
 ```
 

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -71,7 +71,7 @@ You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conve
 >
 {type="warning"}
 
-Starting from Kotlin 1.6.20, there is a support for callable references to functional interface constructors.
+Starting from 1.6.20, Kotlin supports callable references to functional interface constructors.
 This support adds a source-compatible way to migrate from an interface with a constructor function to a functional interface.
 Consider this "legacy" code:
 

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -76,28 +76,33 @@ adds a source-compatible way to migrate from an interface with a constructor fun
 Consider this code:
 
 ```kotlin
-interface KRunnable { 
-    fun invoke() 
+interface Printer { 
+    fun print() 
 }
 
-fun KRunnable(block: () -> Unit): KRunnable = object : KRunnable { override fun invoke() = block() }
+fun Printer(block: () -> Unit): Printer = object : Printer { override fun print() = block() }
 ```
 
-Functional interfaces make the same code more concise. To migrate this code to the functional interface `KRunnable`, use the following code:
+Functional interfaces make the same code more concise. To migrate this code to the functional interface `Printer`, use the following code:
 
 ```kotlin
-fun interface KRunnable { 
-    fun invoke()
+fun interface Printer { 
+    fun print()
 }
 ```
 
-With callable references to functional interface constructors enabled, any code using the `::KRunnable` function reference will compile.
-Preserve the binary compatibility by marking the legacy function `KRunnable` with the [`@Deprecated`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecated/)
+With callable references to functional interface constructors enabled, any code using the `::Printer` function reference will compile. For example:
+
+```kotlin
+documentsStorage.addPrinter(::Printer)
+```
+
+Preserve the binary compatibility by marking the legacy function `Printer` with the [`@Deprecated`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecated/)
 annotation with `DeprecationLevel.HIDDEN`:
 
 ```kotlin
 @Deprecated(message = "Your message about the deprecation", level = DeprecationLevel.HIDDEN)
-fun KRunnable(...) {...}
+fun Printer(...) {...}
 ```
 
 Use the compiler option `-XXLanguage:+KotlinFunInterfaceConstructorReference` to enable this feature.

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -71,7 +71,7 @@ You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conve
 >
 {type="warning"}
 
-Starting from 1.6.20, Kotlin supports callable references to functional interface constructors, which
+Starting from 1.6.20, Kotlin supports [callable references](reflection.md#callable-references) to functional interface constructors, which
 adds a source-compatible way to migrate from an interface with a constructor function to a functional interface.
 Consider this code:
 

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -76,28 +76,28 @@ This support adds a source-compatible way to migrate from an interface with a co
 Consider this "legacy" code:
 
 ```kotlin
-interface A { 
-    fun foo() 
+interface KRunnable { 
+    fun invoke() 
 }
 
-fun A(block: () -> Unit): A = object : A { override fun foo() = block() }
+fun KRunnable(block: () -> Unit): KRunnable = object : KRunnable { override fun invoke() = block() }
 ```
 
-If you want to migrate this code to the functional interface `A`, use the following code:
+To migrate this code to the functional interface `KRunnable`, use the following code:
 
 ```kotlin
-fun interface A { 
-    fun foo()
+fun interface KRunnable { 
+    fun invoke()
 }
 ```
 
-With callable references to functional interface constructors enabled, any code using the `::A` function reference will compile.
-You can preserve the binary compatibility by marking the legacy function `A` with the [`@Deprecated`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecated/)
+With callable references to functional interface constructors enabled, any code using the `::KRunnable` function reference will compile.
+Preserve the binary compatibility by marking the legacy function `KRunnable` with the [`@Deprecated`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecated/)
 annotation with `DeprecationLevel.HIDDEN`:
 
 ```kotlin
 @Deprecated(message = "Your message about the depreciation", level = DeprecationLevel.HIDDEN)
-fun A(...) {...}
+fun KRunnable(...) {...}
 ```
 
 Use the compiler option `-XXLanguage:+KotlinFunInterfaceConstructorReference` to enable this feature.

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -63,6 +63,45 @@ fun main() {
 
 You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conversions).
 
+## Migration from interface with constructor function to functional interface
+
+> Support for callable references to functional interface constructors is [Experimental](components-stability.md).
+> It may be dropped or changed at any time. Opt-in is required (see details below), and you should use it only for evaluation purposes.
+> We would appreciate your feedback on it in [YouTrack](https://youtrack.jetbrains.com/issue/KT-47939).
+>
+{type="warning"}
+
+Starting from Kotlin 1.6.20, there is a support for callable references to functional interface constructors.
+This support adds a source-compatible way to migrate from an interface with a constructor function to a functional interface.
+Consider this "legacy" code:
+
+```kotlin
+interface A { 
+    fun foo() 
+}
+
+fun A(block: () -> Unit): A = object : A { override fun foo() = block() }
+```
+
+If you want to migrate this code to the functional interface `A`, use the following code:
+
+```kotlin
+fun interface A { 
+    fun foo()
+}
+```
+
+With callable references to functional interface constructors enabled, any code using the `::A` function reference will compile.
+You can preserve the binary compatibility by marking the legacy function `A` with the [`@Deprecated`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecated/)
+annotation with `DeprecationLevel.HIDDEN`:
+
+```kotlin
+@Deprecated(message = "Your message about the depreciation", level = DeprecationLevel.HIDDEN)
+fun A(...) {...}
+```
+
+Use the compiler option `-XXLanguage:+KotlinFunInterfaceConstructorReference` to enable this feature.
+
 ## Functional interfaces vs. type aliases
 
 Functional interfaces and [type aliases](type-aliases.md) serve different purposes.


### PR DESCRIPTION
* update: single kotlin eap channel (#2823)

* update: added a note for the Gradle task (#2811)

* update: added a warning and details for the embedAndSignAppleFrameworkForXcode task

* update: add info about callable references to SAM interfaces

* fix: more migration to fun interfaces higher

Co-authored-by: Danil Pavlov <danil.pavlov@jetbrains.com>