### PR TITLE
Fix typo in sealed classes `when` example

### DIFF
--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -88,7 +88,7 @@ However, this works only if you use `when` as an expression (using the result) a
 fun log(e: Error) = when(e) {
     is FileReadError -> { println("Error while reading file ${e.file}") }
     is DatabaseError -> { println("Error while reading from database ${e.source}") }
-    RuntimeError ->  { println("Runtime error") }
+    is RuntimeError ->  { println("Runtime error") }
     // the `else` clause is not required because all the cases are covered
 }
 ```


### PR DESCRIPTION
The final branch was missing an `is` prior to the matched case.