### PR TITLE
Rephrase `final` requirement for inline classes

### DIFF
--- a/docs/topics/inline-classes.md
+++ b/docs/topics/inline-classes.md
@@ -88,7 +88,7 @@ fun main() {
 ```
 
 It is forbidden for inline classes to participate in a class hierarchy. This means that inline classes cannot extend 
-other classes and must be `final`.
+other classes and are always `final`.
 
 ## Representation
 


### PR DESCRIPTION
Saying "must be `final`" could be misinterpreted as "needs `final` modifier in order to work". Since `final` is the default, I propose rephrasing it to show that finality is _always_ the case.