### PR TITLE
api-guidelines docs as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "api-guidelines"]
+	path = api-guidelines
+	url = https://github.com/Kotlin/api-guidelines
+	branch = main

--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ Note that source files for the [server-side landing page](https://kotlinlang.org
 
 #### Sources in different repositories
 
-Source files for the language specification and the docs for coroutines, lincheck, and Dokka are stored in separate repositories
+Source files for the language specification and the docs for coroutines, lincheck, Dokka, and Library creators' guidelines
+are stored in separate repositories
 
-| Website page                                                            | GitHub repository                                                   |
-|-------------------------------------------------------------------------|---------------------------------------------------------------------|
-| [Coroutines docs](https://kotlinlang.org/docs/coroutines-guide.html)    | [kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines/) |
-| [Lincheck docs](https://kotlinlang.org/docs/lincheck-guide.html)        | [kotlinx.lincheck](https://github.com/Kotlin/kotlinx-lincheck/)     |
-| [Dokka docs](https://kotlinlang.org/docs/dokka-introduction.html)       | [Dokka](https://github.com/Kotlin/dokka/)                           |
-| [Language specification](https://kotlinlang.org/spec/introduction.html) | [kotlin-spec](https://github.com/Kotlin/kotlin-spec)                |
+| Website page                                                                                     | GitHub repository                                                   |
+|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| [Coroutines docs](https://kotlinlang.org/docs/coroutines-guide.html)                             | [kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines/) |
+| [Lincheck docs](https://kotlinlang.org/docs/lincheck-guide.html)                                 | [kotlinx.lincheck](https://github.com/Kotlin/kotlinx-lincheck/)     |
+| [Dokka docs](https://kotlinlang.org/docs/dokka-introduction.html)                                | [Dokka](https://github.com/Kotlin/dokka/)                           |
+| [Library creators' guidelines](https://kotlinlang.org/docs/jvm-api-guidelines-introduction.html) | [api-guidelines](https://github.com/Kotlin/api-guidelines)          |
+| [Language specification](https://kotlinlang.org/spec/introduction.html)                          | [kotlin-spec](https://github.com/Kotlin/kotlin-spec)                |
 
 #### Auto-generated content
 

--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -186,6 +186,9 @@
                 <toc-element toc-title="Collections" id="java-to-kotlin-collections-guide.md"/>
                 <toc-element toc-title="Nullability" id="java-to-kotlin-nullability-guide.md"/>
             </toc-element>
+            <toc-element toc-title="Library creators' guidelines">
+                <include from="kl" target="api-guidelines" origin="api-guidelines"/>
+            </toc-element>
         </toc-element>
 
         <toc-element toc-title="Native">


### PR DESCRIPTION
Probably, this PR should be closed, and this one #3526 should be used instead.

Done by example from here https://github.com/JetBrains/kotlin-web-site/pull/3374/files/eca2ff307ccb2099a2a949afedb31b85ce8e2dbe