### PR TITLE
Update multiplatform-mobile-upgrade-app.md

### DIFF
--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-upgrade-app.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-upgrade-app.md
@@ -99,7 +99,7 @@ sourceSets {
             implementation("io.ktor:ktor-client-android:$ktorVersion")
         }
     }
-    val iosMain by creating {
+    val iosMain by getting {
         // ...
         dependencies {
             implementation("io.ktor:ktor-client-darwin:$ktorVersion") 


### PR DESCRIPTION
Changing 
```kotlin
val iosMain by creating
```
to
```kotlin
val iosMain by getting
```

As the `iosMain` source set already exists in the project and `by creating` is generating a gradle error.