### PR TITLE
Add toString, hashCode and equals mapping to Objective-C

### DIFF
--- a/docs/topics/native/native-objc-interop.md
+++ b/docs/topics/native/native-objc-interop.md
@@ -114,8 +114,8 @@ player.moveTo(UP, byInches = 42)
 ```
 
 The methods of `kotlin.Any` (`equals()`, `hashCode()` and `toString()`) are mapped 
-to the methods `isEquals:`, `description` and `hash` in Objective-C, and to the method
-`isEquals(_:)` and the properties `description`, `hash` in Swift.
+to the methods `isEquals:`, `hash` and `description` in Objective-C, and to the method
+`isEquals(_:)` and the properties `hash`, `description` in Swift.
 
 ### Errors and exceptions
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-52579/ObjectiveC-Export-toString-hashCode-equals-from-Any-in-KotlinBase#focus=Comments-27-6125427.0-0