### PR TITLE
Remove nullable boolean "idiom"

### DIFF
--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -330,17 +330,6 @@ stream.buffered().reader().use { reader ->
 inline fun <reified T: Any> Gson.fromJson(json: JsonElement): T = this.fromJson(json, T::class.java)
 ```
 
-## Nullable Boolean
-
-```kotlin
-val b: Boolean? = ...
-if (b == true) {
-    ...
-} else {
-    // `b` is false or null
-}
-```
-
 ## Swap two variables
 
 ```kotlin


### PR DESCRIPTION
Open for discussion here @JetBrains/kotlin-technical-writing – I don't understand the original motivation for adding this as a Kotlin "idiom", seeing how this seems like an instance of the [tri-state boolean](https://thoughtbot.com/blog/avoid-the-threestate-boolean-problem) problem.

If there is a reason as to why we're highlighting this as an idiom, I'd appreciate a short explanation – otherwise, it's probably better if it is removed.