### PR TITLE
Fix formatting in ksp-overview

### DIFF
--- a/docs/topics/ksp/ksp-overview.md
+++ b/docs/topics/ksp/ksp-overview.md
@@ -178,4 +178,4 @@ The table below includes a list of popular libraries on Android and their variou
 |Micronaut|In Progress|[Link](https://github.com/micronaut-projects/micronaut-core/issues/6781)|
 |Epoxy|[Officially supported](https://github.com/airbnb/epoxy)||
 |Paris|[Officially supported](https://github.com/airbnb/paris)||
-|Auto Dagger][Officially supported](https://github.com/ansman/auto-dagger)||
+|Auto Dagger|[Officially supported](https://github.com/ansman/auto-dagger)||


### PR DESCRIPTION
Noticed this was broken

<img width="508" alt="image" src="https://user-images.githubusercontent.com/1361086/222051010-6afeaf3c-aa03-4300-9e18-b03f567e9e4c.png">
