### PR TITLE
Update ksp-multiplatform.md

### DIFF
--- a/docs/topics/ksp/ksp-multiplatform.md
+++ b/docs/topics/ksp/ksp-multiplatform.md
@@ -30,7 +30,7 @@ kotlin {
 }
 
 dependencies {
-    add("kspMetadata", project(":test-processor"))
+    add("kspCommonMainMetadata", project(":test-processor"))
     add("kspJvm", project(":test-processor"))
     add("kspJvmTest", project(":test-processor")) // Not doing anything because there's no test source set for JVM
     // There is no processing for the Linux x64 main source set, because kspLinuxX64 isn't specified


### PR DESCRIPTION
kspMetadata does not seem to work with latest stable Idea CE + Kotlin 1.6.21 + KSP 1.6.21-1.0.5, kspCommonMainMetadata works: https://app.slack.com/client/T09229ZC6/C013BA8EQSE/thread/C0922A726-1654581147.035839