### PR TITLE
Use kotlin DSL function to specify reflection dependency

### DIFF
--- a/docs/topics/reflection.md
+++ b/docs/topics/reflection.md
@@ -23,7 +23,7 @@ To use reflection in a Gradle or Maven project, add the dependency on `kotlin-re
 
     ```kotlin
     dependencies {
-        implementation("org.jetbrains.kotlin:kotlin-reflect:%kotlinVersion%")
+        implementation(kotlin("reflect"))
     }
     ```
 


### PR DESCRIPTION
Uses the same dependency declaration scheme as in https://kotlinlang.org/docs/jvm-test-using-junit.html#add-dependencies (and saves people from having to manually specify the version number for the `reflect` artifact)