### PR TITLE
KTL-1094 kotlinlang: there is not Kotlin version is Docs header

### DIFF
--- a/docs/cfg/buildprofiles.xml
+++ b/docs/cfg/buildprofiles.xml
@@ -9,6 +9,7 @@
             https://github.com/Kotlin/kotlinx.coroutines/edit/master/docs/topics/
         </browser-edits-url-override>
         <kotlin-latest-url>%kotlinLatestUrl%</kotlin-latest-url>
+        <product-web-url>%kotlinLatestUrl%</product-web-url>
         <generate-only-default-anchors>true</generate-only-default-anchors>
         <web-root>https://kotlinlang.org/docs/</web-root>
         <og-image>https://kotlinlang.org/assets/images/open-graph/docs.png</og-image>


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1094/kotlinlang-there-is-not-Kotlin-version-is-Docs-header