### PR TITLE
fix: correct typo in js-ir-compiler.md

### DIFF
--- a/docs/topics/js/js-ir-compiler.md
+++ b/docs/topics/js/js-ir-compiler.md
@@ -26,7 +26,7 @@ kotlin {
 * `LEGACY` uses the old compiler backend.
 * `BOTH` compiles your project with the new IR compiler as well as the default compiler backend. Use this mode for [authoring libraries compatible with both backends](#authoring-libraries-for-the-ir-compiler-with-backwards-compatibility).
 
-> The old compiler backend has been deprecated since Kotlin 1.8.0. Starting with Kotlin 1.9.0, using compiler types `LEGACY` of `BOTH` leads to an error.
+> The old compiler backend has been deprecated since Kotlin 1.8.0. Starting with Kotlin 1.9.0, using compiler types `LEGACY` or `BOTH` leads to an error.
 >
 {type="warning"}
 


### PR DESCRIPTION
This PR swaps out "of" for "or" to clarify the details about the deprecated legacy compiler.