### PR TITLE
Make it more obvious that you can use IDEs besides IntelliJ

### DIFF
--- a/docs/topics/getting-started.md
+++ b/docs/topics/getting-started.md
@@ -12,6 +12,10 @@ To start, why not take our tour of Kotlin? This tour covers the fundamentals of 
 Kotlin is included in each [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) and [Android Studio](https://developer.android.com/studio) release.
 Download and install one of these IDEs to start using Kotlin.
 
+> Want to use a different IDE? Take a look at [this page](https://kotlinlang.org/docs/kotlin-ide.html#other-ides-support) for more info.
+>
+{type="note"}
+
 ## Create your powerful application with Kotlin
  
 <tabs>


### PR DESCRIPTION
Currently, the docs don't really make it obvious that IDEs besides IntelliJ can be used to develop with Kotlin. This PR adds a note to the Getting Started page with a link to the page with info on using other IDEs.