### PR TITLE
Implement not inherit

### DIFF
--- a/docs/topics/collection-ordering.md
+++ b/docs/topics/collection-ordering.md
@@ -5,7 +5,7 @@ For example, two lists of the same elements are not equal if their elements are 
 
 In Kotlin, the orders of objects can be defined in several ways.
 
-First, there is _natural_ order. It is defined for inheritors of the [`Comparable`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-comparable/index.html)
+First, there is _natural_ order. It is defined for implementations of the [`Comparable`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-comparable/index.html)
 interface. Natural order is used for sorting them when no other order is specified.
 
 Most built-in types are comparable:


### PR DESCRIPTION
I believe that natural order is something to be defined for classes which implement the Comparable interface.  It may not be defined for another interface which is an inheritor of Comparable.  I believe implementations makes more sense than inheritors, but you can look it over yourself.