### PR TITLE
Update kotlin-evolution.md to mention Werner Dietl

### DIFF
--- a/docs/topics/kotlin-evolution.md
+++ b/docs/topics/kotlin-evolution.md
@@ -73,7 +73,7 @@ Compilers are complicated software and despite the best effort of their develope
 [JetBrains](https://jetbrains.com), the original creator of Kotlin, is driving its progress with the help of the community and in accord with the [Kotlin Foundation](https://kotlinfoundation.org/).
 
 All changes to the Kotlin Programming Language are overseen by the [Lead Language Designer](https://kotlinfoundation.org/structure/) (currently Roman Elizarov). The Lead Designer has the final say in all matters related to language evolution. Additionally, incompatible changes to fully stable components have to be approved to by the [Language Committee](https://kotlinfoundation.org/structure/) designated 
-under the [Kotlin Foundation](https://kotlinfoundation.org/structure/) (currently comprised of Jeffrey van Gogh, William R. Cook and Roman Elizarov).
+under the [Kotlin Foundation](https://kotlinfoundation.org/structure/) (currently comprised of Jeffrey van Gogh, Werner Dietl, and Roman Elizarov).
 
 The Language Committee makes final decisions on what incompatible changes will be made and what exact measures should be taken to make user updates comfortable. In doing so, it relies on a set of guidelines available [here](https://kotlinfoundation.org/language-committee-guidelines/).
 


### PR DESCRIPTION
Werner Dietl has replaced William Cook in Kotlin Lanauge Committe.