### PR TITLE
fix: target specification for macOS-specific `compilerOpts`

### DIFF
--- a/docs/topics/native/native-c-interop.md
+++ b/docs/topics/native/native-c-interop.md
@@ -165,7 +165,7 @@ Target-specific options only applicable to the certain target can be specified a
 ```c
  compilerOpts = -DBAR=bar
  compilerOpts.linux_x64 = -DFOO=foo1
- compilerOpts.mac_x64 = -DFOO=foo2
+ compilerOpts.macos_x64 = -DFOO=foo2
  ```
 
 With such a configuration, C headers will be analyzed with `-DBAR=bar -DFOO=foo1` on Linux and


### PR DESCRIPTION
[This section](https://kotlinlang.org/docs/native-c-interop.html#c-compiler-and-linker-options) in the documentation on Kotlin Native C Interop says that compiler (and linker) options can be defined in a platform-specific way.

However, the example given suggests the use of `compilerOpts.mac_x64`. This does not work.
[These lines in KonanTarget](https://github.com/JetBrains/kotlin/blob/90102ad8b77a393a1367d747bf97b895b18d78f0/native/utils/src/org/jetbrains/kotlin/konan/target/KonanTarget.kt#L31C1-L32) suggest it should be `compilerOpts.macos_x64`; and this does work.