### PR TITLE
Update data-classes.md to avoid making assumption when choosing data class and class

### DIFF
--- a/docs/topics/data-classes.md
+++ b/docs/topics/data-classes.md
@@ -7,6 +7,7 @@ derivable from the data. In Kotlin, these are called _data classes_ and are mark
 ```kotlin
 data class User(val name: String, val age: Int)
 ```
+In case you know for sure that you do not need any benefit of `data class` then using normal `class` is fine.
 
 The compiler automatically derives the following members from all properties declared in the primary constructor:
 


### PR DESCRIPTION
### 🖼 Summary
Currently at the beginning, this page is making assumption that every classes might need some utility functions that comes with `data class` . However, in some codebase not every class should be marked as `data class` if the purpose of using these objects does not require any utility functions.
It's good to make a clear understanding when choose using `data class` and normal `class`.
In some libraries, they use only class to form a constraint of data to make sure every clients that want to use data from these classes, should only read properties from them and no utility function are required from these classes. In this case, using `class` is good enough

### 💡 Update
Add a reminder of usage `class` or `data class` should be based on each situation