### PR TITLE
KTL-1182 Fix 404 on Evernote link on kotlinlang.org main page

### DIFF
--- a/data/testimonials.yml
+++ b/data/testimonials.yml
@@ -5,7 +5,7 @@
   url: https://www.corda.net/2017/01/10/kotlin/
   text: Corda is an open-source distributed ledger platform, supported by major banks, and built entirely in Kotlin
 - company: Evernote
-  url: https://blog.evernote.com/tech/2017/01/26/android-state-library/
+  url: https://evernote.com/blog/android-state-library/
   text: Evernote recently integrated Kotlin into their Android client
 - company: Coursera
   url: https://building.coursera.org/blog/2016/03/16/becoming-bilingual-coursera/


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1182/Fix-404-on-Evernote-link-on-kotlinlang.org-main-page