### PR TITLE
update: warnings for the new and the legacy memory manager pages

### DIFF
--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-concurrency-and-coroutines.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-concurrency-and-coroutines.md
@@ -3,7 +3,9 @@
 > This page describes the features of the legacy memory manager. Check out [Kotlin/Native memory management](native-memory-manager.md)
 > to learn about the new memory manager, which has been enabled by default since Kotlin 1.7.20.
 >
-{type="note"}
+> For more information on the concurrent programming in Kotlin, see the [Coroutines guide](coroutines-guide.md).
+>
+{type="warning"}
 
 When working with mobile platforms, you may need to write multithreaded code that runs in parallel. For this, 
 you can use the [standard](#coroutines) `kotlinx.coroutines` library or its [multithreaded version](#multithreaded-coroutines) 

--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-concurrency-overview.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-concurrency-overview.md
@@ -3,7 +3,9 @@
 > This page describes the features of the legacy memory manager. Check out [Kotlin/Native memory management](native-memory-manager.md)
 > to learn about the new memory manager, which has been enabled by default since Kotlin 1.7.20.
 >
-{type="note"}
+> For more information on the concurrent programming in Kotlin, see the [Coroutines guide](coroutines-guide.md).
+>
+{type="warning"}
 
 When you extend your development experience from Android to Kotlin Multiplatform for mobile, you will encounter a different state 
 and concurrency model for iOS. This is a Kotlin/Native model that compiles Kotlin code to native binaries that can run without a virtual machine, for example on iOS. 

--- a/docs/topics/multiplatform-mobile/multiplatform-mobile-concurrent-mutability.md
+++ b/docs/topics/multiplatform-mobile/multiplatform-mobile-concurrent-mutability.md
@@ -3,7 +3,9 @@
 > This page describes the features of the legacy memory manager. Check out [Kotlin/Native memory management](native-memory-manager.md)
 > to learn about the new memory manager, which has been enabled by default since Kotlin 1.7.20.
 >
-{type="note"}
+> For more information on the concurrent programming in Kotlin, see the [Coroutines guide](coroutines-guide.md).
+>
+{type="warning"}
 
 When it comes to working with iOS, [Kotlin/Native's state and concurrency model](multiplatform-mobile-concurrency-overview.md) has [two simple rules](multiplatform-mobile-concurrency-overview.md#rules-for-state-sharing).
 

--- a/docs/topics/native/native-immutability.md
+++ b/docs/topics/native/native-immutability.md
@@ -3,7 +3,9 @@
 > This page describes the features of the legacy memory manager. Check out [Kotlin/Native memory management](native-memory-manager.md)
 > to learn about the new memory manager, which has been enabled by default since Kotlin 1.7.20.
 >
-{type="note"}
+> For more information on the concurrent programming in Kotlin, see the [Coroutines guide](coroutines-guide.md).
+>
+{type="warning"}
 
 Kotlin/Native implements strict mutability checks, ensuring
 the important invariant that the object is either immutable or

--- a/docs/topics/native/native-ios-integration.md
+++ b/docs/topics/native/native-ios-integration.md
@@ -1,7 +1,7 @@
 [//]: # (title: iOS integration)
 
 > This page describes the new memory manager enabled by default since Kotlin 1.7.20. See our [migration guide](native-migration-guide.md)
-> to move your projects from the legacy memory manager.
+> to move your projects from the legacy memory manager that will be removed in Kotlin 1.9.20.
 >
 {type="note"}
 

--- a/docs/topics/native/native-memory-manager.md
+++ b/docs/topics/native/native-memory-manager.md
@@ -1,7 +1,7 @@
 [//]: # (title: Kotlin/Native memory management)
 
-> This page describes features of the new memory manager enabled by default since Kotlin 1.7.20.
-> See our [migration guide](native-migration-guide.md) to move your projects from the legacy memory manager.
+> This page describes features of the new memory manager enabled by default since Kotlin 1.7.20. See our [migration guide](native-migration-guide.md)
+> to move your projects from the legacy memory that will be removed in Kotlin 1.9.20.
 >
 {type="note"}
 


### PR DESCRIPTION
* [KT-59547](https://youtrack.jetbrains.com/issue/KT-59547) First result for "Kotlin concurrency" on Google leads to "legacy memory manager" page
* [KT-58582](https://youtrack.jetbrains.com/issue/KT-58582/Web-feedback-from-Kotlin-Native-memory-management-https-kotlinlang.org-docs-native-memory-manager.html)