### PR TITLE
Replace `Map.forEach` with Kotlin's `forEach`

### DIFF
--- a/docs/topics/lambdas.md
+++ b/docs/topics/lambdas.md
@@ -288,7 +288,7 @@ strings.filter { it.length == 5 }.sortedBy { it }.map { it.uppercase() }
 If the lambda parameter is unused, you can place an underscore instead of its name:
 
 ```kotlin
-map.forEach { _, value -> println("$value!") }
+map.forEach { (_, value) -> println("$value!") }
 ```
 
 ### Destructuring in lambdas


### PR DESCRIPTION
```kotlin
map.forEach { key, value -> ... }  // (1)
map.forEach { (key, value) -> ... } // (2)
```

> ... the first line uses Java 8 Map.forEach default method, while the second one Kotlin's extension.
>
> https://youtrack.jetbrains.com/issue/KTIJ-7519