### PR TITLE
Change title for "Sealed Classes" page

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -81,7 +81,7 @@
             <toc-element id="visibility-modifiers.md"/>
             <toc-element id="extensions.md"/>
             <toc-element id="data-classes.md"/>
-            <toc-element id="sealed-classes.md"/>
+            <toc-element id="sealed-classes.md" toc-title="Sealed classes and interfaces"/>
             <toc-element id="generics.md"/>
             <toc-element id="nested-classes.md"/>
             <toc-element id="enum-classes.md"/>

--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -1,4 +1,4 @@
-[//]: # (title: Sealed classes)
+[//]: # (title: Sealed classes and interfaces)
 
 _Sealed_ classes and interfaces represent restricted class hierarchies that provide more control over inheritance.
 All direct subclasses of a sealed class are known at compile time. No other subclasses may appear outside


### PR DESCRIPTION
The page talks about both sealed classes and sealed interfaces. This PR changes the title to reflect this.