### PR TITLE
Add notes about the Kotlin plugin being included in new IDE releases

### DIFF
--- a/docs/topics/install-eap-plugin.md
+++ b/docs/topics/install-eap-plugin.md
@@ -5,6 +5,11 @@
     <p><a href="eap.md#build-details">Explore Kotlin EAP release details</a></p>
 </microformat>
 
+> Starting from IntelliJ IDEA 2023.3 and Android Studio Iguana (2023.2.1) Canary 15, the Kotlin plugin doesn't need to be
+> configured separately. All you need to do is [change the Kotlin version](configure-build-for-eap.md) in your build scripts.
+> 
+{type="note"}
+
 You can follow these instructions to install the preview version of the Kotlin Plugin for IntelliJ IDEA or Android Studio.
 
 1. Select **Tools** | **Kotlin** | **Configure Kotlin Plugin Updates**. 

--- a/docs/topics/jvm/jvm-get-started.md
+++ b/docs/topics/jvm/jvm-get-started.md
@@ -55,12 +55,6 @@ To get started, first download and install the latest version of [IntelliJ IDEA]
 2. Modify the code so that it requests your name and says `Hello` to you alone, and not to the whole world:
    
    * Introduce a local variable `name` with the keyword `val`. It will get its value from an input where you will enter your name – [`readln()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/readln.html).
-     
-     > The readln() function is available since [Kotlin 1.6.0](whatsnew16.md#new-readline-functions).  
-     > Ensure that you have installed the latest version of the [Kotlin plugin](releases.md).
-     > 
-     {type="note"}
-
    * Use a string template by adding a dollar sign `$` before this variable name directly in the text output like this – `$name`.
    
    ```kotlin

--- a/docs/topics/releases.md
+++ b/docs/topics/releases.md
@@ -17,6 +17,11 @@ Learn more about [types of Kotlin releases and their compatibility](kotlin-evolu
 
 ## Update to a new release
 
+> Starting from IntelliJ IDEA 2023.3 and Android Studio Iguana (2023.2.1) Canary 15, the Kotlin plugin is automatically
+> updated. All you need to do is update the Kotlin version in your projects.
+>
+{type="note"}
+
 IntelliJ IDEA and Android Studio suggest updating to a new release once it is out. When you accept the suggestion,
 it automatically updates the Kotlin plugin to the new version. You can check the Kotlin version in **Tools** | **Kotlin**
 | **Configure Kotlin Plugin Updates**.

--- a/docs/topics/whatsnew1920.md
+++ b/docs/topics/whatsnew1920.md
@@ -20,12 +20,15 @@ You can also find a short overview of the updates in this video:
 
 The Kotlin plugins that support 1.9.20 are available for:
 
-| IDE            | Supported versions                      |
-|----------------|-----------------------------------------|
-| IntelliJ IDEA  | 2023.1.x, 2023.2.x                      |
-| Android Studio | Hedgehog (2023.1.1)*, Iguana (2023.2.1) |
+| IDE            | Supported versions                     |
+|----------------|----------------------------------------|
+| IntelliJ IDEA  | 2023.1.x, 2023.2.x, 2023.x             |
+| Android Studio | Hedgehog (2023.1.1), Iguana (2023.2.1) |
 
-\* The Kotlin 1.9.20 plugin will be included with Android Studio Hedgehog (231) and Iguana (232) in their upcoming releases.
+> Starting from IntelliJ IDEA 2023.3.x and Android Studio Iguana (2023.2.1) Canary 15, the Kotlin plugin is automatically
+> included and updated. All you need to do is update the Kotlin version in your projects.
+>
+{type="note"}
 
 ## New Kotlin K2 compiler updates
 


### PR DESCRIPTION
This PR adds notes to relevant pages explaining that users of new IntelliJ and Android Studio versions don't have to configure the Kotlin plugin separately anymore.