### PR TITLE
Add CLI language version example

### DIFF
--- a/docs/topics/compiler-reference.md
+++ b/docs/topics/compiler-reference.md
@@ -84,7 +84,11 @@ Available plugins and their options are listed in the **Tools > Compiler plugins
   
 ### -language-version _version_
 
-Provide source compatibility with the specified version of Kotlin.
+Provide source compatibility with the specified version of Kotlin. For example:
+
+```bash
+kotlinc -language-version %cliLanguageVersion% -script script.kts
+```
 
 ### -api-version _version_
 

--- a/docs/v.list
+++ b/docs/v.list
@@ -30,6 +30,8 @@
 
     <var name="gradleLanguageVersion" value="KOTLIN_2_0" type="string"/>
 
+    <var name="cliLanguageVersion" value="2.0" type="string"/>
+
     <var name="serializationVersion" value="1.5.1" type="string"/>
 
     <var name="defaultJvmTargetVersion" value="1.8" type="string"/>


### PR DESCRIPTION
Update the compiler options page with a code snippet of how to set the language version. This is groundwork for updates to Kotlin scripting documentation.