### PR TITLE
fix: small "after review" fixes

### DIFF
--- a/docs/topics/gradle/get-started-with-jvm-gradle-project.md
+++ b/docs/topics/gradle/get-started-with-jvm-gradle-project.md
@@ -61,7 +61,7 @@ tasks.test { // See 5️⃣
     useJUnitPlatform() // JUnitPlatform for tests. See 6️⃣
 }
 
-kotlin { // Extension to make an easy setup
+kotlin { // Extension for easy setup
    jvmToolchain(8) // Target version of generated JVM bytecode. See 7️⃣
 }
 

--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -296,8 +296,8 @@ Using fallback strategy: Compile without Kotlin daemon
 Try ./gradlew --stop if this issue persists.
 ```
 
-However, a silent fallback to another strategy can consume a lot of system resources or lead to non-deterministic builds, 
-read more about this in this [YouTrack issue](https://youtrack.jetbrains.com/issue/KT-48843/Add-ability-to-disable-Kotlin-daemon-fallback-strategy).
+However, a silent fallback to another strategy can consume a lot of system resources or lead to non-deterministic builds. 
+Read more about this in this [YouTrack issue](https://youtrack.jetbrains.com/issue/KT-48843/Add-ability-to-disable-Kotlin-daemon-fallback-strategy).
 To avoid this, there is a Gradle property `kotlin.daemon.useFallbackStrategy`, whose default value is `true`. 
 When the value is `false`, builds fail on problems with the daemon's startup or communication. Declare this property in
 `gradle.properties`:

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -138,9 +138,9 @@ the `compileJava` task has (or [inherits](https://docs.gradle.org/current/usergu
 Configure the behavior of this check by setting the `kotlin.jvm.target.validation.mode` property in the `build.gradle`
 file to:
 
-* `error` – the plugin will fail the build; the default value for projects on Gradle 8.0+.
-* `warning` – the Kotlin Gradle plugin will print a warning message; the default value for projects on Gradle less than 8.0.
-* `ignore` – the plugin will skip the check and won't produce any messages.
+* `error` – the plugin fails the build; the default value for projects on Gradle 8.0+.
+* `warning` – the plugin prints a warning message; the default value for projects on Gradle less than 8.0.
+* `ignore` – the plugin skips the check and doesn't produce any messages.
 
 To avoid JVM target incompatibility, [configure a toolchain](#gradle-java-toolchains-support) or align JVM versions manually.
 
@@ -601,7 +601,7 @@ kotlin.stdlib.default.dependency=false
 If you explicitly write the Kotlin version 1.8.0 or higher in your dependencies, for example: 
 `implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.0")`, then the Kotlin Gradle Plugin uses this Kotlin version 
 for transitive `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` dependencies. This is for avoiding class duplication from 
-different stdlib versions.[Learn more about [merging `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` into `kotlin-stdlib`](whatsnew18.md#updated-jvm-compilation-target). 
+different stdlib versions. [Learn more about [merging `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` into `kotlin-stdlib`](whatsnew18.md#updated-jvm-compilation-target). 
 You can disable this behavior with the `kotlin.stdlib.jdk.variants.version.alignment` Gradle property:
 
 ```none

--- a/docs/topics/gradle/gradle-plugin-variants.md
+++ b/docs/topics/gradle/gradle-plugin-variants.md
@@ -21,7 +21,7 @@ Currently, there are the following variants of the Kotlin Gradle plugin:
 | `gradle75`     | 7.5                           |
 | `gradle76`     | 7.6 and higher                |
 
-In future Kotlin releases, more variants will be probably added.
+In future Kotlin releases, more variants will probably be added.
 
 To check which variant your build uses, enable
 the [`--info` log level](https://docs.gradle.org/current/userguide/logging.html#sec:choosing_a_log_level) and find a
@@ -61,7 +61,7 @@ configurations.register("customConfiguraton") {
 </tab>
 </tabs>
 
-and want to add a dependency on the Kotlin Gradle plugin, for example:
+And want to add a dependency on the Kotlin Gradle plugin, for example:
 
 <tabs group="build-script">
 <tab title="Kotlin" group-key="kotlin">


### PR DESCRIPTION
Applying [minor suggestions](https://github.com/JetBrains/kotlin-web-site/pull/3333#pullrequestreview-1237071227) from the [Gradle changes 1.8.0 PR](https://github.com/JetBrains/kotlin-web-site/pull/3333) because that PR was reviewed after Kotlin 1.8.0 release.
