### PR TITLE
chore: update core api reference docs (1.9.0)

### DIFF
--- a/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
+++ b/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
@@ -167,7 +167,7 @@ object BuildSitePages : BuildType({
       }
     }
 
-    artifacts(AbsoluteId("Kotlin_KotlinRelease_1820_LibraryReferenceLegacyDocs")) {
+    artifacts(AbsoluteId("Kotlin_KotlinRelease_190_LibraryReferenceLegacyDocs")) {
       buildRule = tag("publish", """
                 +:<default>
                 +:*

--- a/static/js/page/api/api.js
+++ b/static/js/page/api/api.js
@@ -4,7 +4,7 @@ import Dropdown from '../../com/dropdown'
 import NavTree from '../../com/nav-tree'
 import './api.scss'
 
-const DEFAULT_VERSION = '1.8';
+const DEFAULT_VERSION = '1.9';
 const LOCAL_STORAGE_KEY = 'targetApi';
 const PLATFORM_AVAILABILITY = {
     'jvm': '1.0',
@@ -193,7 +193,8 @@ function initializeSelects() {
       '1.5': '1.5',
       '1.6': '1.6',
       '1.7': '1.7',
-      '1.8': '1.8'
+      '1.8': '1.8',
+      '1.9': '1.9'
     },
     selected: state.version != null ? state.version : DEFAULT_VERSION,
     onSelect: (version) => {


### PR DESCRIPTION
- use core api reference docs built with legacy Dokka from 1.9.0 project
- add version selector 1.9 for stdlib docs