### PR TITLE
Clarify Gradle property location in what's new 1.9.0

### DIFF
--- a/docs/topics/whatsnew19.md
+++ b/docs/topics/whatsnew19.md
@@ -60,8 +60,8 @@ If you encounter any issues when using kapt with the K2 compiler, please report 
 
 ### Try the K2 compiler in your project
 
-Starting with 1.9.0 and until the release of Kotlin 2.0, you can easily test the K2 compiler with the `kotlin.experimental.tryK2=true`
-Gradle property. You can also run the following command:
+Starting with 1.9.0 and until the release of Kotlin 2.0, you can easily test the K2 compiler by adding the `kotlin.experimental.tryK2=true`
+Gradle property to your `gradle.properties` file. You can also run the following command:
 
 ```shell
 ./gradlew assemble -Pkotlin.experimental.tryK2=true


### PR DESCRIPTION
At the moment, it's not explicit where to add the Gradle property that allows users to try K2.