### PR TITLE
fix kotlin tour functions (lambda expressions) documentation

### DIFF
--- a/docs/topics/tour/kotlin-tour-functions.md
+++ b/docs/topics/tour/kotlin-tour-functions.md
@@ -383,7 +383,7 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="kotlin-tour-lambda-map"}
 
-The `.map()` function accepts a lambda expression as a transformer:
+The `.map()` function accepts a lambda expression as a transform function:
 * `{ x -> x * 2 }` takes each element of the list and returns that element multiplied by 2.
 * `{ x -> x * 3 }` takes each element of the list and returns that element multiplied by 3.
 

--- a/docs/topics/tour/kotlin-tour-functions.md
+++ b/docs/topics/tour/kotlin-tour-functions.md
@@ -383,7 +383,7 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="kotlin-tour-lambda-map"}
 
-The `.map()` function accepts a lambda expression as a predicate:
+The `.map()` function accepts a lambda expression as a transformer:
 * `{ x -> x * 2 }` takes each element of the list and returns that element multiplied by 2.
 * `{ x -> x * 3 }` takes each element of the list and returns that element multiplied by 3.
 


### PR DESCRIPTION
fix copy-pasted naming in "kotlin tour > functions > lambda expressions > pass to another function > map()" example

the term "predicate" seems to be copy-pasted from a nearby example of filter() method. 
the suitable term for map() method param is "transformer" I guess