### PR TITLE
Clarify that webpack configs need to use `config`

### DIFF
--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -394,7 +394,7 @@ files will automatically be merged into the `build/js/packages/projectName/webpa
 To add a new [webpack loader](https://webpack.js.org/loaders/), for example, add the following to
 a `.js` file inside the `webpack.config.d`:
 
-> In this case, you need to modify the `config` object. Other examples for webpack might use `module.exports` or other names.
+> In this case, the configuration object presented in the `config` global object. You need to modify it in your script.
 >
 {type="note"}
 

--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -401,6 +401,10 @@ config.module.rules.push({
 });
 ```
 
+> The object you need to modify is called `config`. Other examples for webpack might use `module.exports` or something else.
+>
+{type="note"}
+         
 All webpack configuration
 capabilities are well described in its [documentation](https://webpack.js.org/concepts/configuration/).
 

--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -394,17 +394,17 @@ files will automatically be merged into the `build/js/packages/projectName/webpa
 To add a new [webpack loader](https://webpack.js.org/loaders/), for example, add the following to
 a `.js` file inside the `webpack.config.d`:
 
+> In this case, you need to modify the `config` object. Other examples for webpack might use `module.exports` or other names.
+>
+{type="note"}
+
 ```groovy
 config.module.rules.push({
     test: /\.extension$/,
     loader: 'loader-name'
 });
 ```
-
-> The object you need to modify is called `config`. Other examples for webpack might use `module.exports` or something else.
->
-{type="note"}
-         
+     
 All webpack configuration
 capabilities are well described in its [documentation](https://webpack.js.org/concepts/configuration/).
 


### PR DESCRIPTION
Spent about an hour confused by this.