### PR TITLE
Kotlin maven plugin to 1.8.20

### DIFF
--- a/docs/topics/kapt.md
+++ b/docs/topics/kapt.md
@@ -294,7 +294,8 @@ Add an execution of the `kapt` goal from kotlin-maven-plugin before `compile`:
 <execution>
     <id>kapt</id>
     <goals>
-        <goal>kapt</goal> <!-- You can skip <goals> element if you enable extensions for the plugin -->
+        <goal>kapt</goal> <!-- You can skip the <goals> element 
+        if you enable extensions for the plugin -->
     </goals>
     <configuration>
         <sourceDirs>
@@ -355,8 +356,8 @@ Here is a list of the available options:
 * `processors`: A comma-specified list of annotation processor qualified class names. If specified, kapt does not try to find annotation processors in `apclasspath`.
 * `verbose`: Enable verbose output.
 * `aptMode` (*required*)
-    * `stubs` – only generate stubs needed for annotation processing;
-    * `apt` – only run annotation processing;
+    * `stubs` – only generate stubs needed for annotation processing.
+    * `apt` – only run annotation processing.
     * `stubsAndApt` – generate stubs and run annotation processing.
 * `correctErrorTypes`: See [below](#using-in-gradle). Disabled by default.
 

--- a/docs/topics/kapt.md
+++ b/docs/topics/kapt.md
@@ -302,7 +302,7 @@ Add an execution of the `kapt` goal from kotlin-maven-plugin before `compile`:
 <execution>
     <id>kapt</id>
     <goals>
-        <goal>kapt</goal> <!-- You can skip <goals> block if you enable extensions for the plugin -->
+        <goal>kapt</goal> <!-- You can skip <goals> element if you enable extensions for the plugin -->
     </goals>
     <configuration>
         <sourceDirs>

--- a/docs/topics/kapt.md
+++ b/docs/topics/kapt.md
@@ -302,7 +302,7 @@ Add an execution of the `kapt` goal from kotlin-maven-plugin before `compile`:
 <execution>
     <id>kapt</id>
     <goals>
-        <goal>kapt</goal>
+        <goal>kapt</goal> <!-- You can skip <goals> block if you enable extensions for the plugin -->
     </goals>
     <configuration>
         <sourceDirs>
@@ -321,8 +321,25 @@ Add an execution of the `kapt` goal from kotlin-maven-plugin before `compile`:
 </execution>
 ```
 
+You can set one of the following apt modes in the `<configuration>` block:
 
-Please note that kapt is still not supported for IntelliJ IDEA's own build system. Launch the build from the "Maven Projects"
+* `aptMode`
+   * `stubs` – only generate stubs needed for annotation processing;
+   * `apt` – only run annotation processing;
+   * `stubsAndApt` – default; generate stubs and run annotation processing.
+
+For example:
+
+```xml
+<configuration>
+   ...
+   <aptMode>stubs</aptMode>
+</configuration>
+```
+
+## Using in IntelliJ build system
+
+kapt is still not supported for IntelliJ IDEA's own build system. Launch the build from the "Maven Projects"
 toolbar whenever you want to re-run the annotation processing.
 
 ## Using in CLI

--- a/docs/topics/kapt.md
+++ b/docs/topics/kapt.md
@@ -303,7 +303,7 @@ Add an execution of the `kapt` goal from kotlin-maven-plugin before `compile`:
             <sourceDir>src/main/java</sourceDir>
         </sourceDirs>
         <annotationProcessorPaths>
-            <!-- Specify your annotation processors here. -->
+            <!-- Specify your annotation processors here -->
             <annotationProcessorPath>
                 <groupId>com.google.dagger</groupId>
                 <artifactId>dagger-compiler</artifactId>

--- a/docs/topics/kapt.md
+++ b/docs/topics/kapt.md
@@ -313,12 +313,11 @@ Add an execution of the `kapt` goal from kotlin-maven-plugin before `compile`:
 </execution>
 ```
 
-You can set one of the following apt modes in the `<configuration>` block:
+To configure the level of annotation processing, set one of the following as the `aptMode` in the `<configuration>` block:
 
-* `aptMode`
-   * `stubs` – only generate stubs needed for annotation processing;
-   * `apt` – only run annotation processing;
-   * `stubsAndApt` – default; generate stubs and run annotation processing.
+   * `stubs` – only generate stubs needed for annotation processing.
+   * `apt` – only run annotation processing.
+   * `stubsAndApt` – (default) generate stubs and run annotation processing.
 
 For example:
 
@@ -331,7 +330,7 @@ For example:
 
 ## Using in IntelliJ build system
 
-kapt is still not supported for IntelliJ IDEA's own build system. Launch the build from the "Maven Projects"
+kapt is not supported for IntelliJ IDEA's own build system. Launch the build from the "Maven Projects"
 toolbar whenever you want to re-run the annotation processing.
 
 ## Using in CLI

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -82,7 +82,7 @@ The Kotlin Maven Plugin needs to be referenced to compile the sources:
 Starting from Kotlin 1.8.20, you can replace the whole `<executions>` element above with `<extensions>true</extensions>`. 
 Enabling extensions automatically adds the `compile`, `test-compile`, `kapt`, and `test-kapt` executions to your build, 
 bound to their appropriate [lifecycle phases](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html). 
-If you need to configure an execution, you need to specify its id. You can find an example of this in the next section.
+If you need to configure an execution, you need to specify its ID. You can find an example of this in the next section.
 
 > If several build plugins overwrite the default lifecycle and you also enabled the `extensions` option, the last plugin in 
 > the `<build>` section has priority in terms of lifecycle settings. All earlier changes to lifecycle settings are ignored.
@@ -102,12 +102,14 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-maven-plugin</artifactId>
             <version>${kotlin.version}</version>
-            <extensions>true</extensions> <!-- You can set this option to automatically take information about lifecycles -->
+            <extensions>true</extensions> <!-- You can set this option 
+            to automatically take information about lifecycles -->
             <executions>
                 <execution>
                     <id>compile</id>
                     <goals>
-                        <goal>compile</goal> <!-- You can skip <goals> element if you enable extensions for the plugin -->
+                        <goal>compile</goal> <!-- You can skip the <goals> element 
+                        if you enable extensions for the plugin -->
                     </goals>
                     <configuration>
                         <sourceDirs>
@@ -118,7 +120,8 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
                 </execution>
                 <execution>
                     <id>test-compile</id>
-                    <goals> <goal>test-compile</goal> </goals> <!-- You can skip <goals> element if you enable extensions for the plugin -->
+                    <goals> <goal>test-compile</goal> </goals> <!-- You can skip the <goals> element 
+                    if you enable extensions for the plugin -->
                     <configuration>
                         <sourceDirs>
                             <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -248,7 +248,7 @@ Maven plugin node:
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-maven-plugin</artifactId>
     <version>${kotlin.version}</version>
-    <extensions>true</extensions> <!-- If you want to enable automatically adding of executions to your build -->
+    <extensions>true</extensions> <!-- If you want to enable automatic addition of executions to your build -->
     <executions>...</executions>
     <configuration>
         <nowarn>true</nowarn>  <!-- Disable warnings -->

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -87,7 +87,7 @@ If you need to configure an execution, you need to specify its id; see an exampl
 > If several build plugins overwrite the default lifecycle and you enabled the `extensions` option, the last plugin in 
 > the `<build>` section has the top priority in terms of lifecycle settings, and all early ones' lifecycle settings are ignored.
 > 
-> {type="note"}
+{type="note"}
 
 ## Compile Kotlin and Java sources
 

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -82,10 +82,10 @@ The Kotlin Maven Plugin needs to be referenced to compile the sources:
 Starting from Kotlin 1.8.20, you can replace the whole `<executions>` element above with `<extensions>true</extensions>`. 
 Enabling extensions automatically adds the `compile`, `test-compile`, `kapt`, and `test-kapt` executions to your build, 
 bound to their appropriate [lifecycle phases](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html). 
-If you need to configure an execution, you need to specify its id; see an example in the following section.
+If you need to configure an execution, you need to specify its id. You can find an example of this in the next section.
 
-> If several build plugins overwrite the default lifecycle and you enabled the `extensions` option, the last plugin in 
-> the `<build>` section has the top priority in terms of lifecycle settings, and all early ones' lifecycle settings are ignored.
+> If several build plugins overwrite the default lifecycle and you also enabled the `extensions` option, the last plugin in 
+> the `<build>` section has priority in terms of lifecycle settings. All earlier changes to lifecycle settings are ignored.
 > 
 {type="note"}
 

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -79,10 +79,20 @@ The Kotlin Maven Plugin needs to be referenced to compile the sources:
 </build>
 ```
 
+Starting from Kotlin 1.8.20, you can replace the whole `<executions/>` block above with `<extensions>true</extensions>`. 
+Enabling extensions automatically adds the `compile`, `test-compile`, `kapt`, and `test-kapt` executions to your build, 
+bound to their appropriate [lifecycle phases](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html). 
+If you need to configure an execution, you need to specify its id; see an example in the following section.
+
+> If several build plugins overwrite the default lifecycle and you enabled the `extensions` option, the last plugin in 
+> the `<build>` section has the top priority in terms of lifecycle settings, and all early ones' lifecycle settings are ignored.
+> 
+> {type="note"}
+
 ## Compile Kotlin and Java sources
 
 To compile projects that include Kotlin and Java source code, invoke the Kotlin compiler before the Java compiler.
-In maven terms that means that `kotlin-maven-plugin` should be run before `maven-compiler-plugin` using the following method,
+In Maven terms it means that `kotlin-maven-plugin` should be run before `maven-compiler-plugin` using the following method,
 making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in your `pom.xml` file:
 
 ```xml
@@ -92,11 +102,12 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-maven-plugin</artifactId>
             <version>${kotlin.version}</version>
+            <extensions>true</extensions> <!-- You can set this option to automatically take information about lifecycles -->
             <executions>
                 <execution>
                     <id>compile</id>
                     <goals>
-                        <goal>compile</goal>
+                        <goal>compile</goal> <!-- You can skip <goals> block if you enable extensions for the plugin -->
                     </goals>
                     <configuration>
                         <sourceDirs>
@@ -107,7 +118,7 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
                 </execution>
                 <execution>
                     <id>test-compile</id>
-                    <goals> <goal>test-compile</goal> </goals>
+                    <goals> <goal>test-compile</goal> </goals> <!-- You can skip <goals> block if you enable extensions for the plugin -->
                     <configuration>
                         <sourceDirs>
                             <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
@@ -122,12 +133,12 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.5.1</version>
             <executions>
-                <!-- Replacing default-compile as it is treated specially by maven -->
+                <!-- Replacing default-compile as it is treated specially by Maven -->
                 <execution>
                     <id>default-compile</id>
                     <phase>none</phase>
                 </execution>
-                <!-- Replacing default-testCompile as it is treated specially by maven -->
+                <!-- Replacing default-testCompile as it is treated specially by Maven -->
                 <execution>
                     <id>default-testCompile</id>
                     <phase>none</phase>
@@ -237,6 +248,7 @@ Maven plugin node:
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-maven-plugin</artifactId>
     <version>${kotlin.version}</version>
+    <extensions>true</extensions> <!-- If you want to enable automatically adding of executions to your build -->
     <executions>...</executions>
     <configuration>
         <nowarn>true</nowarn>  <!-- Disable warnings -->
@@ -253,7 +265,7 @@ Many of the options can also be configured through properties:
 ```xml
 <project ...>
     <properties>
-        <kotlin.compiler.languageVersion>1.0</kotlin.compiler.languageVersion>
+        <kotlin.compiler.languageVersion>1.9</kotlin.compiler.languageVersion>
     </properties>
 </project>
 ```

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -79,7 +79,7 @@ The Kotlin Maven Plugin needs to be referenced to compile the sources:
 </build>
 ```
 
-Starting from Kotlin 1.8.20, you can replace the whole `<executions/>` block above with `<extensions>true</extensions>`. 
+Starting from Kotlin 1.8.20, you can replace the whole `<executions>` element above with `<extensions>true</extensions>`. 
 Enabling extensions automatically adds the `compile`, `test-compile`, `kapt`, and `test-kapt` executions to your build, 
 bound to their appropriate [lifecycle phases](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html). 
 If you need to configure an execution, you need to specify its id; see an example in the following section.
@@ -107,7 +107,7 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
                 <execution>
                     <id>compile</id>
                     <goals>
-                        <goal>compile</goal> <!-- You can skip <goals> block if you enable extensions for the plugin -->
+                        <goal>compile</goal> <!-- You can skip <goals> element if you enable extensions for the plugin -->
                     </goals>
                     <configuration>
                         <sourceDirs>
@@ -118,7 +118,7 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
                 </execution>
                 <execution>
                     <id>test-compile</id>
-                    <goals> <goal>test-compile</goal> </goals> <!-- You can skip <goals> block if you enable extensions for the plugin -->
+                    <goals> <goal>test-compile</goal> </goals> <!-- You can skip <goals> element if you enable extensions for the plugin -->
                     <configuration>
                         <sourceDirs>
                             <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>


### PR DESCRIPTION
[KT-56317](https://youtrack.jetbrains.com/issue/KT-56317) [Docs][Build Tools] kotlin-maven-plugin + kapt - allow aptMode to be set according to docs
[KT-56316](https://youtrack.jetbrains.com/issue/KT-56316) [Docs][Build Tools] Add components.xml to automatically compile kotlin maven projects