### PR TITLE
KTL-965 Fix broken links in the meta tags

### DIFF
--- a/docs/project.ihp
+++ b/docs/project.ihp
@@ -8,7 +8,7 @@
     <snippets src="snippets"/>
     <images dir="images" web-path="images/"/>
     <vars src="v.list"/>
-    <product id="help/kotlin-reference" src="kr.tree" web-path="/kotlin-reference/"/>
+    <product id="help/kotlin-reference" src="kr.tree" web-path="/" />
     <settings>
         <default-property element-name="toc-element" property-name="show-structure-depth" value="2"/>
     </settings>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-965/Fix-broken-links-in-the-meta-tags

[The demo branch](https://branch-ktl-965-fix-meta-tags.kotlin-web-site.labs.jb.gg/docs/dokka-introduction.html).
So, changing the prop fixes the issue with canonical and og:url meta tags.
