### PR TITLE
Update JS default distribution target directory

### DIFF
--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -371,7 +371,7 @@ kotlin.js.webpack.major.version=4
 
 The most common webpack adjustments can be made directly via the
 `kotlin.js.browser.webpackTask` configuration block in the Gradle build file:
-- `outputFileName` - the name of the webpacked output file. It will be generated in `<projectDir>/build/distributions/` after
+- `outputFileName` - the name of the webpacked output file. It will be generated in `<projectDir>/build/dist/<targetName>` after
   an execution of a webpack task. The default value is the project name.
 - `output.libraryTarget` - the module system for the webpacked output. Learn more about [available module systems for
   Kotlin/JS projects](js-modules.md). The default value is `umd`.
@@ -424,7 +424,7 @@ the resulting JavaScript file, which takes more time, but generates executables 
 the `browserProductionWebpack` task when preparing your project for production use.
  
  Execute either of these tasks to obtain the respective artifacts for development or production. The generated files will
- be available in `build/distributions` unless [specified otherwise](#distribution-target-directory).
+ be available in `build/dist` unless [specified otherwise](#distribution-target-directory).
 
 ```bash
 ./gradlew browserProductionWebpack
@@ -761,7 +761,11 @@ rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlu
 
 ## Distribution target directory
 
-By default, the results of a Kotlin/JS project build reside in the `/build/distribution` directory within the project root.
+By default, the results of a Kotlin/JS project build reside in the `/build/dist/<targetName>/<binaryName>` directory within the project root.
+
+> Prior to Kotlin 1.9.0, the default distribution target directory was `/build/distributions`.
+>
+{type="note" }
 
 To set another location for project distribution files, add the `distribution` block inside `browser` in the build script and 
 assign a value to the `directory` property.
@@ -815,7 +819,7 @@ js {
 }
 ```
 
-Note that this does not affect the webpacked output in `build/distributions`.
+Note that this does not affect the webpacked output in `build/dist`.
 
 ## package.json customization
 

--- a/docs/topics/js/js-react.md
+++ b/docs/topics/js/js-react.md
@@ -1212,7 +1212,7 @@ To package all assets in production mode, run the `build` task in Gradle via the
 running `./gradlew build`. This generates an optimized project build, applying various improvements such as DCE
 (dead code elimination).
 
-Once the build has finished, you can find all the files needed for deployment in `/build/distributions`. They include
+Once the build has finished, you can find all the files needed for deployment in `/build/dist`. They include
 the JavaScript files, HTML files, and other resources required to run the application. You can put them on a static HTTP server,
 serve them using GitHub Pages, or host them on a cloud provider of your choice.
 


### PR DESCRIPTION
For Kotlin 1.9.0, this PR updates the default distribution target directory for Kotlin/JS.