### PR TITLE
chore: remove unnecessary icon of the home page

### DIFF
--- a/docs/topics/home.xml
+++ b/docs/topics/home.xml
@@ -20,7 +20,7 @@
             <a href="basic-syntax.md" description="A quick tour of Kotlin syntax: keywords, operators, program structure">Basic syntax</a>
             <a href="https://play.kotlinlang.org/byExample/overview" description="Simple annotated examples for the Kotlin syntax">Kotlin by example</a>
             <a href="koans.md" description="Programming exercises to get you familiar with Kotlin">Koans</a>
-            <a href="command-line.md" description="Download and install the Kotlin compiler" type="install">Command-line compiler</a>
+            <a href="command-line.md" description="Download and install the Kotlin compiler">Command-line compiler</a>
         </main-group>
         <highlighted-group>
             <title>Featured topics</title>


### PR DESCRIPTION
Hey @koshachy,
let's remove this icon from the "command line compiler" block. 
<img width="872" alt="Screenshot 2022-09-01 at 13 42 31" src="https://user-images.githubusercontent.com/3338311/187906925-bb933bed-8cdf-4bd2-9d1c-ffee1af5ddae.png">
