### PR TITLE
Add a note about toolchains applying to Java tasks

### DIFF
--- a/docs/topics/gradle.md
+++ b/docs/topics/gradle.md
@@ -192,6 +192,7 @@ A Java toolchain:
   if the user doesn't set the `jvmTarget` option explicitly.
   If the user doesn't configure the toolchain, the `jvmTarget` field will use the default value.
   Learn more about [JVM target compatibility](#check-for-jvm-target-compatibility-of-related-compile-tasks).
+* Sets the toolchain to be used by any Java compile, test and javadoc tasks.
 * Affects which JDK [`kapt` workers](kapt.md#running-kapt-tasks-in-parallel) are running on.
 
 Use the following code to set a toolchain. Replace the placeholder `<MAJOR_JDK_VERSION>` with the JDK version you would like to use:


### PR DESCRIPTION
The Kotlin toolchain feature also effectively sets the toolchain for Java, so it also acts as if the following has been applied to the project as well: https://docs.gradle.org/current/userguide/toolchains.html#sec:consuming.

This means the toolchain applied in the Kotlin extension is applied to Java tasks as well. This fact is included in the Kotlin Gradle Plugin KDoc, and is important enough that I think it should be included in the website docs as well.

The KGP doc for `jvmToolchain` option says it "Configures Java toolchain both for Kotlin JVM and Java tasks."