### PR TITLE
Add Gradle's apiVersion as a variable

### DIFF
--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -59,7 +59,7 @@ For both the JVM and Android projects, it's possible to define options using the
 ```kotlin
 kotlin {
     compilerOptions {
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.%gradleApiVersion%)
     }
 }
 ```
@@ -70,7 +70,7 @@ kotlin {
 ```groovy
 kotlin {
     compilerOptions {
-        apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+        apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.%gradleApiVersion%
     }
 }
 ```
@@ -267,7 +267,7 @@ tasks
     .withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask.class)
     .configureEach {
         compilerOptions.languageVersion = 
-                org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+                org.jetbrains.kotlin.gradle.dsl.KotlinVersion.%gradleLanguageVersion%
 }
 ```
 
@@ -299,7 +299,7 @@ Some of the `compilerOptions` use the new types instead of the `String` type:
 | Option | Type | Example |
 |--------|------|---------|
 | `jvmTarget` | [`JvmTarget`](https://github.com/JetBrains/kotlin/blob/1.8.0/libraries/tools/kotlin-gradle-compiler-types/src/generated/kotlin/org/jetbrains/kotlin/gradle/dsl/JvmTarget.kt) | `compilerOptions.jvmTarget.set(JvmTarget.JVM_11)` |
-| `apiVersion` and `languageVersion` | [`KotlinVersion`](https://github.com/JetBrains/kotlin/blob/1.8.0/libraries/tools/kotlin-gradle-compiler-types/src/generated/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinVersion.kt) | `compilerOptions.languageVersion.set(KotlinVersion.KOTLIN_1_9)` |
+| `apiVersion` and `languageVersion` | [`KotlinVersion`](https://github.com/JetBrains/kotlin/blob/1.8.0/libraries/tools/kotlin-gradle-compiler-types/src/generated/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinVersion.kt) | `compilerOptions.languageVersion.set(KotlinVersion.%gradleLanguageVersion%)` |
 | `main` | [`JsMainFunctionExecutionMode`](https://github.com/JetBrains/kotlin/blob/1.8.0/libraries/tools/kotlin-gradle-compiler-types/src/generated/kotlin/org/jetbrains/kotlin/gradle/dsl/JsMainFunctionExecutionMode.kt) | `compilerOptions.main.set(JsMainFunctionExecutionMode.NO_CALL)` |
 | `moduleKind` | [`JsModuleKind`](https://github.com/JetBrains/kotlin/blob/1.8.0/libraries/tools/kotlin-gradle-compiler-types/src/generated/kotlin/org/jetbrains/kotlin/gradle/dsl/JsModuleKind.kt) | `compilerOptions.moduleKind.set(JsModuleKind.MODULE_ES)` |
 | `sourceMapEmbedSources` | [`JsSourceMapEmbedMode`](https://github.com/JetBrains/kotlin/blob/1.8.0/libraries/tools/kotlin-gradle-compiler-types/src/generated/kotlin/org/jetbrains/kotlin/gradle/dsl/JsSourceMapEmbedMode.kt) | `compilerOptions.sourceMapEmbedSources.set(JsSourceMapEmbedMode.SOURCE_MAP_SOURCE_CONTENT_INLINING)` |

--- a/docs/v.list
+++ b/docs/v.list
@@ -30,6 +30,8 @@
 
     <var name="gradleLanguageVersion" value="KOTLIN_2_0" type="string"/>
 
+    <var name="gradleApiVersion" value="KOTLIN_2_0" type="string"/>
+
     <var name="serializationVersion" value="1.5.1" type="string"/>
 
     <var name="defaultJvmTargetVersion" value="1.8" type="string"/>


### PR DESCRIPTION
Similar to #3742, this PR adds `apiVersion` as a variable to make it easier to update in our documentation.