### PR TITLE
Update menu link to Kotlin spec

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -309,7 +309,7 @@
     <toc-element toc-title="Language reference">
         <toc-element id="keyword-reference.md"/>
         <toc-element toc-title="Grammar" href="https://kotlinlang.org/docs/reference/grammar.html"/>
-        <toc-element href="https://kotlin.github.io/kotlin-spec/" toc-title="Language specification"/>
+        <toc-element href="https://kotlinlang.org/spec/" toc-title="Language specification"/>
     </toc-element>
 
     <toc-element toc-title="Tools">


### PR DESCRIPTION
Google isn't indexing our Kotlin spec page with URL: https://kotlinlang.org/spec/

This is because our current link is set to: https://kotlin.github.io/kotlin-spec/

This PR will fix this issue.