### PR TITLE
fix for minor mistakes

### DIFF
--- a/docs/topics/js/js-get-started.md
+++ b/docs/topics/js/js-get-started.md
@@ -100,7 +100,7 @@ Enter your name in the text box and accept the greetings from your application!
 4. Go to the browser and enjoy the result.  
     You will only see the changes if your previous application is still running. If you've stopped your application, [run it again](#run-the-application).
    
-![Web page with with an image](js-output-3.png){width=600}
+![Web page with an image](js-output-3.png){width=600}
 
 ### Add a button that changes text
 

--- a/docs/topics/kotlin-and-ci.md
+++ b/docs/topics/kotlin-and-ci.md
@@ -45,7 +45,7 @@ Basically this step is limited to defining the Step Name and the version of Kotl
 
 <img src="teamcity-setupkotlin.png" alt="Setup Kotlin Compiler" width="700"/>
 
-The runner will set the value for the property system.path.macro.KOTLIN.BUNDLED to the correct one based on the path settings
+The runner will set the value for the property `system.path.macro.KOTLIN.BUNDLED` to the correct one based on the path settings
 from the IntelliJ IDEA project. However, this value needs to be defined in TeamCity (and can be set to any value).
 Therefore, you need to define it as a system variable.
 
@@ -61,4 +61,3 @@ With that, our project should now build and produce the corresponding artifacts.
 
 If using a continuous integration tool different to TeamCity, as long as it supports any of the build tools,
 or calling command line tools, compiling Kotlin and automating things as part of a CI process should be possible.
-

--- a/docs/topics/native/mapping-function-pointers-from-c.md
+++ b/docs/topics/native/mapping-function-pointers-from-c.md
@@ -148,7 +148,7 @@ Check out the [kotlin-multiplatform](multiplatform-discover-project.md#multiplat
 plugin documentation to learn about all the different ways you could configure it.
 
 Let's create a `src/nativeMain/kotlin/hello.kt` stub file with the following content
-to see how C primitive type declarations are visible from Kotlin:
+to see how C function pointer declarations are visible from Kotlin:
 
 ```kotlin
 import interop.*

--- a/docs/topics/native/mapping-strings-from-c.md
+++ b/docs/topics/native/mapping-strings-from-c.md
@@ -174,7 +174,7 @@ Check out the [kotlin-multiplatform](multiplatform-discover-project.md#multiplat
 plugin documentation to learn about all the different ways you could configure it.
 
 Let's create a `src/nativeMain/kotlin/hello.kt` stub file with the following content
-to see how C primitive type declarations are visible from Kotlin:
+to see how C string declarations are visible from Kotlin:
 
 ```kotlin
 import interop.*
@@ -191,9 +191,9 @@ fun main() {
 Now you are ready to
 [open the project in IntelliJ IDEA](native-get-started.md)
 and to see how to fix the example project. While doing that,
-see how C primitive types are mapped into Kotlin/Native.
+see how C strings are mapped into Kotlin/Native.
 
-## Primitive types in Kotlin
+## Strings in Kotlin
 
 With the help of IntelliJ IDEA's __Go to | Declaration__ or
 compiler errors, you see the following generated API for the C functions:

--- a/docs/topics/native/mapping-struct-union-types-from-c.md
+++ b/docs/topics/native/mapping-struct-union-types-from-c.md
@@ -147,7 +147,7 @@ Check out the [kotlin-multiplatform](multiplatform-discover-project.md#multiplat
 plugin documentation to learn about all the different ways you could configure it.
 
 Create a `src/nativeMain/kotlin/hello.kt` stub file with the following content
-to see how C declarations are visible from Kotlin:
+to see how C struct and union declarations are visible from Kotlin:
 
 ```kotlin
 import interop.*
@@ -165,9 +165,9 @@ fun main() {
 Now you are ready to
 [open the project in IntelliJ IDEA](native-get-started.md)
 and to see how to fix the example project. While doing that,
-see how C primitive types are mapped into Kotlin/Native.
+see how C struct and union types are mapped into Kotlin/Native.
 
-## Primitive types in Kotlin
+## Struct and union types in Kotlin
 
 With the help of IntelliJ IDEA's __Go to | Declaration__ or
 compiler errors, you see the following generated API for the C functions, `struct`, and `union`:
@@ -401,4 +401,3 @@ Continue exploring the C language types and their representation in Kotlin/Nativ
 - [Mapping strings from C](mapping-strings-from-c.md)
 
 The [C Interop documentation](native-c-interop.md) covers more advanced scenarios of the interop.
-

--- a/docs/topics/native/native-get-started.md
+++ b/docs/topics/native/native-get-started.md
@@ -67,7 +67,7 @@ performs the incremental build of the project.
 
 1. Open the file `main.kt` in `src/nativeMain/kotlin`.
 
-   The `src` directory contains the Kotlin source files and resources. The file `main.kt` includes sample code that prints "Hello, Kotlin/Native!" using the [`println()`](https://kotlinlang.org/api/latest/jvm/stdlib/stdlib/kotlin.io/println.html) function.
+   The `src` directory contains the Kotlin source files and resources. The file `main.kt` includes sample code that prints "Hello, Kotlin/Native!" using the [`println()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/println.html) function.
 
 2. Add code to read the input. Use the [`readln()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/readln.html) function to read the input value and assign it to the `name` variable:
 

--- a/docs/topics/no-arg-plugin.md
+++ b/docs/topics/no-arg-plugin.md
@@ -5,7 +5,7 @@ The *no-arg* compiler plugin generates an additional zero-argument constructor f
 The generated constructor is synthetic so it can’t be directly called from Java or Kotlin, but it can be called using reflection.
 
 This allows the Java Persistence API (JPA) to instantiate a class although it doesn't have the zero-parameter constructor
-from Kotlin or Java point of view (see the description of `kotlin-jpa` plugin [below](#jpa-support).
+from Kotlin or Java point of view (see the description of `kotlin-jpa` plugin [below](#jpa-support)).
 
 ## Gradle
 


### PR DESCRIPTION
### Change List
fix for minor mistakes:
- missing bracket
- incorrect API doc URL
- incorrect words (maybe copied & pasted from other page)
