### PR TITLE
Add definitely non-nullable types documentation

### DIFF
--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -322,6 +322,41 @@ fun <T> copyWhenGreater(list: List<T>, threshold: T): List<String>
 The passed type must satisfy all conditions of the `where` clause simultaneously. In the above example, the `T` type
 must implement _both_ `CharSequence` and `Comparable`.
 
+## Definitely non-nullable types
+
+To make interoperability with generic Java classes and interfaces easier, Kotlin supports declaring a generic type parameter
+as **definitely non-nullable**. 
+
+To declare a generic type `T` as definitely non-nullable, declare the type with `& Any`. For example: `T & Any`.
+
+A definitely non-nullable type must have a nullable [upper bound](#upper-bounds).
+
+The most common use case for declaring definitely non-nullable types is when you want to override a Java method that 
+contains `@NotNull` as an argument. For example, consider the `load()` method:
+
+```java
+import org.jetbrains.annotations.*;
+
+public interface Game<T> {
+    public T save(T x) {}
+    @NotNull
+    public T load(@NotNull T x) {}
+}
+```
+
+To override the `load()` method in Kotlin successfully, you need `T1` to be declared as definitely non-nullable:
+
+```kotlin
+interface ArcadeGame<T1> : Game<T1> {
+    override fun save(x: T1): T1
+    // T1 is definitely non-nullable
+    override fun load(x: T1 & Any): T1 & Any
+}
+```
+
+When working only with Kotlin, it's unlikely that you will need to declare definitely non-nullable types explicitly because 
+Kotlin's type inference takes care of this for you.
+
 ## Type erasure
 
 The type safety checks that Kotlin performs for generic declaration usages are done at compile time.

--- a/docs/topics/jvm/java-to-kotlin-nullability-guide.md
+++ b/docs/topics/jvm/java-to-kotlin-nullability-guide.md
@@ -116,6 +116,36 @@ on a value of a non-nullable type.
 
 Learn more about [calling Java from Kotlin in regard to null-safety and platform types](java-interop.md#null-safety-and-platform-types).
 
+## Support for definitely non-nullable types
+
+In Kotlin, if you want to override a Java method that contains `@NotNull` as an argument, you need Kotlin's definitely
+non-nullable types.
+
+For example, consider this `load()` method in Java:
+
+```java
+import org.jetbrains.annotations.*;
+
+public interface Game<T> {
+  public T save(T x) {}
+  @NotNull
+  public T load(@NotNull T x) {}
+}
+```
+
+To override the `load()` method in Kotlin successfully, you need `T1` to be declared as definitely
+non-nullable (`T1 & Any`):
+
+```kotlin
+interface ArcadeGame<T1> : Game<T1> {
+  override fun save(x: T1): T1
+  // T1 is definitely non-nullable
+  override fun load(x: T1 & Any): T1 & Any
+}
+```
+
+Learn more about generic types that are [definitely non-nullable](generics.md#definitely-non-nullable-types).
+
 ## Checking the result of a function call
 
 One of the most common situations where you need to check for `null` is when you obtain a result from a function call.

--- a/docs/topics/null-safety.md
+++ b/docs/topics/null-safety.md
@@ -227,4 +227,5 @@ val intList: List<Int> = nullableList.filterNotNull()
 
 ## What's next?
 
-Learn how to [handle nullability in Java and Kotlin](java-to-kotlin-nullability-guide.md).
+* Learn how to [handle nullability in Java and Kotlin](java-to-kotlin-nullability-guide.md).
+* Learn about generic types that are [definitely non-nullable](generics.md#definitely-non-nullable-types).


### PR DESCRIPTION
This PR adds documentation for generic types that are definitely non-nullable. The content is primarily added to the [Generics](https://kotlinlang.org/docs/generics.html) page. A link has been added to the [Null safety](https://kotlinlang.org/docs/null-safety.html) page, and the [Java to Kotlin nullability guide](https://kotlinlang.org/docs/java-to-kotlin-nullability-guide.html) also has a small update.

This PR resolves [KT-54422](https://youtrack.jetbrains.com/issue/KT-54422/Add-documentation-on-website-for-Definitely-non-nullable-types-feature).