### PR TITLE
fix: default implementation of MutableList is ArrayList

### DIFF
--- a/docs/topics/collections-overview.md
+++ b/docs/topics/collections-overview.md
@@ -184,7 +184,7 @@ However, there is one important difference:  an array's size is defined upon ini
 in turn, a list doesn't have a predefined size; a list's size can be changed as a result of write operations: adding, 
 updating, or removing elements.
 
-In Kotlin, the default implementation of `List` is [`ArrayList`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-array-list/index.html) 
+In Kotlin, the default implementation of `MutableList` is [`ArrayList`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-array-list/index.html) 
 which you can think of as a resizable array.
 
 ### Set

--- a/docs/topics/collections-overview.md
+++ b/docs/topics/collections-overview.md
@@ -210,7 +210,7 @@ fun main() {
 [`MutableSet`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-set/index.html) is a `Set` with 
 write operations from `MutableCollection`.
 
-The default implementation of `Set` – [`LinkedHashSet`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-linked-hash-set/index.html) – 
+The default implementation of `MutableSet` – [`LinkedHashSet`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-linked-hash-set/index.html) – 
 preserves the order of elements insertion.
 Hence, the functions that rely on the order, such as `first()` or `last()`, return predictable results on such sets.
 
@@ -283,7 +283,7 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
-The default implementation of `Map` – [`LinkedHashMap`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-linked-hash-map/index.html) – 
+The default implementation of `MutableMap` – [`LinkedHashMap`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-linked-hash-map/index.html) – 
 preserves the order of elements insertion when iterating the map.
 In turn, an alternative implementation – [`HashMap`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-hash-map/index.html) – 
 says nothing about the elements order.


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-51602/Web-feedback-from-Overview-httpskotlinlangorgdocscollections-overviewhtml