### PR TITLE
fix: clear up the example of usefulness of invariant generics

### DIFF
--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -39,9 +39,17 @@ compiled but caused an exception at runtime:
 ```java
 // Java
 List<String> strs = new ArrayList<String>();
-List<Object> objs = strs; // Java reports a type mismatch here at compile-time, but what if it didn't?
-objs.add(1); // We would be able to put an Integer into a list of Strings
-String s = strs.get(0); // And then at runtime, Java would throw a ClassCastException: Integer cannot be cast to String
+
+// Java reports a type mismatch here at compile-time.
+List<Object> objs = strs;
+
+// What if it didn't?
+// We would be able to put an Integer into a list of Strings.
+objs.add(1);
+
+// And then at runtime, Java would throw
+// a ClassCastException: Integer cannot be cast to String
+String s = strs.get(0); 
 ```
 
 Java prohibits such things to guarantee runtime safety. But this has implications. For example,
@@ -97,9 +105,9 @@ you don't get a `String`, but rather an `Object`.
 
 Joshua Bloch gives the name _Producers_ to objects you only _read from_ and _Consumers_ to those you only _write to_. He recommends:
 
->"For maximum flexibility, use wildcard types on input parameters that represent producers or consumers,"
+>"For maximum flexibility, use wildcard types on input parameters that represent producers or consumers."
 
-and proposes the following mnemonic: _PECS_ stands for _Producer-Extends, Consumer-Super._
+He then proposes the following mnemonic: _PECS_ stands for _Producer-Extends, Consumer-Super._
 
 > If you use a producer-object, say, `List<? extends Foo>`, you are not allowed to call `add()` or `set()` on this object,
 > but this does not mean that it is _immutable_: for example, nothing prevents you from calling `clear()`

--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -105,7 +105,7 @@ and proposes the following mnemonic: _PECS_ stands for _Producer-Extends, Consum
 > but this does not mean that it is _immutable_: for example, nothing prevents you from calling `clear()`
 > to remove all the items from the list, since `clear()` does not take any parameters at all.
 >
->The only thing guaranteed by wildcards (or other types of variance) is _type safety_. Immutability is a completely different story.
+> The only thing guaranteed by wildcards (or other types of variance) is _type safety_. Immutability is a completely different story.
 >
 {type="note"}
 

--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -29,12 +29,9 @@ Kotlin doesn't have these. Instead, Kotlin has declaration-site variance and typ
 
 ### Variance and wildcards in Java
 
-Let's think about why Java needs these mysterious wildcards. The problem is explained well in 
-[Effective Java, 3rd Edition](http://www.oracle.com/technetwork/java/effectivejava-136174.html), 
-Item 31: _Use bounded wildcards to increase API flexibility_.
-First, generic types in Java are _invariant_, meaning that `List<String>` is _not_ a subtype of `List<Object>`.
-If `List` were not _invariant_, it would have been no better than Java's arrays, as the following code would have 
-compiled but caused an exception at runtime:
+Let's think about why Java needs these mysterious wildcards. First, generic types in Java are _invariant_,
+meaning that `List<String>` is _not_ a subtype of `List<Object>`. If `List` were not _invariant_, it would
+have been no better than Java's arrays, as the following code would have compiled but caused an exception at runtime:
 
 ```java
 // Java
@@ -75,9 +72,6 @@ void copyAll(Collection<Object> to, Collection<String> from) {
 }
 ```
 
-(In Java, you probably learned this the hard way, see [Effective Java, 3rd Edition](http://www.oracle.com/technetwork/java/effectivejava-136174.html), 
-Item 28: _Prefer lists to arrays_.)
-
 That's why the actual signature of `addAll()` is the following:
 
 ```java
@@ -103,7 +97,9 @@ The latter is called _contravariance_, and you can only call methods that take `
 (for example, you can call `add(String)` or `set(int, String)`).  If you call something that returns `T` in `List<T>`,
 you don't get a `String`, but rather an `Object`.
 
-Joshua Bloch gives the name _Producers_ to objects you only _read from_ and _Consumers_ to those you only _write to_. He recommends:
+Joshua Bloch, in his book [Effective Java, 3rd Edition](http://www.oracle.com/technetwork/java/effectivejava-136174.html), explains the problem well
+(Item 31: "Use bounded wildcards to increase API flexibility"). He gives the name _Producers_ to objects you only
+_read from_ and _Consumers_ to those you only _write to_. He recommends:
 
 >"For maximum flexibility, use wildcard types on input parameters that represent producers or consumers."
 


### PR DESCRIPTION
The comments in the example are not sufficient to explain the train of thought preceding it.