### PR TITLE
fix: link to CocoapodsExtension.kt

### DIFF
--- a/docs/topics/native/native-cocoapods.md
+++ b/docs/topics/native/native-cocoapods.md
@@ -83,7 +83,7 @@ as well as [a Kotlin Gradle project and an Xcode project](native-cocoapods-xcode
     }
     ```
 
-    > See the full syntax of Kotlin DSL in the [Kotlin Gradle plugin repository](https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt).
+    > See the full syntax of Kotlin DSL in the [Kotlin Gradle plugin repository](https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/native/cocoapods/CocoapodsExtension.kt).
     >
     {type="note"}
     


### PR DESCRIPTION
Fixes broken link to `CocoapodsExtension.kt`.