### PR TITLE
fix: clarity in the tip for the specific source set

### DIFF
--- a/docs/topics/multiplatform/multiplatform-add-dependencies.md
+++ b/docs/topics/multiplatform/multiplatform-add-dependencies.md
@@ -205,7 +205,7 @@ kotlin {
 If you want to use a multiplatform library just for specific source sets, you can add it exclusively to them. The
 specified library declarations will then be available only in those source sets.
 
-> Don't use a platform-specific name in such cases, like SQLDelight `native-driver` in the example below. Find the exact name in the library's documentation.
+> Use a general library name in such cases, not a platform-specific one. Like with SQLDelight in the example below, use `native-driver`, not `native-driver-iosx64` or other iOS versions. Find the exact name in the library's documentation.
 >
 {type="note"}
 

--- a/docs/topics/multiplatform/multiplatform-add-dependencies.md
+++ b/docs/topics/multiplatform/multiplatform-add-dependencies.md
@@ -205,7 +205,7 @@ kotlin {
 If you want to use a multiplatform library just for specific source sets, you can add it exclusively to them. The
 specified library declarations will then be available only in those source sets.
 
-> Use a general library name in such cases, not a platform-specific one. Like with SQLDelight in the example below, use `native-driver`, not `native-driver-iosx64` or other iOS versions. Find the exact name in the library's documentation.
+> Use a common library name in such cases, not a platform-specific one. Like with SQLDelight in the example below, use `native-driver`, not `native-driver-iosx64`. Find the exact name in the library's documentation.
 >
 {type="note"}
 


### PR DESCRIPTION
I was trying to understand what exactly I was supposed to do: don't use the name like it's used in the example, or don't use the name like it's not used in the example.

I think I get it now, so I tried to clarify this.