### PR TITLE
update: add about usage of freeCompilerArgs in KGP

### DIFF
--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -255,7 +255,7 @@ Use the task property `compilerExecutionStrategy` in your build scripts:
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 // ...
@@ -269,7 +269,7 @@ tasks.withType<KotlinCompile>().configureEach {
 <tab title="Groovy" group-key="groovy">
 
 ```groovy
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 // ...

--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -73,7 +73,7 @@ It is also possible to configure all of the Kotlin compilation tasks in the proj
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile>().configureEach {
     kotlinOptions { /*...*/ }
 }
 ```
@@ -82,7 +82,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 <tab title="Groovy" group-key="groovy">
 
 ```groovy
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile).configureEach {
     kotlinOptions { /*...*/ }
 }
 ```
@@ -108,7 +108,61 @@ Here is a complete list of options for Gradle tasks:
 | `allWarningsAsErrors` | Report an error if there are any warnings |  | false |
 | `suppressWarnings` | Don't generate warnings |  | false |
 | `verbose` | Enable verbose logging output. Works only when the [Gradle debug log level enabled](https://docs.gradle.org/current/userguide/logging.html) |  | false |
-| `freeCompilerArgs` | A list of additional compiler arguments |  | [] |
+| `freeCompilerArgs` | A list of additional compiler arguments. You can use experimental `-X` arguments here too. See an [example](#example-of-additional-arguments-usage-via-freeCompilerArgs) |  | [] |
+
+> We are going to deprecate the attribute `freeCompilerArgs` in future releases. If you miss some option in the Kotlin Gradle DSL,
+> please, [file an issue](https://youtrack.jetbrains.com/newissue?project=kt).
+>
+> {type="warning"}
+
+#### Example of additional arguments usage via freeCompilerArgs {initial-collapse-state="collapsed"}
+
+Use the attribute `freeCompilerArgs` to supply additional (including experimental) compiler arguments. You can add a single
+argument to this attribute or a list of arguments:
+
+<tabs group="build-script">
+<tab title="Kotlin" group-key="kotlin">
+
+```kotlin
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+// ...
+
+val compileKotlin: KotlinCompile by tasks
+
+// Single experimental argument
+compileKotlin.kotlinOptions.freeCompilerArgs += "-Xexport-kdoc"
+// Single additional argument, can be a key-value pair
+compileKotlin.kotlinOptions.freeCompilerArgs += "-opt-in=org.mylibrary.OptInAnnotation"
+// List of arguments
+compileKotlin.kotlinOptions.freeCompilerArgs += listOf("-Xno-param-assertions", "-Xno-receiver-assertions", "-Xno-call-assertions")
+```
+
+</tab>
+<tab title="Groovy" group-key="groovy">
+
+```groovy
+compileKotlin {
+    // Single experimental argument
+    kotlinOptions.freeCompilerArgs += "-Xexport-kdoc"
+    // Single additional argument, can be a key-value pair
+    kotlinOptions.freeCompilerArgs += "-opt-in=org.mylibrary.OptInAnnotation"
+    // List of arguments
+    kotlinOptions.freeCompilerArgs += ["-Xno-param-assertions", "-Xno-receiver-assertions", "-Xno-call-assertions"]
+}
+
+//or
+
+compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs += "-Xexport-kdoc"
+        kotlinOptions.freeCompilerArgs += "-opt-in=org.mylibrary.OptInAnnotation"
+        freeCompilerArgs += ["-Xno-param-assertions", "-Xno-receiver-assertions", "-Xno-call-assertions"]
+    }
+}
+```
+
+</tab>
+</tabs>
 
 ### Attributes common to JVM and JS
 

--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -113,7 +113,7 @@ Here is a complete list of options for Gradle tasks:
 > We are going to deprecate the attribute `freeCompilerArgs` in future releases. If you miss some option in the Kotlin Gradle DSL,
 > please, [file an issue](https://youtrack.jetbrains.com/newissue?project=kt).
 >
-> {type="warning"}
+{type="warning"}
 
 #### Example of additional arguments usage via freeCompilerArgs {initial-collapse-state="collapsed"}
 

--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -108,7 +108,7 @@ Here is a complete list of options for Gradle tasks:
 | `allWarningsAsErrors` | Report an error if there are any warnings |  | false |
 | `suppressWarnings` | Don't generate warnings |  | false |
 | `verbose` | Enable verbose logging output. Works only when the [Gradle debug log level enabled](https://docs.gradle.org/current/userguide/logging.html) |  | false |
-| `freeCompilerArgs` | A list of additional compiler arguments. You can use experimental `-X` arguments here too. See an [example](#example-of-additional-arguments-usage-via-freeCompilerArgs) |  | [] |
+| `freeCompilerArgs` | A list of additional compiler arguments. You can use experimental `-X` arguments here too. See an [example](#example-of-additional-arguments-usage-via-freecompilerargs) |  | [] |
 
 > We are going to deprecate the attribute `freeCompilerArgs` in future releases. If you miss some option in the Kotlin Gradle DSL,
 > please, [file an issue](https://youtrack.jetbrains.com/newissue?project=kt).

--- a/docs/topics/opt-in-requirements.md
+++ b/docs/topics/opt-in-requirements.md
@@ -142,7 +142,7 @@ If you build your module with Gradle, you can add arguments like this:
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile>().configureEach {
     kotlinOptions.freeCompilerArgs += "-opt-in=org.mylibrary.OptInAnnotation"
 }
 ```
@@ -151,7 +151,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 <tab title="Groovy" group-key="groovy">
 
 ```groovy
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs += "-opt-in=org.mylibrary.OptInAnnotation"
     }

--- a/docs/topics/whatsnew1620.md
+++ b/docs/topics/whatsnew1620.md
@@ -668,7 +668,7 @@ If you are publishing a `klib` and want to use only relative paths of source fil
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).configureEach {
+tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile::class).configureEach {
     // $base is a base path of source files
     kotlinOptions.freeCompilerArgs += "-Xklib-relative-path-base=$base"
 }
@@ -678,7 +678,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class).configure
 <tab title="Groovy" group-key="groovy">
 
 ```groovy
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile).configureEach {
     kotlinOptions {
         // $base is a base path of source files
         freeCompilerArgs += "-Xklib-relative-path-base=$base"
@@ -821,7 +821,7 @@ The available values for the `compilerExecutionStrategy` task property are:
 Use the task property `compilerExecutionStrategy` in the `build.gradle.kts` build script:
 
 ```kotlin
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 // ...


### PR DESCRIPTION
Manual copy of the https://github.com/JetBrains/kotlin-web-site/pull/3187/files because those changes were made before splitting the Gradle page into several.