### PR TITLE
fix: use the right case on table name when adding database support

### DIFF
--- a/docs/topics/jvm/jvm-spring-boot-restful.md
+++ b/docs/topics/jvm/jvm-spring-boot-restful.md
@@ -161,7 +161,7 @@ before the `id` field. These annotations also require additional imports:
    import org.springframework.data.annotation.Id
    import org.springframework.data.relational.core.mapping.Table
   
-   @Table("messages")
+   @Table("MESSAGES")
    data class Message(@Id val id: String?, val text: String)
    ```
 


### PR DESCRIPTION
Based on the code repository, the table name should be in uppercase in order for H2 to found the table on the H2 database.