### PR TITLE
Make all tour examples print something

### DIFF
--- a/docs/topics/time-measurement.md
+++ b/docs/topics/time-measurement.md
@@ -301,13 +301,10 @@ to create a [`TimeMark`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.tim
 import kotlin.time.*
 
 fun main() {
-//sampleStart
    val timeSource = TimeSource.Monotonic
    val mark = timeSource.markNow()
-//sampleEnd
 }
 ```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="kotlin-time-mark-moment"}
 
 ### Measure differences in time
 

--- a/docs/topics/tour/kotlin-tour-collections.md
+++ b/docs/topics/tour/kotlin-tour-collections.md
@@ -39,8 +39,13 @@ fun main() {
 //sampleStart
     // Read only list
     val readOnlyShapes = listOf("triangle", "square", "circle")
+    println(readOnlyShapes)
+    // [triangle, square, circle]
+    
     // Mutable list with explicit type declaration
-    val shapes: MutableList<String> = mutableListOf("triangle", "square", "circle") 
+    val shapes: MutableList<String> = mutableListOf("triangle", "square", "circle")
+    println(shapes)
+    // [triangle, square, circle]
 //sampleEnd
 }
 ```
@@ -242,8 +247,13 @@ fun main() {
 //sampleStart
     // Read-only map
     val readOnlyAccountBalances = mapOf(1 to 100, 2 to 100, 3 to 100)
+    println(readOnlyAccountBalances)
+    // {1=100, 2=100, 3=100}
+    
     // Mutable map with explicit type declaration
-    val accountBalances: MutableMap<Int, Int> = mutableMapOf(1 to 100, 2 to 100, 3 to 100)                    
+    val accountBalances: MutableMap<Int, Int> = mutableMapOf(1 to 100, 2 to 100, 3 to 100)         
+    println(accountBalances)
+    // {1=100, 2=100, 3=100}
 //sampleEnd
 }
 ```

--- a/docs/topics/tour/kotlin-tour-hello-world.md
+++ b/docs/topics/tour/kotlin-tour-hello-world.md
@@ -49,6 +49,8 @@ fun main() {
     
     // Some customers leave the queue
     customers = 8
+    println(customers)
+    // 8
 //sampleEnd
 }
 ```


### PR DESCRIPTION
There are a couple of runnable examples in the Kotlin tour that have no output to console. This PR adds `println()` to these examples to generate output.