### PR TITLE
Replace until with rangeUntil operator in Kotlin tour

### DIFF
--- a/docs/topics/tour/kotlin-tour-control-flow.md
+++ b/docs/topics/tour/kotlin-tour-control-flow.md
@@ -151,7 +151,7 @@ Before talking about loops, it's useful to know how to construct ranges for loop
 
 The most common way to create a range in Kotlin is to use the `..` operator. For example, `1..4` is equivalent to `1, 2, 3, 4`.
 
-To declare a range that doesn't include the end value, use `until`. For example, `1 until 4` is equivalent to `1, 2, 3`.
+To declare a range that doesn't include the end value, use the `..<` operator. For example, `1..<4` is equivalent to `1, 2, 3`.
 
 To declare a range in reverse order, use `downTo.` For example, `4 downTo 1` is equivalent to `4, 3, 2, 1`.
 


### PR DESCRIPTION
This PR updates the Control flow page in the Kotlin tour so that is uses the new rangeUntil operator introduced in 1.9.0.