### PR TITLE
Configure a Gradle project﻿: format gradle.properties snippets

### DIFF
--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -596,7 +596,7 @@ plugin won't override it or add a second standard library.
 
 If you do not need a standard library at all, you can add the opt-out option to the `gradle.properties`:
 
-```none
+```properties
 kotlin.stdlib.default.dependency=false
 ```
 
@@ -608,8 +608,8 @@ for transitive `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` dependencies. This 
 different stdlib versions. [Learn more about [merging `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` into `kotlin-stdlib`](whatsnew18.md#updated-jvm-compilation-target). 
 You can disable this behavior with the `kotlin.stdlib.jdk.variants.version.alignment` Gradle property:
 
-```none
- `kotlin.stdlib.jdk.variants.version.alignment=false`
+```properties
+kotlin.stdlib.jdk.variants.version.alignment=false
 ```
 
 ##### Other ways to align versions {initial-collapse-state="collapsed"}


### PR DESCRIPTION
* Add `properties` language tag
* remove unnecessary backticks from snippet content

Screenshot:

<img width="632" alt="image" src="https://user-images.githubusercontent.com/897017/215918237-c2cf4f11-c2a7-49e8-a25a-521a60930479.png">


View rendered Markdown: 

* https://github.com/aSemy/kotlin-web-site/blob/a1fef6cc78af6def80114f15f04633b7ca859460/docs/topics/gradle/gradle-configure-project.md#dependency-on-the-standard-library
* https://github.com/aSemy/kotlin-web-site/blob/a1fef6cc78af6def80114f15f04633b7ca859460/docs/topics/gradle/gradle-configure-project.md#versions-alignment-of-transitive-dependencies