### PR TITLE
Update attributes common to JVM and JS in Gradle and Maven compiler options

### DIFF
--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -186,10 +186,10 @@ tasks.named('compileKotlin', KotlinCompilationTask) {
 
 ### Attributes common to JVM and JS
 
-| Name | Description | Possible values |Default value |
-|------|-------------|-----------------|--------------|
-| `apiVersion` | Restrict the use of declarations to those from the specified version of bundled libraries | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" |  |
-| `languageVersion` | Provide source compatibility with the specified version of Kotlin | "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" |  |
+| Name | Description | Possible values                                                                          |Default value |
+|------|-------------|------------------------------------------------------------------------------------------|--------------|
+| `apiVersion` | Restrict the use of declarations to those from the specified version of bundled libraries | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) |  |
+| `languageVersion` | Provide source compatibility with the specified version of Kotlin | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) |  |
 
 Also, see [Types for compiler options](#types-for-compiler-options).
 

--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -186,8 +186,8 @@ tasks.named('compileKotlin', KotlinCompilationTask) {
 
 ### Attributes common to JVM and JS
 
-| Name | Description | Possible values                                                                          |Default value |
-|------|-------------|------------------------------------------------------------------------------------------|--------------|
+| Name | Description | Possible values |Default value |
+|------|-------------|-----------------|--------------|
 | `apiVersion` | Restrict the use of declarations to those from the specified version of bundled libraries | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) |  |
 | `languageVersion` | Provide source compatibility with the specified version of Kotlin | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) |  |
 

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -267,10 +267,10 @@ The following attributes are supported:
 | `nowarn` | | Generate no warnings | true, false                                                                              | false |
 | `languageVersion` | kotlin.compiler.languageVersion | Provide source compatibility with the specified version of Kotlin | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) | 
 | `apiVersion` | kotlin.compiler.apiVersion | Allow using declarations only from the specified version of bundled libraries | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) | 
-| `sourceDirs` | | The directories containing the source files to compile |                                                                                          | The project source roots
-| `compilerPlugins` | | Enabled compiler plugins  |                                                                                          | []
-| `pluginOptions` | | Options for compiler plugins  |                                                                                          | []
-| `args` | | Additional compiler arguments |                                                                                          | []
+| `sourceDirs` | | The directories containing the source files to compile | | The project source roots
+| `compilerPlugins` | | Enabled compiler plugins  | | []
+| `pluginOptions` | | Options for compiler plugins  | | []
+| `args` | | Additional compiler arguments | | []
 
 ### Attributes specific to JVM
 

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -262,9 +262,9 @@ The following attributes are supported:
 
 ### Attributes common to JVM and JS
 
-| Name | Property name | Description | Possible values                                                                          |Default value |
-|------|---------------|-------------|------------------------------------------------------------------------------------------|--------------|
-| `nowarn` | | Generate no warnings | true, false                                                                              | false |
+| Name | Property name | Description | Possible values | Default value |
+|------|---------------|-------------|-----------------|---------------|
+| `nowarn` | | Generate no warnings | true, false | false |
 | `languageVersion` | kotlin.compiler.languageVersion | Provide source compatibility with the specified version of Kotlin | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) | 
 | `apiVersion` | kotlin.compiler.apiVersion | Allow using declarations only from the specified version of bundled libraries | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) | 
 | `sourceDirs` | | The directories containing the source files to compile | | The project source roots

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -262,15 +262,15 @@ The following attributes are supported:
 
 ### Attributes common to JVM and JS
 
-| Name | Property name | Description | Possible values |Default value |
-|------|---------------|-------------|-----------------|--------------|
-| `nowarn` | | Generate no warnings | true, false | false |
-| `languageVersion` | kotlin.compiler.languageVersion | Provide source compatibility with the specified version of Kotlin | "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" | 
-| `apiVersion` | kotlin.compiler.apiVersion | Allow using declarations only from the specified version of bundled libraries | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" | 
-| `sourceDirs` | | The directories containing the source files to compile | | The project source roots
-| `compilerPlugins` | | Enabled compiler plugins  | | []
-| `pluginOptions` | | Options for compiler plugins  | | []
-| `args` | | Additional compiler arguments | | []
+| Name | Property name | Description | Possible values                                                                          |Default value |
+|------|---------------|-------------|------------------------------------------------------------------------------------------|--------------|
+| `nowarn` | | Generate no warnings | true, false                                                                              | false |
+| `languageVersion` | kotlin.compiler.languageVersion | Provide source compatibility with the specified version of Kotlin | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) | 
+| `apiVersion` | kotlin.compiler.apiVersion | Allow using declarations only from the specified version of bundled libraries | "1.3" (DEPRECATED), "1.4" (DEPRECATED), "1.5", "1.6", "1.7", "1.8", "1.9" (EXPERIMENTAL) | 
+| `sourceDirs` | | The directories containing the source files to compile |                                                                                          | The project source roots
+| `compilerPlugins` | | Enabled compiler plugins  |                                                                                          | []
+| `pluginOptions` | | Options for compiler plugins  |                                                                                          | []
+| `args` | | Additional compiler arguments |                                                                                          | []
 
 ### Attributes specific to JVM
 


### PR DESCRIPTION
This PR updates the tables of attributes common to JVM and JS in Gradle and Maven pages. Specifically it marks 1.3 as a language version that is supported but deprecated. In addition, API and language versions 1.9 are marked as experimental.