### PR TITLE
Explicitly state lack of support for bytecode < Java 8

### DIFF
--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -96,7 +96,7 @@ When targeting native, Kotlin will produce platform-specific code (via LLVM).
 Kotlin lets you choose the version of JVM for execution. By default, the Kotlin/JVM compiler produces Java 8 compatible bytecode.
 If you want to make use of optimizations available in newer versions of Java, you can explicitly specify the target Java
 version from 9 to 18. Note that in this case the resulting bytecode might not run on lower versions.
-Starting with [Kotlin 1.5](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), the compiler does not support producing bytecode compatible with Java versions below 8.
+Starting with [Kotlin 1.5](whatsnew15.md#new-default-jvm-target-1-8), the compiler does not support producing bytecode compatible with Java versions below 8.
 
 ### Is Kotlin hard?
 

--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -95,7 +95,8 @@ When targeting native, Kotlin will produce platform-specific code (via LLVM).
 
 Kotlin lets you choose the version of JVM for execution. By default, the Kotlin/JVM compiler produces Java 8 compatible bytecode.
 If you want to make use of optimizations available in newer versions of Java, you can explicitly specify the target Java
-version from 9 to 18. Note that in this case the resulting bytecode might not run on lower versions. 
+version from 9 to 18. Note that in this case the resulting bytecode might not run on lower versions.
+The Kotlin compiler does not support producing bytecode compatible with Java versions below 8.
 
 ### Is Kotlin hard?
 

--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -96,7 +96,7 @@ When targeting native, Kotlin will produce platform-specific code (via LLVM).
 Kotlin lets you choose the version of JVM for execution. By default, the Kotlin/JVM compiler produces Java 8 compatible bytecode.
 If you want to make use of optimizations available in newer versions of Java, you can explicitly specify the target Java
 version from 9 to 18. Note that in this case the resulting bytecode might not run on lower versions.
-The Kotlin compiler does not support producing bytecode compatible with Java versions below 8.
+Starting with [Kotlin 1.5](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), the compiler does not support producing bytecode compatible with Java versions below 8.
 
 ### Is Kotlin hard?
 


### PR DESCRIPTION
> 'compileJava' task (current target is 16) and 'compileKotlin' task (current target is 1.6) jvm target compatibility should be set to the same Java version.
> w: JVM target 1.6 is deprecated and will be removed in a future release. Please migrate to JVM target 1.8 or above

Historically, Kotlin had supported compiling all the way down to JVM 1.6 targets, and you can still find references to this on [StackOverflow](https://stackoverflow.com/questions/48036758/is-the-jdk-required-for-kotlin).

Since this target is deprecated, it makes sense to state the requirement of targeting Java 8 compatible code explicitly.