### PR TITLE
Update multiplatform-library.md

### DIFF
--- a/docs/topics/multiplatform/multiplatform-library.md
+++ b/docs/topics/multiplatform/multiplatform-library.md
@@ -152,6 +152,19 @@ JS-specific functionality:
        fun encode(s: String): String
    }
    ```
+   
+   If `@JsModule` and `@JsNonModule` are invalid, please check your build.gradle.kts file compiler settings. The project might have been created with the default setting `js(BOTH)`, so please change it to `js(IR)`
+   
+   ```kotlin
+   kotlin {
+       // ...
+       js(IR) {
+           browser {
+            //...
+         }
+      }
+   }
+   ```
 
 ### Native
 


### PR DESCRIPTION
When using IDEA (versions before 2023.1.4) to create a project following a tutorial, the default setting for the js compiler is 'BOTH', which may lead to errors. Need to manually change it to 'IR'.
<img width="678" alt="image" src="https://github.com/JetBrains/kotlin-web-site/assets/56824280/bec4920c-b2c6-4051-8ca6-ec6cb6ca0868">
