### PR TITLE
Fix typo on generics.md

### DIFF
--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -85,7 +85,7 @@ In other words, the wildcard with an _extends_\-bound (_upper_ bound) makes the 
 The key to understanding why this works is rather simple: if you can only _take_ items from a collection,
 then using a collection of `String`s and reading `Object`s from it is fine. Conversely, if you can only _put_ items
 into the collection, it's okay to take a collection of `Object`s and put `String`s into it: in Java there is
-`List<? super String>`, a _supertype_ of `List<Object>`.
+`List<? super String>`, a _supertype_ of `List<String>`.
 
 The latter is called _contravariance_, and you can only call methods that take `String` as an argument on `List<? super String>`
 (for example, you can call `add(String)` or `set(int, String)`).  If you call something that returns `T` in `List<T>`,


### PR DESCRIPTION
List<? super String> is not a supertype of List\<Object\>. 
List<? super String> is a supertype of List\<String\> though. 

I'm assuming this is what the author meant. 