### PR TITLE
Rebrand EduTools plugin

### DIFF
--- a/data/_nav.yml
+++ b/data/_nav.yml
@@ -496,9 +496,9 @@ tutorials:
     - title: Education
       content:
         - url: /docs/tutorials/edu-tools-learner.html
-          title: Learning Kotlin with EduTools plugin
+          title: Learning Kotlin with JetBrains Academy plugin
         - url: /docs/tutorials/edu-tools-educator.html
-          title: Teaching Kotlin with EduTools plugin
+          title: Teaching Kotlin with JetBrains Academy plugin
 
 foundation:
   content:

--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -371,7 +371,7 @@
         <toc-element id="kotlin-tips.md"/>
         <toc-element id="books.md"/>
         <toc-element id="advent-of-code.md" toc-title="Advent of Code puzzles"/>
-        <toc-element toc-title="Learn in IDE (EduTools)">
+        <toc-element toc-title="Learn in IDE (JetBrains Academy)">
             <toc-element id="edu-tools-learner.md" toc-title="Learn Kotlin"/>
             <toc-element id="edu-tools-educator.md" toc-title="Teach Kotlin"/>
         </toc-element>

--- a/docs/topics/edu-tools-educator.md
+++ b/docs/topics/edu-tools-educator.md
@@ -1,8 +1,8 @@
-[//]: # (title: Teaching Kotlin with EduTools plugin)
+[//]: # (title: Teaching Kotlin with JetBrains Academy plugin)
 
-With the [EduTools plugin](https://plugins.jetbrains.com/plugin/10081-edutools), available both in 
+With the [JetBrains Academy plugin](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy), available both in 
 [Android Studio](https://developer.android.com/studio) and [IntelliJ IDEA](https://www.jetbrains.com/idea/), you can teach Kotlin through code practicing tasks.
-Take a look at the [Educator Start Guide](https://plugins.jetbrains.com/plugin/10081-edutools/docs/educator-start-guide.html?section=Kotlin)
+Take a look at the [Educator Start Guide](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/educator-start-guide.html?section=Kotlin)
 to learn how to create a simple Kotlin course that includes a set of programming tasks and integrated tests.
 
-If you want to use the EduTools plugin to learn Kotlin, read [Learning Kotlin with EduTools plugin](edu-tools-learner.md).
+If you want to use the JetBrains Academy plugin to learn Kotlin, read [Learning Kotlin with JetBrains Academy plugin](edu-tools-learner.md).

--- a/docs/topics/edu-tools-learner.md
+++ b/docs/topics/edu-tools-learner.md
@@ -1,11 +1,11 @@
-[//]: # (title: Learning Kotlin with EduTools plugin)
+[//]: # (title: Learning Kotlin with JetBrains Academy plugin)
 
-With the [EduTools plugin](https://plugins.jetbrains.com/plugin/10081-edutools), available both in 
+With the [JetBrains Academy plugin](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy), available both in 
 [Android Studio](https://developer.android.com/studio) and [IntelliJ IDEA](https://www.jetbrains.com/idea/), you can learn Kotlin through code practicing tasks.
 
-Take a look at the [Learner Start Guide](https://plugins.jetbrains.com/plugin/10081-edutools/docs/learner-start-guide.html?section=Kotlin%20Koans),
+Take a look at the [Learner Start Guide](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/learner-start-guide.html?section=Kotlin%20Koans),
 which will get you started with the Kotlin Koans course inside IntelliJ IDEA.
 Solve interactive coding challenges and get instant feedback right inside the IDE. 
 
-If you want to use the EduTools plugin for teaching, read [Teaching Kotlin with EduTools plugin](edu-tools-educator.md).
+If you want to use the JetBrains Academy plugin for teaching, read [Teaching Kotlin with JetBrains Academy plugin](edu-tools-educator.md).
 

--- a/docs/topics/home.xml
+++ b/docs/topics/home.xml
@@ -51,7 +51,9 @@
                     <a href="https://hyperskill.org/join/fromdocstoJetSalesStat?redirect=true&amp;next=/tracks/18" description="Kotlin Basics track on JetBrains Academy">JetBrains Academy</a>
                     <a href="advent-of-code.md" description="Code puzzles in idiomatic Kotlin">Advent of Code</a>
                     <a href="https://play.kotlinlang.org/hands-on/overview" description="Complete long-form tutorials to fully grasp a technology">Hands-on tutorials</a>
-                    <a href="edu-tools-learner.md" description="An IDE plugin for learning and teaching programming languages">EduTools in IntelliJ IDEA</a>
+                    <a href="edu-tools-learner.md"
+                       description="An IDE plugin for learning and teaching programming languages">JetBrains Academy in
+                        IntelliJ IDEA</a>
                     <a href="books.md" description="The books that we've reviewed and recommend for learning Kotlin">Books</a>
                 </link-collection>
                 <link-collection>

--- a/docs/topics/jvm/jvm-get-started.md
+++ b/docs/topics/jvm/jvm-get-started.md
@@ -94,5 +94,5 @@ Congratulations! You have just run your first Kotlin application.
 Once you've created this application, you can start to dive deeper into Kotlin syntax:
 
 * Add sample code from [Kotlin examples](https://play.kotlinlang.org/byExample/overview) 
-* Install the [EduTools plugin](https://plugins.jetbrains.com/plugin/10081-edutools) for IDEA and complete exercises 
-from the [Kotlin Koans course](https://plugins.jetbrains.com/plugin/10081-edutools/docs/learner-start-guide.html?section=Kotlin%20Koans)
+* Install the [JetBrains Academy plugin](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy) for IDEA and complete 
+  exercises from the [Kotlin Koans course](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/learner-start-guide.html?section=Kotlin%20Koans)

--- a/docs/topics/koans.md
+++ b/docs/topics/koans.md
@@ -5,12 +5,13 @@ Each exercise is created as a failing unit test, and your job is to make it pass
 You can complete the Kotlin Koans tasks in one of the following ways:
 
 * You can play with [Koans online](https://play.kotlinlang.org/koans).
-* You can perform the tasks right inside IntelliJ IDEA or Android Studio by [installing the EduTools plugin](https://plugins.jetbrains.com/plugin/10081-edutools/docs/install-edutools-plugin.html)
-  and [choosing the Kotlin Koans course](https://plugins.jetbrains.com/plugin/10081-edutools/docs/learner-start-guide.html?section=Kotlin%20Koans).
+* You can perform the tasks right inside IntelliJ IDEA or Android Studio by [installing the JetBrains Academy plugin](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/install-jetbrains-academy-plugin.html)
+  and [choosing the Kotlin Koans course](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/learner-start-guide.html?section=Kotlin%20Koans).
 
 Whatever way you choose to solve koans, you can see the solution for each task:
 * In the online version, click **Show answer**.
-* For the EduTools plugin, try to complete the task first and then choose **Peek solution** if your answer is incorrect.
+* For the JetBrains Academy plugin, try to complete the task first and then choose **Peek solution** if your answer is 
+  incorrect.
 
 We recommend you check the solution after implementing the task to compare your answer with the proposed one.
 Make sure you don't cheat!

--- a/static/js/ktl-component/teach/index.jsx
+++ b/static/js/ktl-component/teach/index.jsx
@@ -279,9 +279,9 @@ const Teach = (props) => {
                 </li>
                 <li className="teach-list__item">
                   <a
-                    href="https://plugins.jetbrains.com/plugin/10081-edutools" target="_blank" rel="noopener">
+                    href="https://plugins.jetbrains.com/plugin/10081-jetbrains-academy" target="_blank" rel="noopener">
                       <span className="rs-link">
-                        EduTools plugin
+                        JetBrains Academy plugin
                       </span>
                     <span>↗</span>
                   </a>

--- a/static/js/ktl-component/why-teach/index.jsx
+++ b/static/js/ktl-component/why-teach/index.jsx
@@ -379,7 +379,7 @@ export const WhyTeach = ({path}) => {
                   </p>
 
                   <p className="ktl-text-1 ktl-offset-bottom-s">
-                    The educational EduTools plugin is also available to help learn and teach Kotlin programming.
+                    The educational JetBrains Academy plugin is also available to help learn and teach Kotlin programming.
                     Educators
                     can use existing interactive courses or create custom ones, with hands-on assignments and practice
                     coding tasks. Integrated tests will automatically check the assignments and provide feedback.
@@ -409,9 +409,9 @@ export const WhyTeach = ({path}) => {
                       </a>
                     </li>
                     <li className="ktl-offset-bottom-s">
-                      <a href="https://plugins.jetbrains.com/plugin/10081-edutools" target="_blank"
+                      <a href="https://plugins.jetbrains.com/plugin/10081-jetbrains-academy" target="_blank"
                          className="ktl-text-2 ktl-link">
-                        <span className="rs-link">EduTools plugin</span>
+                        <span className="rs-link">JetBrains Academy plugin</span>
                         <span>&nbsp;↗</span>
                       </a>
                     </li>


### PR DESCRIPTION
The EduTools plugin has been rebranded to JetBrains Academy plugin. Some of the links to the plugin documentation are now dead because of this rebrand so this PR will fix that.

[KT-57021](https://youtrack.jetbrains.com/issue/KT-57021/Broken-links-in-Kotlin-Koans)