### PR TITLE
Remove junit from test sample

### DIFF
--- a/templates/inc/pages/index/code-examples.html
+++ b/templates/inc/pages/index/code-examples.html
@@ -129,8 +129,6 @@ val messages = listOf(                                        // Create a list
             <div class="kotlin-overview-code-example is_hidden" id="kotlin-code-example-tests">
                 <pre theme="darcula" class="sample" data-mobile-shorter-height="400" auto-indent="false" data-min-compiler-version="1.5"  data-target-platform="junit">
 // Tests
-// The following example works for JVM only
-import org.junit.Test
 import kotlin.test.*
 
 class SampleTest {


### PR DESCRIPTION
kotlin.test is MPP and supports all targets

Needs https://github.com/AlexanderPrendota/kotlin-compiler-server/pull/611