### PR TITLE
Update of destination directory configuration sample

### DIFF
--- a/docs/topics/multiplatform/multiplatform-build-native-binaries.md
+++ b/docs/topics/multiplatform/multiplatform-build-native-binaries.md
@@ -353,7 +353,7 @@ kotlin {
         // The fat framework must have the same base name as the initial frameworks.
         baseName = "my_framework"
         // The default destination directory is "<build directory>/fat-framework".
-        destinationDir = buildDir.resolve("fat-framework/debug")
+        destinationDirectory = buildDir.resolve("fat-framework/debug")
         // Specify the frameworks to be merged.
         from(
             ios32.binaries.getFramework("DEBUG"),
@@ -385,7 +385,7 @@ kotlin {
         // The fat framework must have the same base name as the initial frameworks.
         baseName = "my_framework"
         // The default destination directory is "<build directory>/fat-framework".
-        destinationDir = file("$buildDir/fat-framework/debug")
+        destinationDirectory = file("$buildDir/fat-framework/debug")
         // Specify the frameworks to be merged.
         from(
             targets.ios32.binaries.getFramework("DEBUG"),


### PR DESCRIPTION
According to the replacement of the deprecated API made in 1.7.0. See https://kotlinlang.org/docs/whatsnew17.html#changes-in-compile-tasks for details.