### PR TITLE
Update version of Spring Boot in tutorial to 2.7.3

### DIFF
--- a/docs/topics/jvm/jvm-spring-boot-restful.md
+++ b/docs/topics/jvm/jvm-spring-boot-restful.md
@@ -26,7 +26,7 @@ Use Spring Initializr to create a new project:
 >
 {type="note"}
 
-1. Open [Spring Initializr](https://start.spring.io/#!type=gradle-project&language=kotlin&platformVersion=2.6.0&packaging=jar&jvmVersion=11&groupId=com.example&artifactId=demo&name=demo&description=Demo%20project%20for%20Spring%20Boot&packageName=demo&dependencies=web,data-jdbc,h2). This link opens the page with the project settings for this tutorial already filled in.
+1. Open [Spring Initializr](https://start.spring.io/#!type=gradle-project&language=kotlin&platformVersion=2.7.3&packaging=jar&jvmVersion=11&groupId=com.example&artifactId=demo&name=demo&description=Demo%20project%20for%20Spring%20Boot&packageName=demo&dependencies=web,data-jdbc,h2). This link opens the page with the project settings for this tutorial already filled in.
 This project uses **Gradle**, **Kotlin**, **Spring Web**, **Spring Data JDBC**, and **H2 Database**:
 
    ![Create a new project with Spring Initializr](spring-boot-create-project-with-initializr.png){width=800}


### PR DESCRIPTION
This is a minor modification to the url for the `Spring Initializr` link, near the top of the associated tutorial.

The previous version (2.6.0) is no longer offered, so the Initializr website shows a warning and switches to the latest 2.6.x release (currently 2.6.11).