### PR TITLE
Added note that kotlin serialization plugin does not support v1.9.x

### DIFF
--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-upgrade-app.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-upgrade-app.md
@@ -66,7 +66,7 @@ the existing `plugins` block at the very beginning of the `build.gradle.kts` fil
 ```kotlin
 plugins {
     // ...
-    kotlin("plugin.serialization") version "%kotlinVersion%"
+    kotlin("plugin.serialization") version "%kotlinVersion%" # As of writing, v1.9.x versions are not supported, this should read 1.8.21.
 }
 ```
 


### PR DESCRIPTION
It seems in this case depending upon `%kotlinVersion%` is causing a problem, which as a new Kotlin adopter going through for the first time the "Hello world" guide, having to debug the fact this package doesn't exist for Kotlin `>=1.9.0` is not a great first impression.