### PR TITLE
Kotlin/Wasm: adding new page for troubleshooting

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -229,6 +229,7 @@
             <toc-element id="wasm-get-started.md"/>
             <toc-element id="wasm-libraries.md" toc-title="Add dependencies on Kotlin libraries"/>
             <toc-element id="wasm-js-interop.md"/>
+            <toc-element id="wasm-troubleshooting.md"/>
         </toc-element>
 
         <toc-element toc-title="JavaScript">

--- a/docs/topics/wasm/wasm-get-started.md
+++ b/docs/topics/wasm/wasm-get-started.md
@@ -41,45 +41,6 @@ This tutorial demonstrates how to work with a Kotlin/Wasm application in Intelli
 
    ![Run the Kotlin/Wasm application](wasm-app-run.png){width=650}
 
-### Troubleshooting
-
-Despite the fact that most of the browsers support WebAssembly, you need to update the settings in your browser.
-
-To run a Kotlin/Wasm project, you need to update the settings of the target environment:
-
-<tabs>
-<tab title="Chrome">
-
-* For version 109:
-
-  Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
-
-* For version 110 or later:
-
-   1. Go to `chrome://flags/#enable-webassembly-garbage-collection` in your browser.
-   2. Enable **WebAssembly Garbage Collection**.
-   3. Relaunch your browser.
-
-</tab>
-<tab title="Firefox">
-
-For version 109 or later:
-
-1. Go to `about:config` in your browser.
-2. Enable `javascript.options.wasm_function_references` and `javascript.options.wasm_gc` options.
-3. Relaunch your browser.
-
-</tab>
-<tab title="Edge">
-
-For version 109 or later:
-
-Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
-
-</tab>
-</tabs>
-
-
 ## Update your application
 
 1. Open `Simple.kt` and update the code:

