### PR TITLE
Remove obsolete mapping

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -7,6 +7,5 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/kotlinx.coroutines" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
I consulted with @konstantin.chernenko: IDEA complains about this line, which points to a directory that no longer exists.