### PR TITLE
chore: update core api reference docs (1.9.20)

### DIFF
--- a/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
+++ b/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
@@ -179,7 +179,7 @@ object BuildSitePages : BuildType({
       }
     }
 
-    artifacts(AbsoluteId("Kotlin_KotlinRelease_190_LibraryReferenceLegacyDocs")) {
+    artifacts(AbsoluteId("Kotlin_KotlinRelease_1920_LibraryReferenceLegacyDocs")) {
       buildRule = tag("publish", """
                 +:<default>
                 +:*


### PR DESCRIPTION
use core api reference docs built with legacy Dokka from 1.9.20 project