### PR TITLE
Fix duplicate page titles

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -152,8 +152,8 @@
             <toc-element id="multiplatform-build-native-binaries.md" accepts-web-file-names="mpp-build-native-binaries.html"/>
         </toc-element>
         <toc-element id="multiplatform-dsl-reference.md" accepts-web-file-names="mpp-dsl-reference.html,mpp-supported-platforms.html,multiplatform-supported-platforms.html"/>
-        <toc-element id="multiplatform-mobile-samples.md" accepts-web-file-names="kmm-samples.html"/>
-        <toc-element id="multiplatform-mobile-faq.md" accepts-web-file-names="kmm-faq.html"/>
+        <toc-element id="multiplatform-mobile-samples.md" toc-title="Samples" accepts-web-file-names="kmm-samples.html"/>
+        <toc-element id="multiplatform-mobile-faq.md" accepts-web-file-names="kmm-faq.html" toc-title="FAQ"/>
         <toc-element id="multiplatform-mobile-introduce-your-team.md" accepts-web-file-names="kmm-introduce-your-team.html"/>
         <toc-element id="multiplatform-compatibility-guide.md" toc-title="Compatibility guide"/>
         <toc-element id="multiplatform-mobile-plugin-releases.md" accepts-web-file-names="kmm-plugin-releases.html"/>
@@ -260,7 +260,7 @@
                 <toc-element id="js-reflection.md"/>
                 <toc-element id="typesafe-html-dsl.md"/>
             </toc-element>
-            <toc-element id="js-samples.md"/>
+            <toc-element id="js-samples.md" toc-title="Samples"/>
             <toc-element id="js-react.md"/>
         </toc-element>
 

--- a/docs/topics/js/js-samples.md
+++ b/docs/topics/js/js-samples.md
@@ -1,4 +1,4 @@
-[//]: # (title: Samples)
+[//]: # (title: Kotlin/JS samples)
 
 This is a curated list of Kotlin/JS samples.
 

--- a/docs/topics/ksp/ksp-faq.md
+++ b/docs/topics/ksp/ksp-faq.md
@@ -1,4 +1,4 @@
-[//]: # (title: FAQ)
+[//]: # (title: KSP FAQ)
 
 ### Why KSP?
 

--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-faq.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-faq.md
@@ -1,4 +1,4 @@
-[//]: # (title: FAQ)
+[//]: # (title: Kotlin Multiplatform Mobile FAQ)
 
 ### What is Kotlin Multiplatform Mobile?
 

--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-samples.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-samples.md
@@ -1,4 +1,4 @@
-[//]: # (title: Samples)
+[//]: # (title: Kotlin Multiplatform Mobile samples)
 
 This is a curated list of Kotlin Multiplatform Mobile samples.
 


### PR DESCRIPTION
We have pages with the same titles "Samples" and "FAQ". This PR makes changes so that all page titles are unique.