### PR TITLE
chore: update core api reference docs (1.8.20)

### DIFF
--- a/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
+++ b/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
@@ -167,7 +167,7 @@ object BuildSitePages : BuildType({
       }
     }
 
-    artifacts(AbsoluteId("Kotlin_KotlinRelease_180_LibraryReferenceDocs")) {
+    artifacts(AbsoluteId("Kotlin_KotlinRelease_1820_LibraryReferenceLegacyDocs")) {
       buildRule = tag("publish", """
                 +:<default>
                 +:*


### PR DESCRIPTION
use core api reference docs built with legacy Dokka from 1.8.20 project