### PR TITLE
Update in interfaces.md file

### DIFF
--- a/docs/topics/interfaces.md
+++ b/docs/topics/interfaces.md
@@ -108,7 +108,7 @@ class D : A, B {
 ```
 
 Interfaces *A* and *B* both declare functions *foo()* and *bar()*. Both of them implement *foo()*, but only *B* implements
-*bar()* (*bar()* is not marked as abstract in *A*, because this is the default for interfaces if the function has no body).
+*bar()* (*bar()* is marked as abstract in *A*, because this is the default for interfaces if the function has no body).
 Now, if you derive a concrete class *C* from *A*, you have to override *bar()* and provide an implementation.
 
 However, if you derive *D* from *A* and *B*, you need to implement all the methods that you have


### PR DESCRIPTION
Inside resolving interface conflicts,
I think `bar()` method is abstract by default in `A` interface.

So, we need to remove `not` word from the documentation.

Correct me If I am wrong, comments appreciated!