### PR TITLE
clarify sealed class inheritance restrictions

### DIFF
--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -2,7 +2,7 @@
 
 _Sealed_ classes and interfaces represent restricted class hierarchies that provide more control over inheritance.
 All direct subclasses of a sealed class are known at compile time. No other subclasses may appear outside
-a module within which the sealed class is defined. For example, third-party clients can't extend your sealed class in their code.
+the module or package within which the sealed class is defined. For example, third-party clients can't extend your sealed class in their code.
 Thus, each instance of a sealed class has a type from a limited set that is known when this class is compiled.
 
 The same works for sealed interfaces and their implementations: once a module with a sealed interface is compiled,


### PR DESCRIPTION
Indicate the base package restriction around sealed class in the first paragraph.

Sealed classes can only be inherited from within the same package and module in which the sealed class is defined. This implies:

1. that classes within the same compilation unit (module) but not within the base package cannot inherit from them
2. that classes in the same base package but not in the same compilation unit can also not inherit from them.

Previously, this paragraph only indicated the second restriction (2.), that the class needs to be within the same module. This change tries to also capture (1.) in this first paragraph. The same restrictions are explained in greater detail in a later section.