### PR TITLE
chore: update java in sample verifier

### DIFF
--- a/.github/workflows/verify-samples.yml
+++ b/.github/workflows/verify-samples.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'zulu'
       - name: Run a verifier
         uses: AlexanderPrendota/kotlin-samples-verifier@master
         with:


### PR DESCRIPTION
Kotlin compiler server works on Java 17. (see https://github.com/JetBrains/kotlin-compiler-server/pull/634) 