### PR TITLE
Update multiplatform-library.md

### DIFF
--- a/docs/topics/multiplatform/multiplatform-library.md
+++ b/docs/topics/multiplatform/multiplatform-library.md
@@ -388,7 +388,7 @@ with `src/build.gradle.kts` in it.
    
    ```kotlin
    plugins {
-       "kotlin-dsl" // Is needed to turn our build logic written in Kotlin into the Gradle Plugin
+       `kotlin-dsl` // Is needed to turn our build logic written in Kotlin into the Gradle Plugin
    }
    
    repositories {


### PR DESCRIPTION
Fix that Plugin [id: 'convention.publication ' ] was not found due to incorrect quotes.