### PR TITLE
Fix compilation error in java-to-kotlin-nullability-guide.md

### DIFF
--- a/docs/topics/jvm/java-to-kotlin-nullability-guide.md
+++ b/docs/topics/jvm/java-to-kotlin-nullability-guide.md
@@ -149,13 +149,9 @@ Converting the Java code above to Kotlin code directly results in the following:
 
 ```kotlin
 // Kotlin
-data class Order {
-  val customer: Customer
-}
+data class Order(val customer: Customer)
 
-data class Customer {
-  val name: String
-}
+data class Customer(val name: String)
 
 val order = findOrder()
 


### PR DESCRIPTION
Fix "Data class must have at least one primary constructor parameter" compilation error for an example with data classes.