### PR TITLE
Add `import io.ktor.server.http.content.*` to `Server.kt`

### DIFF
--- a/docs/topics/multiplatform/multiplatform-full-stack-app.md
+++ b/docs/topics/multiplatform/multiplatform-full-stack-app.md
@@ -148,6 +148,7 @@ engine on a port, in this case, `9090`.
     import io.ktor.server.plugins.cors.routing.*
     import io.ktor.server.request.*
     import io.ktor.server.response.*
+    import io.ktor.server.http.content.*
     import io.ktor.server.routing.*
     
     fun main() {


### PR DESCRIPTION
I ran into compile errors following these steps of the [multiplatform full stack app tutorial](https://kotlinlang.org/docs/multiplatform-full-stack-app.html#serve-html-and-javascript-files-from-ktor):

```
> Task :compileKotlinJvm
e: file:///<path>/jvm-js-fullstack/src/jvmMain/kotlin/Server.kt:34:7 Unresolved reference: static
e: file:///<path>/jvm-js-fullstack/src/jvmMain/kotlin/Server.kt:35:9 Unresolved reference: resources

> Task :compileKotlinJvm FAILED
...
```

I checked the [Kotr docs on static files](https://ktor.io/docs/serving-static-content.html) and noticed they `import io.ktor.server.http.content.*` . 
After adding this the compile errors were gone and the html page loads as expected :)