### PR TITLE
Update Gradle versions  for 1.9.20

### DIFF
--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -303,11 +303,6 @@ use the `kotlin.experimental.tryK2=true` Gradle property or run the following co
 This Gradle property automatically sets the default language version to 2.0 and updates the [build report](#build-reports)
 with the number of Kotlin tasks compiled using the K2 compiler compared to the current compiler.
 
-> Build reports don't provide information about Kotlin/Native tasks yet. Despite that,
-> we still recommend that you use Kotlin 2.0 as the default version.
-> 
-{type="tip"}
-
 Learn more about the stabilization of the K2 compiler in our [Kotlin blog](https://blog.jetbrains.com/kotlin/2023/02/k2-kotlin-2-0/)
 
 ## Defining Kotlin compiler execution strategy

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -44,14 +44,15 @@ plugins {
 When configuring your project, check the Kotlin Gradle plugin (KGP) compatibility with available Gradle versions. 
 In the following table, there are the minimum and maximum **fully supported** versions of Gradle and Android Gradle plugin (AGP):
 
-| KGP version | Gradle min and max versions             | AGP min and max versions                              |
-|-------------|-----------------------------------------|-------------------------------------------------------|
-| 1.9.0       | %minGradleVersion% – %maxGradleVersion% | %minAndroidGradleVersion% – %maxAndroidGradleVersion% |
-| 1.8.20      | 6.8.3 – 7.6.0                           | 4.1.3 – 7.4.0                                         |      
-| 1.8.0       | 6.8.3 – 7.3.3                           | 4.1.3 – 7.2.1                                         |   
-| 1.7.20      | 6.7.1 – 7.1.1                           | 3.6.4 – 7.0.4                                         |
-| 1.7.0       | 6.7.1 – 7.0.2                           | 3.4.3 – 7.0.2                                         |
-| 1.6.20      | 6.1.1 - 7.0.2                           | 3.4.3 - 7.0.2                                         |
+| KGP version   | Gradle min and max versions           | AGP min and max versions                            |
+|---------------|---------------------------------------|-----------------------------------------------------|
+| 1.9.20        | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 1.9.0–1.9.10  | 6.8.3–7.6.0                           | 4.2.2–7.4.0                                         |
+| 1.8.20–1.8.22 | 6.8.3–7.6.0                           | 4.1.3–7.4.0                                         |      
+| 1.8.0–1.8.11  | 6.8.3–7.3.3                           | 4.1.3–7.2.1                                         |   
+| 1.7.20–1.7.22 | 6.7.1–7.1.1                           | 3.6.4–7.0.4                                         |
+| 1.7.0–1.7.10  | 6.7.1–7.0.2                           | 3.4.3–7.0.2                                         |
+| 1.6.20–1.6.21 | 6.1.1–7.0.2                           | 3.4.3–7.0.2                                         |
 
 > You can also use Gradle and AGP versions up to the latest releases, but if you do, keep in mind that you might encounter 
 > deprecation warnings or some new features might not work.

--- a/docs/topics/gradle/gradle-plugin-variants.md
+++ b/docs/topics/gradle/gradle-plugin-variants.md
@@ -19,9 +19,11 @@ Currently, there are the following variants of the Kotlin Gradle plugin:
 | `gradle70`     | 7.0                           |
 | `gradle71`     | 7.1-7.4                       |
 | `gradle75`     | 7.5                           |
-| `gradle76`     | 7.6 and higher                |
+| `gradle76`     | 7.6                           |
+| `gradle80`     | 8.0                           |
+| `gradle81`     | 8.1.1 and higher              |
 
-In future Kotlin releases, more variants will probably be added.
+In future Kotlin releases, more variants will be added.
 
 To check which variant your build uses, enable
 the [`--info` log level](https://docs.gradle.org/current/userguide/logging.html#sec:choosing_a_log_level) and find a

--- a/docs/v.list
+++ b/docs/v.list
@@ -20,13 +20,13 @@
 
     <var name="minGradleVersion" value="6.8.3" type="string"/>
 
-    <var name="maxGradleVersion" value="7.6.0" type="string"/>
+    <var name="maxGradleVersion" value="8.1.1" type="string"/>
 
     <var name="minAndroidGradleVersion" value="4.2.2" type="string"/>
 
     <var name="maxAndroidGradleVersion" value="7.4.0" type="string"/>
 
-    <var name="gradleVersion" value="7.6" type="string"/>
+    <var name="gradleVersion" value="8.1.1" type="string"/>
 
     <var name="gradleLanguageVersion" value="KOTLIN_2_0" type="string"/>
 


### PR DESCRIPTION
This PR updates Gradle versions for 1.9.20 and removes a tip explaining that Kotlin/Native tasks aren't included in Gradle build reports.