### PR TITLE
Replace non-Java-Identifier const by constant

### DIFF
--- a/docs/topics/jvm/java-to-kotlin-interop.md
+++ b/docs/topics/jvm/java-to-kotlin-interop.md
@@ -200,7 +200,7 @@ In Java:
 
 ```java
 
-int const = Obj.CONST;
+int constant = Obj.CONST;
 int max = ExampleKt.MAX;
 int version = C.VERSION;
 ```


### PR DESCRIPTION
const is in Java a keyword and therefore not a valid identifier.
So the example Java Code 
```java
int const = Obj.CONST;
int max = ExampleKt.MAX;
int version = C.VERSION;
```
about using const properties in Java wouldn't compile.
I propose renaming the variable const to constant.