### PR TITLE
mapping-strings-from-c.md - fix string typo

### DIFF
--- a/docs/topics/native/mapping-strings-from-c.md
+++ b/docs/topics/native/mapping-strings-from-c.md
@@ -55,7 +55,7 @@ void pass_string(char* str) {
 }
 
 char* return_string() {
-  return "C stirng";
+  return "C string";
 }
 
 int copy_string(char* str, int size) {


### PR DESCRIPTION
stirng → string