### PR TITLE
chore(workflow): change push repo for samples

### DIFF
--- a/.github/workflows/verify-samples.yml
+++ b/.github/workflows/verify-samples.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run a verifier
         uses: AlexanderPrendota/kotlin-samples-verifier@master
         with:
-          push-repository: 'https://github.com/AlexanderPrendota/kotlin-compiler-server'
+          push-repository: 'https://github.com/JetBrains/kotlin-compiler-server'
           tag-filter: '#tag="code" & kotlin-runnable="true" & !validate="false"'
           push-path: 'src/test/resources/test-compile-data/jvm/kotlin-web-site'
           username: '${{ secrets.KOTLIN_WEB_SITE_TOKEN }}' #token with an access to create PR in push-repository and issue in this repository


### PR DESCRIPTION
The repo https://github.com/AlexanderPrendota/kotlin-compiler-server was transferred to JetBrains.
So the verifier can not work with redirection. (`cannot retry due to redirection, in streaming mode`)
