### PR TITLE
Add paragraph on node.js test env variables

### DIFF
--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -322,6 +322,20 @@ To run tests, execute the standard lifecycle `check` task:
 ```bash
 ./gradlew check
 ```
+         
+To specify envirnoment variables used by your Node.js test runners (e.g. to pass external information to your tests, or to fine-tune package resolution), use the `environment` function with a key-value pair inside the `testTask` block in your build script:
+         
+```groovy
+kotlin {
+    js {
+        nodejs {
+            testTask {
+                environment("key", "value")
+            }
+        }
+    }
+}        
+```
 
 ### Karma configuration
 

--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -323,7 +323,7 @@ To run tests, execute the standard lifecycle `check` task:
 ./gradlew check
 ```
          
-To specify envirnoment variables used by your Node.js test runners (e.g. to pass external information to your tests, or to fine-tune package resolution), use the `environment` function with a key-value pair inside the `testTask` block in your build script:
+To specify envirnoment variables used by your Node.js test runners (for example, to pass external information to your tests, or to fine-tune package resolution), use the `environment` function with a key-value pair inside the `testTask` block in your build script:
          
 ```groovy
 kotlin {


### PR DESCRIPTION
Documents https://youtrack.jetbrains.com/issue/KT-51414/Allow-set-up-environment-variables-for-JS-tests