### PR TITLE
KT-53643: Update coding style conventions wrt rangeUntil operator

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -967,11 +967,11 @@ of the operations being performed in each case and keep performance consideratio
 
 ### Loops on ranges
 
-Use the `until` function to loop over an open range:
+Use the `..<` (`rangeUntil`) operator to loop over an open range:
 
 ```kotlin
 for (i in 0..n - 1) { /*...*/ }  // bad
-for (i in 0 until n) { /*...*/ }  // good
+for (i in 0..<n) { /*...*/ }  // good
 ```
 
 ### Strings


### PR DESCRIPTION
I'm slightly hesitant about including part "Prior to Kotlin 1.9, it was recommended to use the `until` function". In the end, decided not to add it as new projects will use only `..<` and old projects will continue to use `until` as they used to. 