### PR TITLE
Fix warning about non-matching annotations in code example

### DIFF
--- a/docs/topics/multiplatform/multiplatform-expect-actual.md
+++ b/docs/topics/multiplatform/multiplatform-expect-actual.md
@@ -524,7 +524,7 @@ annotation, which must have a corresponding actual declaration in each platform 
 
 ```kotlin
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 expect annotation class XmlSerializable()
 
 @XmlSerializable
@@ -552,7 +552,7 @@ Take the `@XmlSerializable` annotation declared above and add `OptionalExpectati
 ```kotlin
 @OptIn(ExperimentalMultiplatform::class)
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 @OptionalExpectation
 expect annotation class XmlSerializable()
 ```


### PR DESCRIPTION
This code was reporting a warning 
> Annotation `@Retention(value = AnnotationRetention.SOURCE)` has different arguments on actual declaration: `@Retention(value = AnnotationRetention.RUNTIME)` ...
> All annotations from expect `annotation class XmlSerializable : Annotation defined in com.example in file Main.common.kt` must be present with the same arguments on actual `annotation class XmlRootElement : Annotation defined in javax.xml.bind.annotation in file XmlRootElement.class`, otherwise they might behave incorrectly.

The proper fix is to set Retention to RUNTIME on expect declaration.