### PR TITLE
fix: style inspection changed its place

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -17,9 +17,8 @@ the given code style.
 
 ### Verify that your code follows the style guide
 
-1. Go to **Settings/Preferences | Editor | Inspections | Kotlin**.
-2. Open **Kotlin | Style issues**.
-3. Switch on **File is not formatted according to project settings** inspection.
+1. Go to **Settings/Preferences | Editor | Inspections | General**.
+2. Switch on **Incorrect formatting** inspection.
 Additional inspections that verify other issues described in the style guide (such as naming conventions) are enabled by default.
 
 ## Source code organization


### PR DESCRIPTION
In the mail, we received feedback on the 19th of September that the inspection "File is not formatted according to project settings" is missed. Seems like the separate setup for Kotlin is a checkbox in the "Incorrect formatting" tab.
<img width="979" alt="Screenshot 2022-10-24 at 14 48 45" src="https://user-images.githubusercontent.com/78360457/197530028-eeceb4f5-9c5b-48b4-a7ec-ea5e37045902.png">
<img width="984" alt="Screenshot 2022-10-24 at 14 46 05" src="https://user-images.githubusercontent.com/78360457/197530072-56182dfd-97d4-4d37-b290-4006fedc1258.png">
