### PR TITLE
update: add compatibility guide links for Kotlin 1.7.0

### DIFF
--- a/docs/topics/releases.md
+++ b/docs/topics/releases.md
@@ -60,7 +60,9 @@ You can also use [preview versions of Kotlin](eap.md#build-details).
             <ul>
                 <li><a href="whatsnew17.md" target="_blank">What's new in Kotlin 1.7.0</a></li>
                 <li><a href="https://youtu.be/54WEfLKtCGk" target="_blank">What's new in Kotlin YouTube video</a></li>
-            </ul></td>
+                <li><a href="compatibility-guide-17.md" target="_blank">Compatibility Guide for Kotlin 1.7.0</a></li>
+            </ul>
+        </td>
         <td>
             <ul>
                 <li><a href="https://github.com/Kotlin/kotlinx.serialization" target="_blank">kotlinx.serialization</a> version: <a href="https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.3.2" target="_blank">1.3.2</a></li>

--- a/docs/topics/releases.md
+++ b/docs/topics/releases.md
@@ -60,7 +60,7 @@ You can also use [preview versions of Kotlin](eap.md#build-details).
             <ul>
                 <li><a href="whatsnew17.md" target="_blank">What's new in Kotlin 1.7.0</a></li>
                 <li><a href="https://youtu.be/54WEfLKtCGk" target="_blank">What's new in Kotlin YouTube video</a></li>
-                <li><a href="compatibility-guide-17.md" target="_blank">Compatibility Guide for Kotlin 1.7.0</a></li>
+                <li><a href="compatibility-guide-17.md" target="_blank">Compatibility guide for Kotlin 1.7.0</a></li>
             </ul>
         </td>
         <td>
@@ -158,7 +158,7 @@ You can also use [preview versions of Kotlin](eap.md#build-details).
             <ul>
                 <li><a href="https://blog.jetbrains.com/kotlin/2021/11/kotlin-1-6-0-is-released/" target="_blank">Release blog post</a></li>
                 <li><a href="whatsnew16.md" target="_blank">What's new in Kotlin 1.6.0</a></li>
-                <li><a href="compatibility-guide-16.md" target="_blank">Compatibility Guide</a></li>
+                <li><a href="compatibility-guide-16.md" target="_blank">Compatibility guide</a></li>
             </ul>
         </td>
         <td>
@@ -333,7 +333,7 @@ You can also use [preview versions of Kotlin](eap.md#build-details).
             <ul>
                 <li><a href="https://blog.jetbrains.com/kotlin/2021/04/kotlin-1-5-0-released/" target="_blank">Release blog post</a></li>
                 <li><a href="whatsnew15.md" target="_blank">What's new in Kotlin 1.5.0</a></li>
-                <li><a href="compatibility-guide-15.md" target="_blank">Compatibility Guide</a></li>
+                <li><a href="compatibility-guide-15.md" target="_blank">Compatibility guide</a></li>
             </ul>
         </td>
         <td>
@@ -504,7 +504,7 @@ You can also use [preview versions of Kotlin](eap.md#build-details).
             <ul>
                 <li><a href="https://blog.jetbrains.com/kotlin/2020/08/kotlin-1-4-released-with-a-focus-on-quality-and-performance/" target="_blank">Release blog post</a></li>
                 <li><a href="whatsnew14.md" target="_blank">What's new in Kotlin 1.4.0</a></li>
-                <li><a href="compatibility-guide-14.md" target="_blank">Compatibility Guide</a></li>
+                <li><a href="compatibility-guide-14.md" target="_blank">Compatibility guide</a></li>
                 <li><a href="whatsnew14.md#migrating-to-kotlin-1-4-0" target="_blank">Migrating to Kotlin 1.4.0</a></li>
             </ul>
         </td>

--- a/docs/topics/whatsnew17.md
+++ b/docs/topics/whatsnew17.md
@@ -1042,3 +1042,28 @@ kotlin {
     }
 }
 ```
+
+## Migrating to Kotlin 1.7.0
+
+### Install Kotlin 1.7.0
+
+IntelliJ IDEA 2022.1 and Android Studio Chipmunk (212) will suggest updating the Kotlin plugin to 1.7.0 once it is available.
+
+> For Intellij IDEA 2022.2, and Android Studio Dolphin (213) or Android Studio Electric Eel (221), the Kotlin plugin 1.7.0 will be delivered with upcoming Intellij IDEA and Android Studios updates.
+> 
+{type="note"}
+
+The new command-line compiler is available for download on the [GitHub release page](https://github.com/JetBrains/kotlin/releases/tag/v1.7.0).
+
+### Migrate existing or start a new project with Kotlin 1.7.0
+
+* To migrate existing projects to Kotlin 1.7.0, change the Kotlin version to `1.7.0` and reimport your Gradle or Maven
+project. [Learn how to update to Kotlin 1.7.0](releases.md#update-to-a-new-release).
+
+* To start a new project with Kotlin 1.7.0, update the Kotlin plugin and run the Project Wizard from **File** \| **New** \|
+**Project**.
+
+### Compatibility Guide for Kotlin 1.7.0
+
+Kotlin 1.7.0 is a [feature release](kotlin-evolution.md#feature-releases-and-incremental-releases) and can, therefore, bring changes that are incompatible with your code written for earlier versions of the language.
+Find the detailed list of such changes in the [Compatibility Guide for Kotlin 1.7.0](compatibility-guide-17.md).

--- a/docs/topics/whatsnew17.md
+++ b/docs/topics/whatsnew17.md
@@ -1063,7 +1063,7 @@ project. [Learn how to update to Kotlin 1.7.0](releases.md#update-to-a-new-relea
 * To start a new project with Kotlin 1.7.0, update the Kotlin plugin and run the Project Wizard from **File** \| **New** \|
 **Project**.
 
-### Compatibility Guide for Kotlin 1.7.0
+### Compatibility guide for Kotlin 1.7.0
 
 Kotlin 1.7.0 is a [feature release](kotlin-evolution.md#feature-releases-and-incremental-releases) and can, therefore, bring changes that are incompatible with your code written for earlier versions of the language.
-Find the detailed list of such changes in the [Compatibility Guide for Kotlin 1.7.0](compatibility-guide-17.md).
+Find the detailed list of such changes in the [Compatibility guide for Kotlin 1.7.0](compatibility-guide-17.md).

--- a/docs/topics/whatsnew17.md
+++ b/docs/topics/whatsnew17.md
@@ -1047,7 +1047,7 @@ kotlin {
 
 ### Install Kotlin 1.7.0
 
-IntelliJ IDEA 2022.1 and Android Studio Chipmunk (212) will suggest updating the Kotlin plugin to 1.7.0 once it is available.
+IntelliJ IDEA 2022.1 and Android Studio Chipmunk (212) automatically suggest updating the Kotlin plugin to 1.7.0.
 
 > For Intellij IDEA 2022.2, and Android Studio Dolphin (213) or Android Studio Electric Eel (221), the Kotlin plugin 1.7.0 will be delivered with upcoming Intellij IDEA and Android Studios updates.
 > 


### PR DESCRIPTION
Add info about migration to 1.7.0