--- a/docs/topics/wasm/wasm-overview.md
+++ b/docs/topics/wasm/wasm-overview.md
@@ -22,7 +22,7 @@ With Kotlin/Wasm, you can create applications that run on different environments
 
 To run applications built with Kotlin/Wasm in a browser, you need a version supporting the new [garbage collection feature](https://github.com/WebAssembly/gc).
 
-[Learn more in Get started with Kotlin/Wasm](wasm-get-started.md#troubleshooting).
+[Learn more in Browser versions](wasm-troubleshooting.md).
 
 ## Interoperability
 

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -14,11 +14,11 @@ the new WasmGC by default or if you need to make changes to the environment.
 
 ### Chrome 
 
-* For version 119 or later:
+* *For version 119 or later:*
 
   Works by default.
 
-* For older versions:
+* *For older versions:*
 
   1. In your browser, go to `chrome://flags/#enable-webassembly-garbage-collection`.
   2. Enable **WebAssembly Garbage Collection**.
@@ -30,11 +30,11 @@ the new WasmGC by default or if you need to make changes to the environment.
 
 Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Internet.
 
-* For version 119 or later:
+* *For version 119 or later:*
 
   Works by default.
 
-* For older versions:
+* *For older versions:*
 
   Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
 
@@ -42,11 +42,11 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 
 ### Firefox
 
-* For version 120 or later:
+* *For version 120 or later:*
 
   Works by default.
 
-* For version 119:
+* *For version 119:*
 
   1. In your browser, go to `about:config`.
   2. Enable `javascript.options.wasm_gc` option.

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -1,16 +1,16 @@
 [//]: # (title: Troubleshooting)
 
 Kotlin/Wasm relies on new [WebAssembly proposals](https://webassembly.org/roadmap/) like garbage collection and 
-exception handling. These proposals introduce improvements and new features within WebAssembly. 
+exception handling to introduce improvements and new features within WebAssembly. 
 
-However, to ensure proper execution and utilization of these features, you require an environment that supports the new proposals. 
-In some cases, you might need to set up the environment to make it compatible with the proposals.
+However, to ensure these features work properly, you need an environment that supports the new proposals. 
+In some cases, you may need to set up the environment to make it compatible with the proposals.
 
 ## Browser versions
 
 To run applications built with Kotlin/Wasm in a browser, you need a browser version supporting the new 
 [WebAssembly garbage collection (WasmGC) feature](https://github.com/WebAssembly/gc). Check if the browser version supports 
-the new WasmGC by default or if you need to set the environment up.
+the new WasmGC by default or if you need to make changes to the environment.
 
 ### Chrome 
 
@@ -20,11 +20,11 @@ the new WasmGC by default or if you need to set the environment up.
 
 * For older versions:
 
-  1. Go to `chrome://flags/#enable-webassembly-garbage-collection` in your browser.
+  1. In your browser, go to `chrome://flags/#enable-webassembly-garbage-collection`.
   2. Enable **WebAssembly Garbage Collection**.
   3. Relaunch your browser.
 
-  Besides updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
+  In addition to updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
 
 ### Chromium-based
 
@@ -38,7 +38,7 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 
   Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
 
-  Besides updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
+  In addition to updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
 
 ### Firefox
 
@@ -48,16 +48,16 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 
 * For version 119:
 
-  1. Go to `about:config` in your browser.
+  1. In your browser, go to `about:config`.
   2. Enable `javascript.options.wasm_gc` option.
   3. Refresh the page.
 
 ### Safari/WebKit
 
-For Safari and WebKit, the WebAssembly garbage collection support is currently under
+WebAssembly garbage collection support is currently under
 [active development](https://bugs.webkit.org/show_bug.cgi?id=247394).
 
-> Learn more about setting up projects, using dependencies, and other tasks with the 
+> Learn more about setting up projects, using dependencies, and other tasks with our 
 > [Kotlin/Wasm examples](https://github.com/Kotlin/kotlin-wasm-examples#readme).
 >
 {type="tip"}

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -57,7 +57,7 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 WebAssembly garbage collection support is currently under
 [active development](https://bugs.webkit.org/show_bug.cgi?id=247394).
 
-
+<p>&nbsp;</p>
 
 > Learn more about setting up projects, using dependencies, and other tasks with our 
 > [Kotlin/Wasm examples](https://github.com/Kotlin/kotlin-wasm-examples#readme).

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -1,0 +1,48 @@
+[//]: # (title: Troubleshooting)
+
+Most of the browsers support WebAssembly. For recent browser versions, WebAssembly works by default. However,
+for older browser versions, you still need to update the browser settings.
+
+To run a Kotlin/Wasm project, check if you need to update the settings of the target environment:
+
+<tabs>
+<tab title="Chrome">
+
+* For version 119 or later:
+  
+  It works by default.
+
+* For older versions:
+
+    1. Go to `chrome://flags/#enable-webassembly-garbage-collection` in your browser.
+    2. Enable **WebAssembly Garbage Collection**.
+    3. Relaunch your browser.
+
+</tab>
+<tab title="Firefox">
+
+* For version 120 or later:
+  
+  It works by default.
+
+* For version 119:
+
+  1. Go to `about:config` in your browser.
+  2. Enable `javascript.options.wasm_gc` option.
+  3. Relaunch your browser.
+
+</tab>
+<tab title="Edge">
+
+* For version 119 or later:
+
+  It works by default.
+
+* For older versions:
+
+  Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
+
+</tab>
+</tabs>
+
+For more information about running a Kotlin/Wasm project, see the [Kotlin/Wasm examples.](https://github.com/Kotlin/kotlin-wasm-examples#readme) 

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -1,7 +1,7 @@
 [//]: # (title: Troubleshooting)
 
-Kotlin/Wasm relies on new [WebAssembly proposals](https://github.com/WebAssembly/proposals) like garbage collection, 
-exception handling, and typed function references. These proposals introduce improvements and new features within WebAssembly. 
+Kotlin/Wasm relies on new [WebAssembly proposals](https://webassembly.org/roadmap/) like garbage collection and 
+exception handling. These proposals introduce improvements and new features within WebAssembly. 
 
 However, to ensure proper execution and utilization of these features, you require an environment that supports the new proposals. 
 In some cases, you might need to set up the environment to make it compatible with the proposals.

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -24,7 +24,7 @@ the new WasmGC by default or if you need to make changes to the environment.
   2. Enable **WebAssembly Garbage Collection**.
   3. Relaunch your browser.
 
-  In addition to updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
+  In addition to updating the browser settings, make sure you use a Kotlin version before 1.9.20.
 
 ### Chromium-based
 
@@ -38,7 +38,7 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 
   Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
 
-  In addition to updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
+  In addition to updating the browser settings, make sure you use a Kotlin version before 1.9.20.
 
 ### Firefox
 
@@ -56,6 +56,8 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 
 WebAssembly garbage collection support is currently under
 [active development](https://bugs.webkit.org/show_bug.cgi?id=247394).
+
+
 
 > Learn more about setting up projects, using dependencies, and other tasks with our 
 > [Kotlin/Wasm examples](https://github.com/Kotlin/kotlin-wasm-examples#readme).

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -3,14 +3,17 @@
 Most of the browsers support WebAssembly. For recent browser versions, WebAssembly works by default. However,
 for older browser versions, you still need to update the browser settings.
 
-To run a Kotlin/Wasm project, check if you need to update the settings of the target environment:
+## Browser versions
+
+To run a Kotlin/Wasm project, check if WebAssembly works with the browser version by default. Otherwise, update the 
+settings of the target environment:
 
 <tabs>
 <tab title="Chrome">
 
 * For version 119 or later:
-  
-  It works by default.
+
+  WebAssembly works by default.
 
 * For older versions:
 
@@ -18,12 +21,27 @@ To run a Kotlin/Wasm project, check if you need to update the settings of the ta
     2. Enable **WebAssembly Garbage Collection**.
     3. Relaunch your browser.
 
+  Besides updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
+
+</tab>
+<tab title="Chromium-based">
+
+Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Internet.
+
+* For version 119 or later:
+
+  WebAssembly works by default.
+
+* For older versions:
+
+  Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
+
 </tab>
 <tab title="Firefox">
 
 * For version 120 or later:
-  
-  It works by default.
+
+  WebAssembly works by default.
 
 * For version 119:
 
@@ -32,15 +50,10 @@ To run a Kotlin/Wasm project, check if you need to update the settings of the ta
   3. Relaunch your browser.
 
 </tab>
-<tab title="Edge">
+<tab title="Safari/WebKit">
 
-* For version 119 or later:
-
-  It works by default.
-
-* For older versions:
-
-  Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
+For Safari and WebKit, the WebAssembly garbage collection (WasmGC) support is currently under 
+[active development](https://bugs.webkit.org/show_bug.cgi?id=247394).
 
 </tab>
 </tabs>

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -1,61 +1,63 @@
 [//]: # (title: Troubleshooting)
 
-Most of the browsers support WebAssembly. For recent browser versions, WebAssembly works by default. However,
-for older browser versions, you still need to update the browser settings.
+Kotlin/Wasm relies on new [WebAssembly proposals](https://github.com/WebAssembly/proposals) like garbage collection, 
+exception handling, and typed function references. These proposals introduce improvements and new features within WebAssembly. 
+
+However, to ensure proper execution and utilization of these features, you require an environment that supports the new proposals. 
+In some cases, you might need to set up the environment to make it compatible with the proposals.
 
 ## Browser versions
 
-To run a Kotlin/Wasm project, check if WebAssembly works with the browser version by default. Otherwise, update the 
-settings of the target environment:
+To run applications built with Kotlin/Wasm in a browser, you need a browser version supporting the new 
+[WebAssembly garbage collection (WasmGC) feature](https://github.com/WebAssembly/gc). Check if the browser version supports 
+the new WasmGC by default or if you need to set the environment up.
 
-<tabs>
-<tab title="Chrome">
+### Chrome 
 
 * For version 119 or later:
 
-  WebAssembly works by default.
+  Works by default.
 
 * For older versions:
 
-    1. Go to `chrome://flags/#enable-webassembly-garbage-collection` in your browser.
-    2. Enable **WebAssembly Garbage Collection**.
-    3. Relaunch your browser.
+  1. Go to `chrome://flags/#enable-webassembly-garbage-collection` in your browser.
+  2. Enable **WebAssembly Garbage Collection**.
+  3. Relaunch your browser.
 
   Besides updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
 
-</tab>
-<tab title="Chromium-based">
+### Chromium-based
 
 Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Internet.
 
 * For version 119 or later:
 
-  WebAssembly works by default.
+  Works by default.
 
 * For older versions:
 
   Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
 
-</tab>
-<tab title="Firefox">
+  Besides updating the browser settings, make sure you use the Kotlin toolchain before 1.9.20.
+
+### Firefox
 
 * For version 120 or later:
 
-  WebAssembly works by default.
+  Works by default.
 
 * For version 119:
 
   1. Go to `about:config` in your browser.
   2. Enable `javascript.options.wasm_gc` option.
-  3. Relaunch your browser.
+  3. Refresh the page.
 
-</tab>
-<tab title="Safari/WebKit">
+### Safari/WebKit
 
-For Safari and WebKit, the WebAssembly garbage collection (WasmGC) support is currently under 
+For Safari and WebKit, the WebAssembly garbage collection support is currently under
 [active development](https://bugs.webkit.org/show_bug.cgi?id=247394).
 
-</tab>
-</tabs>
-
-For more information about running a Kotlin/Wasm project, see the [Kotlin/Wasm examples.](https://github.com/Kotlin/kotlin-wasm-examples#readme) 
+> Learn more about setting up projects, using dependencies, and other tasks with the 
+> [Kotlin/Wasm examples](https://github.com/Kotlin/kotlin-wasm-examples#readme).
+>
+{type="tip"}

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -14,11 +14,11 @@ the new WasmGC by default or if you need to make changes to the environment.
 
 ### Chrome 
 
-* *For version 119 or later:*
+* **For version 119 or later:**
 
   Works by default.
 
-* *For older versions:*
+* **For older versions:**
 
   1. In your browser, go to `chrome://flags/#enable-webassembly-garbage-collection`.
   2. Enable **WebAssembly Garbage Collection**.
@@ -30,11 +30,11 @@ the new WasmGC by default or if you need to make changes to the environment.
 
 Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Internet.
 
-* *For version 119 or later:*
+* **For version 119 or later:**
 
   Works by default.
 
-* *For older versions:*
+* **For older versions:**
 
   Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
 
@@ -42,11 +42,11 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 
 ### Firefox
 
-* *For version 120 or later:*
+* **For version 120 or later:**
 
   Works by default.
 
-* *For version 119:*
+* **For version 119:**
 
   1. In your browser, go to `about:config`.
   2. Enable `javascript.options.wasm_gc` option.

--- a/docs/topics/whatsnew19.md
+++ b/docs/topics/whatsnew19.md
@@ -564,7 +564,7 @@ You can write, run, and share your Kotlin code that targets the Kotlin/Wasm. [Ch
 
 > Using Kotlin/Wasm requires enabling experimental features in your browser.
 >
-> [Learn more about how to enable these features](wasm-get-started.md#troubleshooting).
+> [Learn more about how to enable these features](wasm-troubleshooting.md).
 >
 {type="note"}
 

--- a/docs/topics/whatsnew1920.md
+++ b/docs/topics/whatsnew1920.md
@@ -717,7 +717,7 @@ Wasm GC moves to the final phase and it requires updates of opcodes – constant
 Kotlin 1.9.20 supports the latest opcodes, so we strongly recommend that you update your Wasm projects to the latest version of Kotlin.
 We also recommend using the latest versions of browsers with the Wasm environment:
 * Version 119 or newer for Chrome and Chromium–based browsers.
-* Version 119 or newer for Firefox. Note that in Firefox 119, you need to [turn on Wasm GC manually](wasm-get-started.md#troubleshooting).
+* Version 119 or newer for Firefox. Note that in Firefox 119, you need to [turn on Wasm GC manually](wasm-troubleshooting.md).
 
 ### New `wasm-wasi` target, and the renaming of the `wasm` target to `wasm-js`
 


### PR DESCRIPTION
created a new page for troubleshooting, updated content, and removed troubleshooting content from getting started.