### PR TITLE
Add summary sentences for `let` and `run` functionality

### DIFF
--- a/docs/topics/scope-functions.md
+++ b/docs/topics/scope-functions.md
@@ -464,7 +464,7 @@ fun main() {
 
 You can also invoke `run` as a non-extension function. The non-extension variant of `run` has no context object, but it
 still returns the lambda result. Non-extension `run` lets you execute a block of several statements where an expression 
-is required.
+is required. In code, non-extension `run` can be read as "_run the code block and compute the result._"
 
 ```kotlin
 fun main() {


### PR DESCRIPTION
When I was reading the section of Scope functions, [I started to summarize for me to memorize them](https://blog.kotlin-academy.com/kotlin-scope-functions-for-dummies-cb8c8970b8d9). There are good summary sentences about `with`, `apply`, and `also` in the doc. I added summary sentences for `let` and `run`. I hope it's good enough.