### PR TITLE
Remove `binaries.executable` from within `browser` block

### DIFF
--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -457,7 +457,6 @@ browser {
             enabled.set(true)
         }
     }
-    binaries.executable()
 }
 ```
 
@@ -471,7 +470,6 @@ browser {
             it.enabled.set(true)
         }
     }
-    binaries.executable()
 }
 ```
 


### PR DESCRIPTION
`binaries.executable` is a configuration on the `KotlinJsTargetDsl`, not on the `KotlinJsBrowserDsl`. That means it should generally be placed in the parent scope, like in the other examples:

```
js(IR) {
    browser {
        // . . .
    }
    binaries.executable()
}
```

...and not, like in these examples, inside the browser-block specifically:
```
js(IR) {
    browser {
        binaries.executable()
    }
}
```
