### PR TITLE
update: add links to api reference on @JvmDefaultWithCompatibility

### DIFF
--- a/docs/topics/jvm/java-to-kotlin-interop.md
+++ b/docs/topics/jvm/java-to-kotlin-interop.md
@@ -338,7 +338,7 @@ public class BB8 implements Robot {
 
 If there are clients that use your Kotlin interfaces compiled without the `-Xjvm-default=all` option, then they may
 be binary-incompatible with the code compiled with this option. To avoid breaking the compatibility with such clients, 
-use the `-Xjvm-default=all` mode and mark interfaces with the [`@JvmDefaultWithCompatibility` annotation](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default-with-compatibility/). 
+use the `-Xjvm-default=all` mode and mark interfaces with the [`@JvmDefaultWithCompatibility`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default-with-compatibility/) annotation. 
 This allows you to add this annotation to all interfaces in the public API once, and you won't need to use any annotations for new non-public code.
 
 > Starting from Kotlin 1.6.20, you can compile modules in the default mode (the `-Xjvm-default=disable` compiler option) against 

--- a/docs/topics/jvm/java-to-kotlin-interop.md
+++ b/docs/topics/jvm/java-to-kotlin-interop.md
@@ -338,7 +338,7 @@ public class BB8 implements Robot {
 
 If there are clients that use your Kotlin interfaces compiled without the `-Xjvm-default=all` option, then they may
 be binary-incompatible with the code compiled with this option. To avoid breaking the compatibility with such clients, 
-use the `-Xjvm-default=all` mode and mark interfaces with the `@JvmDefaultWithCompatibility` annotation. 
+use the `-Xjvm-default=all` mode and mark interfaces with the [`@JvmDefaultWithCompatibility` annotation](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default-with-compatibility/). 
 This allows you to add this annotation to all interfaces in the public API once, and you won't need to use any annotations for new non-public code.
 
 > Starting from Kotlin 1.6.20, you can compile modules in the default mode (the `-Xjvm-default=disable` compiler option) against 

--- a/docs/topics/whatsnew1620.md
+++ b/docs/topics/whatsnew1620.md
@@ -131,7 +131,7 @@ Kotlin 1.6.20 introduces:
 
 ### New @JvmDefaultWithCompatibility annotation for interfaces
 
-Kotlin 1.6.20 introduces the [new annotation `@JvmDefaultWithCompatibility`](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/src/kotlin/jvm/JvmDefault.kt#L53): use it along with the `-Xjvm-default=all` compiler option [to create the default method in JVM interface](java-to-kotlin-interop.md#default-methods-in-interfaces) for any non-abstract member in any Kotlin interface.
+Kotlin 1.6.20 introduces the [new annotation `@JvmDefaultWithCompatibility`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default-with-compatibility/).: use it along with the `-Xjvm-default=all` compiler option [to create the default method in JVM interface](java-to-kotlin-interop.md#default-methods-in-interfaces) for any non-abstract member in any Kotlin interface.
 
 If there are clients that use your Kotlin interfaces compiled without the `-Xjvm-default=all` option, they may be binary-incompatible with the code compiled with this option.
 Before Kotlin 1.6.20, to avoid this compatibility issue, the [recommended approach](https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/#JvmDefaultWithoutCompatibility) was to use the `-Xjvm-default=all-compatibility` mode and also the `@JvmDefaultWithoutCompatibility` annotation for interfaces that didn't need this type of compatibility.

--- a/docs/topics/whatsnew1620.md
+++ b/docs/topics/whatsnew1620.md
@@ -131,7 +131,7 @@ Kotlin 1.6.20 introduces:
 
 ### New @JvmDefaultWithCompatibility annotation for interfaces
 
-Kotlin 1.6.20 introduces the [new annotation `@JvmDefaultWithCompatibility`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default-with-compatibility/).: use it along with the `-Xjvm-default=all` compiler option [to create the default method in JVM interface](java-to-kotlin-interop.md#default-methods-in-interfaces) for any non-abstract member in any Kotlin interface.
+Kotlin 1.6.20 introduces the new annotation [`@JvmDefaultWithCompatibility`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default-with-compatibility/): use it along with the `-Xjvm-default=all` compiler option [to create the default method in JVM interface](java-to-kotlin-interop.md#default-methods-in-interfaces) for any non-abstract member in any Kotlin interface.
 
 If there are clients that use your Kotlin interfaces compiled without the `-Xjvm-default=all` option, they may be binary-incompatible with the code compiled with this option.
 Before Kotlin 1.6.20, to avoid this compatibility issue, the [recommended approach](https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/#JvmDefaultWithoutCompatibility) was to use the `-Xjvm-default=all-compatibility` mode and also the `@JvmDefaultWithoutCompatibility` annotation for interfaces that didn't need this type of compatibility.


### PR DESCRIPTION
The API reference was updated after the 1.6.20 release.