### PR TITLE
KTL-696 kotlinlang.org: customize Dokka's Header

### DIFF
--- a/dokka-templates/includes/header.ftl
+++ b/dokka-templates/includes/header.ftl
@@ -1,5 +1,6 @@
 <#import "source_set_selector.ftl" as source_set_selector>
 <#macro display>
+    {% ktl_component "header" %}
     <div class="navigation-wrapper" id="navigation-wrapper">
         <div id="leftToggler"><span class="icon-toggler"></span></div>
         <div class="library-name">

--- a/static/js/page/dokka-template/header/index.jsx
+++ b/static/js/page/dokka-template/header/index.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import GlobalHeader from '@jetbrains/kotlin-web-site-ui/out/components/header';
+import searchConfig from '../../../../../search-config.json';
+
+const Header = (props) => {
+	return (
+		<GlobalHeader { ... props } searchConfig={searchConfig} noScrollClassName={'_no-scroll'} />
+	);
+}
+
+export default Header;

--- a/static/js/page/dokka-template/index.js
+++ b/static/js/page/dokka-template/index.js
@@ -1,6 +1,7 @@
 import './index.scss';
 import { initComponent, ktlHelpers } from "../../ktl-component/ktl-helpers";
 import Footer from "./footer/index.jsx";
+import Header from "./header/index.jsx";
 
 document.addEventListener('DOMContentLoaded', init);
 
@@ -9,6 +10,9 @@ function init() {
     switch (name) {
       case 'footer':
         initComponent(node.nextElementSibling, Footer, props);
+        break;
+      case 'header':
+        initComponent(node.nextElementSibling, Header, props);
         break;
       default:
         console.error(`The "${name}" component was not found.`);


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-696/kotlinlangorg-customize-Dokkas-Header