### PR TITLE
Update EAP and Classes pages

### DIFF
--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -16,8 +16,8 @@ class Empty
 
 ## Constructors
 
-A class in Kotlin can have a _primary constructor_ and one or more _secondary constructors_. The primary constructor is a
-part of the class header, and it goes after the class name and optional type parameters.
+A class in Kotlin has a _primary constructor_ and possibly one or more _secondary constructors_. The primary constructor
+is declared in the class header, and it goes after the class name and optional type parameters.
 
 ```kotlin
 class Person constructor(firstName: String) { /*...*/ }
@@ -29,8 +29,10 @@ If the primary constructor does not have any annotations or visibility modifiers
 class Person(firstName: String) { /*...*/ }
 ```
 
-The primary constructor cannot contain any code. Initialization code can be placed in _initializer blocks_ prefixed with
-the `init` keyword.
+The primary constructor initializes a class instance and its properties in the class header. The class header can't contain
+any runnable code. If you want to run some code during object creation, use _initializer blocks_ inside the class body.
+Initializer blocks are declared with the `init` keyword followed by curly braces. Write any code that you want to run
+within the curly braces.
 
 During the initialization of an instance, the initializer blocks are executed in the same order as they appear in the
 class body, interleaved with the property initializers:

--- a/docs/topics/data-classes.md
+++ b/docs/topics/data-classes.md
@@ -23,13 +23,13 @@ To ensure consistency and meaningful behavior of the generated code, data classe
 
 Additionally, the generation of data class members follows these rules with regard to the members' inheritance:
 
-* If there are explicit implementations of `equals()`, `hashCode()`, or `toString()` in the data class body or
+* If there are explicit implementations of `.equals()`, `.hashCode()`, or `.toString()` in the data class body or
   `final` implementations in a superclass, then these functions are not generated, and the existing
   implementations are used.
-* If a supertype has `componentN()` functions that are `open` and return compatible types, the
+* If a supertype has `.componentN()` functions that are `open` and return compatible types, the
   corresponding functions are generated for the data class and override those of the supertype. If the functions of the
   supertype cannot be overridden due to incompatible signatures or due to their being final, an error is reported.
-* Providing explicit implementations for the `componentN()` and `copy()` functions is not allowed.
+* Providing explicit implementations for the `.componentN()` and `.copy()` functions is not allowed.
 
 Data classes may extend other classes (see [Sealed classes](sealed-classes.md) for examples).
 

--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -63,4 +63,9 @@ check [our instructions on how to configure your build to support this version](
         </td>
     </tr>
 </table>
+
+> If the Kotlin EAP plugin can't find the latest EAP build, check that you are using the latest version of [IntelliJ IDEA](https://www.jetbrains.com/help/idea/update.html) or [Android Studio](https://developer.android.com/studio/intro/update).
+>
+{type="note"}
+
 -->

--- a/docs/topics/install-eap-plugin.md
+++ b/docs/topics/install-eap-plugin.md
@@ -5,7 +5,7 @@
     <p><a href="eap.md#build-details">Explore Kotlin EAP release details</a></p>
 </microformat>
 
-You can follow these instructions to install [the preview version of the Kotlin Plugin for IntelliJ IDEA or Android Studio](eap.md#build-details).
+You can follow these instructions to install the preview version of the Kotlin Plugin for IntelliJ IDEA or Android Studio.
 
 1. Select **Tools** | **Kotlin** | **Configure Kotlin Plugin Updates**. 
     
@@ -21,6 +21,10 @@ You can follow these instructions to install [the preview version of the Kotlin 
 
     ![Install the EAP build](idea-latest-kotlin-eap.png)
     {width="500"}
+   
+   > If the Kotlin EAP plugin can't find the latest EAP build, check that you are using the latest version of [IntelliJ IDEA](https://www.jetbrains.com/help/idea/update.html) or [Android Studio](https://developer.android.com/studio/intro/update).
+   >
+   {type="note"}
 
 4. Click **Install**. 
 

--- a/docs/topics/tour/kotlin-tour-functions.md
+++ b/docs/topics/tour/kotlin-tour-functions.md
@@ -13,7 +13,7 @@
 You can declare your own functions in Kotlin using the `fun` keyword.
 
 ```kotlin
-fun hello(){
+fun hello() {
     return println("Hello, world!")
 }
 


### PR DESCRIPTION
This PR adds a note to EAP pages explaining that if the Kotlin EAP plugin can't find the latest Kotlin version, users need to check that they are on the latest IDE version. It also clarifies the definition of a primary constructor as the current description is misleading. In addition, there is some formatting fixes for data class member functions.

This PR resolves:
- [KT-57525](https://youtrack.jetbrains.com/issue/KT-57525/Primary-constructor-definition)
- [KT-57864](https://youtrack.jetbrains.com/issue/KT-57864/Web-feedback-from-Install-the-Kotlin-EAP-Plugin-user-cannot-update)