### PR TITLE
KTL-764 kotlin.Result extension function sample provides kotlin.Collections samples

### DIFF
--- a/redirects/api.yml
+++ b/redirects/api.yml
@@ -742,8 +742,6 @@
   to: /api/latest/jvm/stdlib/kotlin.ranges/-char-range/is-empty.html
 - from: /api/latest/jvm/stdlib/kotlin/-char-range/end-inclusive.html
   to: /api/latest/jvm/stdlib/kotlin.ranges/-char-range/end-inclusive.html
-- from: /api/latest/jvm/stdlib/kotlin/get-or-else.html
-  to: /api/latest/jvm/stdlib/kotlin.collections/get-or-else.html
 - from: /api/latest/jvm/stdlib/kotlin/to-sorted-map.html
   to: /api/latest/jvm/stdlib/kotlin.collections/to-sorted-map.html
 - from: /api/latest/jvm/stdlib/kotlin/require-no-nulls.html


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-764/kotlinResult-extension-function-sample-provides-kotlinCollections-samples

It is just a quick fix, and then we will review all redirects to find and remove redundant.