### PR TITLE
Update multiplatform-mobile-upgrade-app.md

### DIFF
--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-upgrade-app.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-upgrade-app.md
@@ -237,7 +237,6 @@ straightforward:
 
    ```kotlin
    import androidx.compose.runtime.*
-   import kotlinx.coroutines.launch
    
    class MainActivity : ComponentActivity() {
        override fun onCreate(savedInstanceState: Bundle?) {
@@ -248,15 +247,12 @@ straightforward:
                        modifier = Modifier.fillMaxSize(),
                        color = MaterialTheme.colors.background
                    ) {
-                       val scope = rememberCoroutineScope()
                        var text by remember { mutableStateOf("Loading") }
                        LaunchedEffect(true) {
-                           scope.launch {
-                               text = try {
-                                   Greeting().greeting()
-                               } catch (e: Exception) {
-                                   e.localizedMessage ?: "error"
-                               }
+                           text = try {
+                               Greeting().greeting()
+                           } catch (e: Exception) {
+                               e.localizedMessage ?: "error"
                            }
                        }
                        GreetingView(text)


### PR DESCRIPTION
Remove unnecessary scope, as `LaunchedEffect`'s `block` is already `suspend`.

See https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Effects.kt;l=334