### PR TITLE
fix: fix small typo from "need" to "want"

### DIFF
--- a/docs/topics/properties.md
+++ b/docs/topics/properties.md
@@ -88,7 +88,7 @@ var stringRepresentation: String
 
 By convention, the name of the setter parameter is `value`, but you can choose a different name if you prefer.
 
-If you need to annotate an accessor or change its visibility, but you don't need to change the default implementation,
+If you need to annotate an accessor or change its visibility, but you don't want to change the default implementation,
 you can define the accessor without defining its body:
 
 ```kotlin


### PR DESCRIPTION
fix small typo on [Properties Page](https://kotlinlang.org/docs/properties.html#backing-fields) that lead to misunderstanding