### PR TITLE
Add SealedX to list of KSP supported libraries

### DIFF
--- a/docs/topics/ksp/ksp-overview.md
+++ b/docs/topics/ksp/ksp-overview.md
@@ -179,3 +179,4 @@ The table below includes a list of popular libraries on Android and their variou
 |Epoxy|[Officially supported](https://github.com/airbnb/epoxy)||
 |Paris|[Officially supported](https://github.com/airbnb/paris)||
 |Auto Dagger|[Officially supported](https://github.com/ansman/auto-dagger)||
+|SealedX|[Officially supported](https://github.com/skydoves/sealedx)||


### PR DESCRIPTION
Add [SealedX](https://github.com/skydoves/sealedx) to list of KSP-supported libraries.