### PR TITLE
Update ksp-quickstart.md

### DIFF
--- a/docs/topics/ksp/ksp-quickstart.md
+++ b/docs/topics/ksp/ksp-quickstart.md
@@ -227,6 +227,12 @@ ksp {
 
 ## Make IDE aware of generated code
 
+> Generated source files are registered automatically since KSP 1.8.0-1.0.9.
+> If you're using KSP 1.0.9 or newer and don't need to make the IDE aware of generated resources,
+> feel free to skip this section.
+>
+{type="note"}
+
 By default, IntelliJ IDEA or other IDEs don't know about the generated code. So it will mark references to generated
 symbols unresolvable. To make an IDE be able to reason about the generated symbols, mark the
 following paths as generated source roots:


### PR DESCRIPTION
Update the section of *Make IDE aware of generated code* with a note that everything should work out of the box and registering generated source manually is no longer required since KSP 1.8.0-1.0.9.