### PR TITLE
Seems to be an error in the kotlin-first date

### DIFF
--- a/docs/topics/android-overview.md
+++ b/docs/topics/android-overview.md
@@ -1,6 +1,6 @@
 [//]: # (title: Kotlin for Android)
 
-Android mobile development has been Kotlin-first since Google I/O in 2019.
+Android mobile development has been Kotlin-first since Google I/O in 2017.
 
 Using Kotlin for Android development, you can benefit from:
 


### PR DESCRIPTION
It was promoted the first time during the Google I/O in 2017 (cf. [Google Blog: Google I/O 2017](https://android-developers.googleblog.com/2017/05/google-io-2017-empowering-developers-to.html) and [Youtube Android Developers: Introduction to Kotlin(Google I/O '17)](https://www.youtube.com/watch?v=X1RVYt2QKQE)).
Maybe Kotlin-first on the android documentation in 2019 but it was kotlin-first since Google I/O in 2017.