### PR TITLE
KTL-764 kotlin.Result extension function sample provides kotlin.Collections samples

### DIFF
--- a/kotlin-website.py
+++ b/kotlin-website.py
@@ -431,7 +431,10 @@ def generate_redirect_pages():
                         url_list = url_from if isinstance(url_from, list) else [url_from]
 
                         for url in url_list:
-                            app.add_url_rule(url, view_func=RedirectTemplateView.as_view(url, url=url_to))
+                            if file == 'api.yml' and path.isfile(path.join(root_folder, url[1:])):
+                                print("The file " + url + " is already exist.")
+                            else:
+                                app.add_url_rule(url, view_func=RedirectTemplateView.as_view(url, url=url_to))
 
                 except yaml.YAMLError as exc:
                     sys.stderr.write('Cant parse data file ' + file + ': ')

--- a/redirects/api.yml
+++ b/redirects/api.yml
@@ -182,8 +182,6 @@
   to: /api/latest/jvm/stdlib/kotlin.text/is-not-blank.html
 - from: /api/latest/jvm/stdlib/kotlin/any.html
   to: /api/latest/jvm/stdlib/kotlin.collections/any.html
-- from: /api/latest/jvm/stdlib/kotlin/map.html
-  to: /api/latest/jvm/stdlib/kotlin.collections/map.html
 - from: /api/latest/jvm/stdlib/kotlin/sorted.html
   to: /api/latest/jvm/stdlib/kotlin.collections/sorted.html
 - from: /api/latest/jvm/stdlib/kotlin/to-byte.html
@@ -440,8 +438,6 @@
   to: /api/latest/jvm/stdlib/kotlin/
 - from: /api/latest/jvm/stdlib/kotlin/java.util.regex.-pattern/to-regex.html
   to: /api/latest/jvm/stdlib/kotlin.text/java.util.regex.-pattern/to-regex.html
-- from: /api/latest/jvm/stdlib/kotlin/compare-to.html
-  to: /api/latest/jvm/stdlib/kotlin.text/compare-to.html
 - from: /api/latest/jvm/stdlib/kotlin/remove-suffix.html
   to: /api/latest/jvm/stdlib/kotlin.text/remove-suffix.html
 - from: /api/latest/jvm/stdlib/kotlin/sorted-by.html
@@ -1034,8 +1030,6 @@
   to: /api/latest/jvm/stdlib/kotlin.collections/find-last.html
 - from: /api/latest/jvm/stdlib/kotlin/step.html
   to: /api/latest/jvm/stdlib/kotlin.ranges/step.html
-- from: /api/latest/jvm/stdlib/kotlin/fold.html
-  to: /api/latest/jvm/stdlib/kotlin.collections/fold.html
 - from: /api/latest/jvm/stdlib/kotlin/-char-category/-o-t-h-e-r_-s-y-m-b-o-l.html
   to: /api/latest/jvm/stdlib/kotlin.text/-char-category/-o-t-h-e-r_-s-y-m-b-o-l.html
 - from: /api/latest/jvm/stdlib/kotlin/-char-category/-n-o-n_-s-p-a-c-i-n-g_-m-a-r-k.html
@@ -1160,8 +1154,6 @@
   to: /api/latest/jvm/stdlib/kotlin.collections/add-all.html
 - from: /api/latest/jvm/stdlib/kotlin/join-to-string.html
   to: /api/latest/jvm/stdlib/kotlin.collections/join-to-string.html
-- from: /api/latest/jvm/stdlib/kotlin/-throwable/print-stack-trace.html
-  to: /api/latest/jvm/stdlib/kotlin/print-stack-trace.html
 - from: /api/latest/jvm/stdlib/kotlin/is-null-or-blank.html
   to: /api/latest/jvm/stdlib/kotlin.text/is-null-or-blank.html
 - from: /api/latest/jvm/stdlib/kotlin/split-to-sequence.html


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-764/kotlinResult-extension-function-sample-provides-kotlinCollections-samples

The affected pages:
https://branch-ktl-764-fix-stdlib-redirects.kotlin-web-site.labs.jb.gg/api/latest/jvm/stdlib/kotlin/map.html
https://branch-ktl-764-fix-stdlib-redirects.kotlin-web-site.labs.jb.gg/api/latest/jvm/stdlib/kotlin/compare-to.html
https://branch-ktl-764-fix-stdlib-redirects.kotlin-web-site.labs.jb.gg/api/latest/jvm/stdlib/kotlin/fold.html
https://branch-ktl-764-fix-stdlib-redirects.kotlin-web-site.labs.jb.gg/api/latest/jvm/stdlib/kotlin/-throwable/print-stack-trace.html