### PR TITLE
Fixed how name of publications is computed

### DIFF
--- a/docs/topics/multiplatform/multiplatform-publish-lib.md
+++ b/docs/topics/multiplatform/multiplatform-publish-lib.md
@@ -71,7 +71,7 @@ kotlin {
     mingwX64()
     linuxX64()
     val publicationsFromMainHost = 
-        listOf(jvm(), js()).map { it.name } + "kotlinMultiplatform"
+        listOf(jvm(), js()).map { "${it.name}kotlinMultiplatform" }
     publishing {
         publications {
             matching { it.name in publicationsFromMainHost }.all {


### PR DESCRIPTION
I believe this was a small mistake in the docs as I couldn't publish anything with the sample shown... after this change, it works fine.