### PR TITLE
Update kspVersion to 1.0.8

### DIFF
--- a/docs/v.list
+++ b/docs/v.list
@@ -40,7 +40,7 @@
 
     <var name="kspSupportedKotlinVersion" value="1.8.0" type="string"/>
 
-    <var name="kspVersion" value="1.0.7" type="string"/>
+    <var name="kspVersion" value="1.0.8" type="string"/>
 
     <var name="ktorVersion" value="2.2.1" type="string"/>
 


### PR DESCRIPTION
There is no KSP version 1.0.7, only 1.0.8, for Kotlin 1.8.0 https://github.com/google/ksp/releases