### PR TITLE
Update default arguments﻿

### DIFF
--- a/docs/topics/functions.md
+++ b/docs/topics/functions.md
@@ -55,9 +55,8 @@ fun read(
 
 A default value is defined using `=` after the type.
 
-Overriding methods always use the same default parameter values as the base method.
-When overriding a method that has default parameter values, the default parameter values must be omitted from the signature:
-
+Overriding methods always use the same default parameter values as the base method, and not allowed to specify default values for its parameters.
+So when overriding a method that has default parameter values, the default parameter values must be omitted from the signature:
 ```kotlin
 open class A {
     open fun foo(i: Int = 10) { /*...*/ }


### PR DESCRIPTION
An overridden method should not have default values for its parameters regardless of whether its base method has a default value or not.