### PR TITLE
Remove old source maps link on Debug Kotlin/JS code page

### DIFF
--- a/docs/topics/js/js-debugging.md
+++ b/docs/topics/js/js-debugging.md
@@ -1,8 +1,7 @@
 [//]: # (title: Debug Kotlin/JS code)
 
-JavaScript [source maps](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/) provide mappings between
-the minified code produced by bundlers or minifiers and the actual source code a developer works with. This way, the source
-maps enable support for debugging the code during its execution.
+JavaScript source maps provide mappings between the minified code produced by bundlers or minifiers and the actual source
+code a developer works with. This way, the source maps enable support for debugging the code during its execution.
 
 The Kotlin/JS Gradle plugin automatically generates source maps for the project builds, making them available without any additional configuration.
 


### PR DESCRIPTION
We have an old link on the Debug Kotlin/JS code page pointing to content that doesn't exist anymore. So I'm removing the link entirely.