### PR TITLE
Use kotlin.test.Test in jvmTest sample for multiplatform library tutorial

### DIFF
--- a/docs/topics/multiplatform/multiplatform-library.md
+++ b/docs/topics/multiplatform/multiplatform-library.md
@@ -266,7 +266,7 @@ You can also add tests that will be run only for a specific platform. For exampl
    ```kotlin
    package org.jetbrains.base64
    
-   import org.junit.Test
+   import kotlin.test.Test
    import kotlin.test.assertEquals
    
    class Base64JvmTest {


### PR DESCRIPTION
org.junit is not a direct dependency of the sample project