### PR TITLE
Kotlin 2.0.0-Beta2 release

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -35,7 +35,7 @@
     <toc-element toc-title="What's new in Kotlin">
         <toc-element id="whatsnew1920.md" toc-title="Kotlin 1.9.20" accepts-web-file-names="whatsnew.html"/>
         <toc-element id="whatsnew19.md" toc-title="Kotlin 1.9.0"/>
-        <toc-element id="whatsnew-eap.md" toc-title="Kotlin 2.0.0-Beta1"/>
+        <toc-element id="whatsnew-eap.md" toc-title="Kotlin 2.0.0-Beta2"/>
         <toc-element toc-title="Earlier versions">
             <toc-element id="whatsnew1820.md" toc-title="Kotlin 1.8.20"/>
             <toc-element id="whatsnew18.md" toc-title="Kotlin 1.8.0"/>

--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -42,13 +42,13 @@ check [our instructions on how to configure your build to support this version](
         <th>Build highlights</th>
     </tr>
     <tr>
-        <td><strong>2.0.0-Beta1</strong>
-            <p>Released: <strong>November 15, 2023</strong></p>
-            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta1" target="_blank">Release on GitHub</a></p>
+        <td><strong>2.0.0-Beta2</strong>
+            <p>Released: <strong>December 15, 2023</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta2" target="_blank">Release on GitHub</a></p>
         </td>
         <td>
             <p>A stabilization release for the Kotlin K2 compiler.</p>
-            <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta1">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.0.0-Beta1</a>.</p>
+            <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta2">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.0.0-Beta2</a>.</p>
         </td>
     </tr>
 </table>

--- a/docs/topics/whatsnew-eap.md
+++ b/docs/topics/whatsnew-eap.md
@@ -9,14 +9,13 @@ _[Released: %kotlinEapReleaseDate%](eap.md#build-details)_
 >
 {type="note"}
 
-The Kotlin %kotlinEapVersion% release is out! 
-It mostly covers stabilization of the new Kotlin K2 compiler, 
-which reached its **Beta** status for all targets since 1.9.20.
+The Kotlin %kotlinEapVersion% release is out! It mostly covers stabilization of the [new Kotlin K2 compiler](#kotlin-k2-compiler),
+which reached its Beta status for all targets since 1.9.20. In addition, there is a change in the way that the [Kotlin Gradle plugin stores Kotlin data](#new-directory-for-kotlin-data-in-gradle-projects).
 
 ## IDE support
 
 The Kotlin plugins that support %kotlinEapVersion% are bundled in the latest IntelliJ IDEA and Android Studio. 
-You don’t need to update the Kotlin plugin in your IDE. 
+You don't need to update the Kotlin plugin in your IDE. 
 All you need to do is to [change the Kotlin version](configure-build-for-eap.md) to %kotlinEapVersion% in your build scripts.
 
 ## Kotlin K2 compiler
@@ -28,20 +27,6 @@ unify all platforms that Kotlin supports, and provide a better architecture for 
 The K2 compiler is in [Beta](components-stability.md) for all target platforms: JVM, Native, Wasm, and JS.
 The JetBrains team has ensured the quality of the new compiler by successfully compiling dozens of user and internal projects.
 A large number of users are also involved in the stabilization process, trying the new K2 compiler in their projects and reporting any problems they find.
-
-## What to expect from upcoming Kotlin EAP releases
-
-The upcoming 2.0.0-Beta2 and 2.0.0-Beta3 releases will introduce increased stability to the K2 compiler.
-If you are currently using K2 in your project, 
-we encourage you to stay updated on Kotlin releases and experiment with the updated K2 compiler. 
-[Share your feedback on using Kotlin K2](#leave-your-feedback-on-the-new-k2-compiler).
-
-> Despite the fact that the Kotlin K2 compiler is in Beta for all targets, it is not recommended to use it in production.
-> This is due to K2 binaries poisoning: we need to ensure that code compiled with different versions of Kotlin maintains binary compatibility with K2 binaries.
-> 
-> You can start using the K2 compiler in production starting from **Kotlin 2.0.0-RC1**.
->
-{type="warning"}
 
 ## Current K2 compiler limitations
 
@@ -64,6 +49,10 @@ If you encounter any of the problems mentioned above, you can take the following
        }
    }
    ```
+  > If you configure language and API versions for specific tasks, these values will override the values set by the `compilerOptions` extension. 
+  > In this case, language and API versions should not be higher than 1.9.
+  >
+  {type="note"}
 
 * Update the Gradle version in your project to 8.3 when it becomes available.
 
@@ -88,7 +77,7 @@ Currently, the Kotlin K2 compiler supports the following plugins:
 
 ## How to enable the Kotlin K2 compiler
 
-Starting with Kotlin 2.0.0-Beta1, the Kotlin K2 compiler is enabled by default. 
+Starting with Kotlin 2.0.0-Beta1, the Kotlin K2 compiler is enabled by default.
 No additional actions are required.
 
 ## Leave your feedback on the new K2 compiler
@@ -102,11 +91,45 @@ We would appreciate any feedback you may have!
   on [our issue tracker](https://kotl.in/issue).
 * [Enable the **Send usage statistics** option](https://www.jetbrains.com/help/idea/settings-usage-statistics.html) to
   allow JetBrains to collect anonymous data about K2 usage.
+* 
+## New directory for Kotlin data in Gradle projects
+
+> With this change, you may need to add the `.kotlin` directory to your project's `.gitignore` file.
+>
+{type="warning"}
+
+In Kotlin 1.8.20, the Kotlin Gradle plugin started to store its data in the Gradle project cache directory: `<project-root-directory>/.gradle/kotlin`.
+However, the `.gradle` directory is reserved for Gradle only, and as a result it's not future-proof. To solve this, in 
+Kotlin 2.0.0-Beta2 we store Kotlin data in your `<project-root-directory>/.kotlin` by default. We will continue to store
+some data in `.gradle/kotlin` directory for backward compatibility.
+
+There are new Gradle properties so that you can configure a directory of your choice and more:
+
+| Gradle property                                     | Description                                                                                                      |
+|-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `kotlin.project.persistent.dir`                     | Configures the location where your project-level data is stored. Default: `<project-root-directory>/.kotlin`     |
+| `kotlin.project.persistent.dir.gradle.disableWrite` | A boolean value that controls whether writing Kotlin data to the `.gradle` directory is disabled. Default: false |
+
+Add these properties to the `gradle.properties` file in your projects for them to take effect.
+
+## What to expect from upcoming Kotlin EAP releases
+
+The upcoming 2.0.0-Beta3 release will increase stability of the K2 compiler.
+If you are currently using K2 in your project, 
+we encourage you to stay updated on Kotlin releases and experiment with the updated K2 compiler. 
+[Share your feedback on using Kotlin K2](#leave-your-feedback-on-the-new-k2-compiler).
+
+> Despite the fact that the Kotlin K2 compiler is in Beta for all targets, it is not recommended to use it in production.
+> This is due to K2 binaries poisoning: we need to ensure that code compiled with different versions of Kotlin maintains binary compatibility with K2 binaries.
+> 
+> You can start using the K2 compiler in production starting from **Kotlin 2.0.0-RC1**.
+>
+{type="warning"}
 
 ## How to update to Kotlin %kotlinEapVersion%
 
 Starting from Kotlin 2.0.0-Beta1, the IntelliJ Kotlin plugin is distributed as a bundled plugin only.
-This means that you can’t install the plugin from JetBrains Marketplace anymore.
+This means that you can't install the plugin from JetBrains Marketplace anymore.
 With this change you will receive more frequent updates, ensuring that the latest stable IntelliJ IDEA and Android Studio versions consistently support the Kotlin versions that are released.
 The bundled plugin supports upcoming Kotlin EAP releases.
 

--- a/docs/v.list
+++ b/docs/v.list
@@ -6,13 +6,13 @@
 
     <var name="kotlinVersion" value="1.9.21" type="string"/>
 
-    <var name="kotlinEapVersion" value="2.0.0-Beta1" type="string"/>
+    <var name="kotlinEapVersion" value="2.0.0-Beta2" type="string"/>
 
     <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v1.9.21" type="string"/>
 
     <var name="kotlinReleaseDate" value="November 23, 2023" type="string"/>
 
-    <var name="kotlinEapReleaseDate" value="November 15, 2023" type="string"/>
+    <var name="kotlinEapReleaseDate" value="December 15, 2023" type="string"/>
 
     <var name="coroutinesVersion" value="1.7.3" type="string"/>
 


### PR DESCRIPTION
This PR adds details about the Kotlin 2.0.0-Beta2 release.