### PR TITLE
bugfix : errors in the ksp documentation

### DIFF
--- a/docs/topics/ksp/ksp-overview.md
+++ b/docs/topics/ksp/ksp-overview.md
@@ -114,16 +114,16 @@ the following:
 ```kotlin
 class HelloFunctionFinderProcessor : SymbolProcessor() {
     // ...
-    val functions = mutableListOf<String>()
+    val functions = mutableListOf<KSClassDeclaration>()
     val visitor = FindFunctionsVisitor()
 
     override fun process(resolver: Resolver) {
-        resolver.getAllFiles().map { it.accept(visitor, Unit) }
+        resolver.getAllFiles().forEach { it.accept(visitor, Unit) }
     }
 
     inner class FindFunctionsVisitor : KSVisitorVoid() {
         override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
-            classDeclaration.getDeclaredFunctions().map { it.accept(this, Unit) }
+            classDeclaration.getDeclaredFunctions().forEach { it.accept(this, Unit) }
         }
 
         override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
@@ -131,7 +131,7 @@ class HelloFunctionFinderProcessor : SymbolProcessor() {
         }
 
         override fun visitFile(file: KSFile, data: Unit) {
-            file.declarations.map { it.accept(this, Unit) }
+            file.declarations.forEach { it.accept(this, Unit) }
         }
     }
     // ...


### PR DESCRIPTION
This is a small PR to correct old code in the KSP documentation. The existing code sample did not work, both for compile-time reasons (the `functions` collection was of type `String`) and runtime reasons (the `map` command is optimised out by the compiler, so is never executed, replacing it with `forEach` resolves this). The corrected code makes it clearer for new engineers to understand KSP