### PR TITLE
Fix explanation of KDoc links to elements

### DIFF
--- a/docs/topics/kotlin-doc.md
+++ b/docs/topics/kotlin-doc.md
@@ -121,7 +121,7 @@ Use the method [foo] for this purpose.
 If you want to specify a custom label for the link, use the Markdown reference-style syntax:
 
 ```
-Use [this method](foo) for this purpose.
+Use [this method][foo] for this purpose.
 ```
 
 You can also use qualified names in the links. Note that, unlike Javadoc, qualified names always use the dot character


### PR DESCRIPTION
You cannot actually use `[]()`for elements, but only for external links, for elements you use `[][]`.

Not sure whether that's intended or not, but that's how the IntelliJ Plugin interprets it, so I figured it's intended