### PR TITLE
Use lower-case relation name for the data class

### DIFF
--- a/docs/topics/jvm/jvm-spring-boot-restful.md
+++ b/docs/topics/jvm/jvm-spring-boot-restful.md
@@ -161,7 +161,7 @@ before the `id` field. These annotations also require additional imports:
    import org.springframework.data.annotation.Id
    import org.springframework.data.relational.core.mapping.Table
   
-   @Table("MESSAGES")
+   @Table("messages")
    data class Message(@Id val id: String?, val text: String)
    ```
 


### PR DESCRIPTION
This tutorial works fine with select/find queries, but gives "relation "messages" does not exist" error during persisting the messages. This is due to the relation name being case-sensitive e.g. "MESSAGES" vs "messages"
`findMessages` uses implicit query  `@Query("select * from messages")`("messages") and therefore works.
`db.save(message)` uses the generated query from `SimpleJdbcRepository`("MESSAGES") and therefore fails.
This tutorial https://dba.stackexchange.com/questions/192897/postgres-relation-does-not-exist-error

To be transparent, I tested this tutorial on Postgres database running locally, and not on the in-memory H2.