### PR TITLE
fix: include print statement in object expression example

### DIFF
--- a/docs/topics/object-declarations.md
+++ b/docs/topics/object-declarations.md
@@ -26,8 +26,8 @@ fun main() {
         // object expressions extend Any, so `override` is required on `toString()`
         override fun toString() = "$hello $world"
     }
-//sampleEnd
     print(helloWorld)
+//sampleEnd
 }
 ```
 {kotlin-runnable="true"}

--- a/docs/topics/object-declarations.md
+++ b/docs/topics/object-declarations.md
@@ -26,6 +26,7 @@ fun main() {
         // object expressions extend Any, so `override` is required on `toString()`
         override fun toString() = "$hello $world"
     }
+
     print(helloWorld)
 //sampleEnd
 }


### PR DESCRIPTION
The `print(helloWorld)` line should be visible on the docs page, otherwise one could only guess why "Hello World" is printed when running the example code.

[See example](https://kotlinlang.org/docs/object-declarations.html#creating-anonymous-objects-from-scratch).