### PR TITLE
fix: gradle languageVersion fix for .kts

### DIFF
--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -309,7 +309,7 @@ If you want Gradle to search for the major JDK version, replace the `<MAJOR_JDK_
 ```kotlin
 val service = project.extensions.getByType<JavaToolchainService>()
 val customLauncher = service.launcherFor {
-    it.languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>))
+    languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>))
 }
 project.tasks.withType<UsesKotlinJavaToolchain>().configureEach {
     kotlinJavaToolchain.toolchain.use(customLauncher)


### PR DESCRIPTION
I tried to follow the current documentation and noticed that it didn't compile when using the provided example code in my .kts Gradle project. As far as I can tell, the `it` was simply copy-pasted from groovy and doesn't belong there, which is why I removed it.