### PR TITLE
fix: else is not needed in sealed when independently of is it expression or statement

### DIFF
--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -81,8 +81,7 @@ you can create subclasses in any source set between the `expect` and `actual` de
 
 The key benefit of using sealed classes comes into play when you use them in a [`when`](control-flow.md#when-expression)
 expression. 
-If it's possible to verify that the statement covers all cases, you don't need to add an `else` clause to the statement. 
-However, this works only if you use `when` as an expression (using the result) and not as a statement:
+If it's possible to verify that the statement covers all cases, you don't need to add an `else` clause to the statement:
 
 ```kotlin
 fun log(e: Error) = when(e) {


### PR DESCRIPTION
Following a [good catch in Slack](https://kotlinlang.slack.com/archives/C02B3PECK6E/p1673514938662269).

Checked at [play.kotlin](https://play.kotlinlang.org/#eyJ2ZXJzaW9uIjoiMS44LjAiLCJwbGF0Zm9ybSI6ImphdmEiLCJhcmdzIjoiIiwibm9uZU1hcmtlcnMiOnRydWUsInRoZW1lIjoiaWRlYSIsImNvZGUiOiIvKipcbiAqIFlvdSBjYW4gZWRpdCwgcnVuLCBhbmQgc2hhcmUgdGhpcyBjb2RlLlxuICogcGxheS5rb3RsaW5sYW5nLm9yZ1xuICovXG5mdW4gbWFpbihhcmdzOiBBcnJheTxTdHJpbmc+KSB7XG4gICAgdmFyIGVycm9yOiBFcnJvclxuICAgIGVycm9yID0gRmlsZVJlYWRFcnJvcigpXG4gICAgbG9nKGVycm9yKVxuICAgIGxvZzIoZXJyb3IpXG59XG5cbnNlYWxlZCBpbnRlcmZhY2UgRXJyb3Jcblxuc2VhbGVkIGNsYXNzIElPRXJyb3IoKSA6IEVycm9yXG5cbmNsYXNzIEZpbGVSZWFkRXJyb3IoKSA6IElPRXJyb3IoKVxuY2xhc3MgRGF0YWJhc2VFcnJvcigpIDogSU9FcnJvcigpXG5vYmplY3QgUnVudGltZUVycm9yIDogRXJyb3JcblxuZnVuIGxvZyhlOiBFcnJvcikge1xuICAgIHdoZW4gKGUpIHtcbiAgICAgICAgaXMgRmlsZVJlYWRFcnJvciAtPiB7XG4gICAgICAgICAgICBwcmludGxuKFwiRXJyb3Igd2hpbGUgcmVhZGluZyBmaWxlXCIpXG4gICAgICAgIH1cblxuICAgICAgICBpcyBEYXRhYmFzZUVycm9yIC0+IHtcbiAgICAgICAgICAgIHByaW50bG4oXCJFcnJvciB3aGlsZSByZWFkaW5nIGZyb20gZGF0YWJhc2VcIilcbiAgICAgICAgfVxuXG4gICAgICAgIGlzIFJ1bnRpbWVFcnJvciAtPiB7XG4gICAgICAgICAgICBwcmludGxuKFwiUnVudGltZSBlcnJvclwiKVxuICAgICAgICB9XG4gICAgICAgIC8vIHRoZSBgZWxzZWAgY2xhdXNlIGlzIG5vdCByZXF1aXJlZCBiZWNhdXNlIGFsbCB0aGUgY2FzZXMgYXJlIGNvdmVyZWRcbiAgICB9XG59XG5cbmZ1biBsb2cyKGU6IEVycm9yKSA9IHdoZW4gKGUpIHtcbiAgICBpcyBGaWxlUmVhZEVycm9yIC0+IHtcbiAgICAgICAgcHJpbnRsbihcIkVycm9yIHdoaWxlIHJlYWRpbmcgZmlsZVwiKVxuICAgIH1cblxuICAgIGlzIERhdGFiYXNlRXJyb3IgLT4ge1xuICAgICAgICBwcmludGxuKFwiRXJyb3Igd2hpbGUgcmVhZGluZyBmcm9tIGRhdGFiYXNlXCIpXG4gICAgfVxuXG4gICAgaXMgUnVudGltZUVycm9yIC0+IHtcbiAgICAgICAgcHJpbnRsbihcIlJ1bnRpbWUgZXJyb3JcIilcbiAgICB9XG4gICAgLy8gdGhlIGBlbHNlYCBjbGF1c2UgaXMgbm90IHJlcXVpcmVkIGJlY2F1c2UgYWxsIHRoZSBjYXNlcyBhcmUgY292ZXJlZFxufSJ9)