### PR TITLE
Move Unsigned integer types under Numbers in Basic types section

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -58,11 +58,11 @@
             <toc-element toc-title="Basic types">
                 <toc-element id="basic-types.md" toc-title="Overview"/>
                 <toc-element id="numbers.md"/>
+                <toc-element id="unsigned-integer-types.md"/>
                 <toc-element id="booleans.md"/>
                 <toc-element id="characters.md"/>
                 <toc-element id="strings.md"/>
                 <toc-element id="arrays.md"/>
-                <toc-element id="unsigned-integer-types.md"/>
             </toc-element>
             <toc-element id="typecasts.md"/>
         </toc-element>

--- a/docs/topics/numbers.md
+++ b/docs/topics/numbers.md
@@ -24,6 +24,10 @@ val oneLong = 1L // Long
 val oneByte: Byte = 1
 ```
 
+> In addition to integer types, Kotlin also provides unsigned integer types. For more information, see [Unsigned integer types](unsigned-integer-types.md).
+>
+{type="tip"}
+
 ## Floating-point types
 
 For real numbers, Kotlin provides floating-point types `Float` and `Double` that adhere to the [IEEE 754 standard](https://en.wikipedia.org/wiki/IEEE_754).


### PR DESCRIPTION
Move Unsigned integer types under Numbers in Basic types section, as the topics are closely related.