### PR TITLE
fix: fixed dead link

### DIFF
--- a/docs/topics/null-safety.md
+++ b/docs/topics/null-safety.md
@@ -2,7 +2,7 @@
 
 ## Nullable types and non-null types
 
-Kotlin's type system is aimed at eliminating the danger of null references, also known as [The Billion Dollar Mistake](https://en.wikipedia.org/wiki/Tony_Hoare#Apologies_and_retractions).
+Kotlin's type system is aimed at eliminating the danger of null references, also known as [The Billion Dollar Mistake](https://en.wikipedia.org/wiki/Null_pointer#History).
 
 One of the most common pitfalls in many programming languages, including Java, is that accessing a member of a null
 reference will result in a null reference exception. In Java this would be the equivalent of a `NullPointerException`,


### PR DESCRIPTION
The subheading to Tony Hoare's apologies and retractions was recently removed. (see https://en.wikipedia.org/w/index.php?title=Tony_Hoare&diff=1114844581&oldid=1108470526)