### PR TITLE
Fix misleading idiom if-not-null-else shorthand.

### DIFF
--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -159,11 +159,13 @@ println(files?.size) // size is printed if files is not null
 ```kotlin
 val files = File("Test").listFiles()
 
+// For easy fallback values:
 println(files?.size ?: "empty") // if files is null, this prints "empty"
 
-// To calculate the fallback value in a code block, use `run`
+// To calculate a more complicated fallback value in a code block, use `run`
 val filesSize = files?.size ?: run { 
-    return someSize 
+    val someSize = getSomeSize()
+    someSize * 2
 }
 println(filesSize)
 ```

--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -159,7 +159,7 @@ println(files?.size) // size is printed if files is not null
 ```kotlin
 val files = File("Test").listFiles()
 
-// For easy fallback values:
+// For simple fallback values:
 println(files?.size ?: "empty") // if files is null, this prints "empty"
 
 // To calculate a more complicated fallback value in a code block, use `run`


### PR DESCRIPTION
The return statement in the version before this change will not return the value to the run statement but to the enclosing function.