### PR TITLE
Fix basePackage value for "Build a full-stack web app with Kotlin Multiplatform" tutorial

### DIFF
--- a/docs/topics/multiplatform/multiplatform-full-stack-app.md
+++ b/docs/topics/multiplatform/multiplatform-full-stack-app.md
@@ -480,7 +480,7 @@ root directory.
             ContentType.Text.Html
         )
     }
-    staticResources("/", "static")
+    staticResources("/", "")
     route(ShoppingListItem.path) {
         // ...
     }


### PR DESCRIPTION
I am currently going through the tutorial for ["Build a full-stack web app with Kotlin Multiplatform"](https://kotlinlang.org/docs/multiplatform-full-stack-app.html) but found an issue when I reached the ["Serve HTML and JavaScript files from Ktor"](https://kotlinlang.org/docs/multiplatform-full-stack-app.html#serve-html-and-javascript-files-from-ktor) part.

In my case, I was facing a 404 error when running the app for `shoppinglist.js` file.

<img width="1444" alt="image" src="https://github.com/kuroski/js-to-jsx/assets/1855125/f7dc6ab8-5475-494c-a19e-c7ddf95b82ec">

After some trials and errors, I finally found that the issue was that the `basePackage` property from `Ktor` should actually be empty

```gradle
staticResources("/", "")
```

<img width="1847" alt="image" src="https://github.com/kuroski/js-to-jsx/assets/1855125/339be57f-35b2-48d4-b341-73a92a5dbb97">