### PR TITLE
KTL-869 Set up Lincheck as a part of Docs build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "kotlinx-lincheck"]
-	path = kotlinx-lincheck
-	url = https://github.com/Kotlin/kotlinx-lincheck/
-	branch = master


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-869/Set-up-Lincheck-as-a-part-of-Docs-build

https://branch-ktl-869-remove-lincheck-submodule.kotlin-web-site.labs.jb.gg/docs/lincheck-guide.html