### PR TITLE
KTL-841 Fix kotlinx-datetime version in header

### DIFF
--- a/.teamcity/builds/apiReferences/kotlinx/datetime/KotlinxDatetimeBuildApiReference.kt
+++ b/.teamcity/builds/apiReferences/kotlinx/datetime/KotlinxDatetimeBuildApiReference.kt
@@ -3,6 +3,7 @@ package builds.apiReferences.kotlinx.datetime
 import builds.apiReferences.dependsOnDokkaTemplate
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.triggers.vcs
 
 object KotlinxDatetimeBuildApiReference : BuildType({
@@ -11,6 +12,14 @@ object KotlinxDatetimeBuildApiReference : BuildType({
   artifactRules = "core/build/dokka/html/** => pages.zip"
 
   steps {
+    script {
+      name = "Drop SNAPSHOT word for deploy"
+      scriptContent = """
+                #!/bin/bash
+                sed -i -E "s/versionSuffix=SNAPSHOT//gi" ./gradle.properties
+            """.trimIndent()
+      dockerImage = "debian"
+    }
     gradle {
       name = "Build dokka html"
       tasks = ":kotlinx-datetime:dokkaHtml"


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-841/Publish-documentation-for-kotlinx-datetime

The problem:
There is SNAPSHOT word in the reference [header](https://staging.kotlinlang.org/api/kotlinx-datetime/).
We remove this word for the rest of the references, but that script doesn't fit this reference because of using versionSuffix.

The result:
<img width="478" alt="Screenshot 2022-11-16 at 10 00 52" src="https://user-images.githubusercontent.com/3338311/202135989-9e8fb731-70a5-4947-9357-4fd0dd979ec8.png">
