### PR TITLE
Clarify floating-point numbers comparison

### DIFF
--- a/docs/topics/numbers.md
+++ b/docs/topics/numbers.md
@@ -289,10 +289,30 @@ When the operands `a` and `b` are statically known to be `Float` or `Double` or 
 declared or inferred or is a result of a [smart cast](typecasts.md#smart-casts)), the operations on the
 numbers and the range that they form follow the [IEEE 754 Standard for Floating-Point Arithmetic](https://en.wikipedia.org/wiki/IEEE_754).
 
-However, to support generic use cases and provide total ordering, when the operands are **not** statically typed as
-floating point numbers (for example, `Any`, `Comparable<...>`, a type parameter), the operations use the
-`equals` and `compareTo` implementations for `Float` and `Double`, which disagree with the standard, so that:
+When the operands are **not** statically typed as floating point numbers (for example, `Any`, `Comparable<...>`, a type 
+parameter), these operations behave differently. In this case, the operations use the `equals` and `compareTo` 
+implementations for `Float` and `Double`. As a result:
 
 * `NaN` is considered equal to itself
 * `NaN` is considered greater than any other element including `POSITIVE_INFINITY`
 * `-0.0` is considered less than `0.0`
+
+This behavior is useful when you have generic use cases. Below is an example that shows the difference in behavior
+between operands statically typed as floating point numbers (`Double.NaN`) and operands **not** statically typed
+as floating point numbers (`listOf(T)`).
+
+```kotlin
+fun main() {
+    //sampleStart
+    println(Double.NaN == Double.NaN)                 // false
+    println(listOf(Double.NaN) == listOf(Double.NaN)) // true
+    
+    println(0.0 == -0.0)                              // true
+    println(listOf(0.0) == listOf(-0.0))              // false
+
+    println(listOf(Double.NaN, Double.POSITIVE_INFINITY, 0.0, -0.0).sorted())
+    // [-0.0, 0.0, Infinity, NaN]
+    //sampleEnd
+}
+```
+{kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="kotlin-numbers-floating-comp"}


### PR DESCRIPTION
Ticket: [KT-57282](https://youtrack.jetbrains.com/issue/KT-57282/Numbers-running-code-gives-different-result-than-stated-in-the-docs)

This PR clarifies the difference in behavior of statically typed/not statically typed operands as floating point numbers when completing comparisons.