### PR TITLE
Feat: adding what's new 2.0.0-Beta3 (#3974)

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -35,7 +35,7 @@
     <toc-element toc-title="What's new in Kotlin">
         <toc-element id="whatsnew1920.md" toc-title="Kotlin 1.9.20" accepts-web-file-names="whatsnew.html"/>
         <toc-element id="whatsnew19.md" toc-title="Kotlin 1.9.0"/>
-        <toc-element id="whatsnew-eap.md" toc-title="Kotlin 2.0.0-Beta2"/>
+        <toc-element id="whatsnew-eap.md" toc-title="Kotlin 2.0.0-Beta3"/>
         <toc-element toc-title="Earlier versions">
             <toc-element id="whatsnew1820.md" toc-title="Kotlin 1.8.20"/>
             <toc-element id="whatsnew18.md" toc-title="Kotlin 1.8.0"/>

--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -42,13 +42,14 @@ check [our instructions on how to configure your build to support this version](
         <th>Build highlights</th>
     </tr>
     <tr>
-        <td><strong>2.0.0-Beta2</strong>
-            <p>Released: <strong>December 15, 2023</strong></p>
-            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta2" target="_blank">Release on GitHub</a></p>
+        <td><strong>2.0.0-Beta3</strong>
+            <p>Released: <strong>January 18, 2024</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta3" target="_blank">Release on GitHub</a></p>
         </td>
         <td>
             <p>A stabilization release for the Kotlin K2 compiler.</p>
-            <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta2">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.0.0-Beta2</a>.</p>
+            <p>Improvements to Gradle build tool.</p>
+            <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta3">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.0.0-Beta3</a>.</p>
         </td>
     </tr>
 </table>

--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -48,7 +48,7 @@ check [our instructions on how to configure your build to support this version](
         </td>
         <td>
             <p>A stabilization release for the Kotlin K2 compiler.</p>
-            <p>Improvements to Gradle build tool.</p>
+            <p>Includes improvements for the Gradle build tool.</p>
             <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.0-Beta3">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.0.0-Beta3</a>.</p>
         </td>
     </tr>

--- a/docs/topics/whatsnew-eap.md
+++ b/docs/topics/whatsnew-eap.md
@@ -9,8 +9,8 @@ _[Released: %kotlinEapReleaseDate%](eap.md#build-details)_
 >
 {type="note"}
 
-The Kotlin %kotlinEapVersion% release is out! It mostly covers stabilization of the [new Kotlin K2 compiler](#kotlin-k2-compiler),
-which reached its Beta status for all targets since 1.9.20. In addition, there is a change in the way that the [Kotlin Gradle plugin stores Kotlin data](#new-directory-for-kotlin-data-in-gradle-projects).
+The Kotlin %kotlinEapVersion% release is out! It mostly covers the stabilization of the [new Kotlin K2 compiler](#kotlin-k2-compiler), 
+which reached its Beta status for all targets since 1.9.20. In addition, there are also improvements to the Gradle build tool.
 
 ## IDE support
 
@@ -20,7 +20,7 @@ All you need to do is to [change the Kotlin version](configure-build-for-eap.md)
 
 ## Kotlin K2 compiler
 
-The JetBrains team is still working on stabilization of the new Kotlin K2 compiler.
+The JetBrains team is still working on the stabilization of the new Kotlin K2 compiler.
 The new Kotlin K2 compiler will bring major performance improvements, speed up new language feature development,
 unify all platforms that Kotlin supports, and provide a better architecture for multiplatform projects.
 
@@ -41,18 +41,14 @@ If you encounter any of the problems mentioned above, you can take the following
 
 * Set the language version for `buildSrc`, any Gradle plugins, and their dependencies:
 
-   ```kotlin
+```kotlin
    kotlin {
-       compilerOptions {
-           languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
-           apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
-       }
-   }
-   ```
-  > If you configure language and API versions for specific tasks, these values will override the values set by the `compilerOptions` extension. 
-  > In this case, language and API versions should not be higher than 1.9.
-  >
-  {type="note"}
+  compilerOptions {
+    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
+    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
+  }
+}
+```
 
 * Update the Gradle version in your project to 8.3 when it becomes available.
 
@@ -70,6 +66,7 @@ Currently, the Kotlin K2 compiler supports the following plugins:
 * [Jetpack Compose compiler plugin](https://developer.android.com/jetpack/compose)
 * [Kotlin Symbol Processing (KSP) plugin](ksp-overview.md)
 * [`jvm-abi-gen`](https://github.com/JetBrains/kotlin/tree/master/plugins/jvm-abi-gen)
+* [`parcelize`](https://plugins.gradle.org/plugin/org.jetbrains.kotlin.plugin.parcelize)
 
 > If you use any additional compiler plugins, check their documentation to see if they are compatible with K2.
 >
@@ -87,11 +84,137 @@ We would appreciate any feedback you may have!
 * Provide your feedback directly to K2 developers on Kotlin
   Slack – [get an invite](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up?_gl=1*ju6cbn*_ga*MTA3MTk5NDkzMC4xNjQ2MDY3MDU4*_ga_9J976DJZ68*MTY1ODMzNzA3OS4xMDAuMS4xNjU4MzQwODEwLjYw)
   and join the [#k2-early-adopters](https://kotlinlang.slack.com/archives/C03PK0PE257) channel.
-* Report any problems you faced with the new K2 compiler
-  on [our issue tracker](https://kotl.in/issue).
+* Report any problems you face with the new K2 compiler
+  in [our issue tracker](https://kotl.in/issue).
 * [Enable the **Send usage statistics** option](https://www.jetbrains.com/help/idea/settings-usage-statistics.html) to
   allow JetBrains to collect anonymous data about K2 usage.
-* 
+
+## Improved Gradle dependency handling for CInteropProcess in Kotlin/Native
+
+In this release, we enhanced the handling of the `defFile` property to ensure better Gradle task dependency management in 
+Kotlin/Native projects. 
+
+Before this update, Gradle builds could fail if the `defFile` property was designated as an output 
+of another task that hadn't been executed yet. The workaround for this issue was to add a dependency on this task:
+
+```kotlin
+kotlin {
+  macosArm64("native") {
+    compilations.getByName("main") {
+      cinterops {
+        val cinterop by creating {
+          defFileProperty.set(createDefFileTask.flatMap { it.defFile.asFile })
+          project.tasks.named(interopProcessingTaskName).configure {
+            dependsOn(createDefFileTask)
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+To fix this, there is a new `RegularFileProperty` called `definitionFile`.  Now, Gradle lazily verifies the presence of 
+the `definitionFile` property after the connected task has run later in the build process. This new approach eliminates 
+the need for additional dependencies.
+
+The `CInteropProcess` task and the `CInteropSettings` class use the `definitionFile` property instead of `defFile` and 
+`defFileProperty`. Both `defFile` and `defFileProperty` parameters are now deprecated:
+
+<tabs>
+
+<tab id="kotlin" title="Kotlin">
+
+```kotlin
+kotlin {
+  macosArm64("native") {
+    compilations.getByName("main") {
+      cinterops {
+        val cinterop by creating {
+          definitionFile.set(project.file("def-file.def"))
+        }
+      }
+    }
+  }
+}
+```
+
+</tab>
+
+<tab id="groovy" title="Groovy">
+
+```groovy
+kotlin {
+  macosArm64("native") {
+    compilations.main {
+      cinterops {
+        cinterop {
+          definitionFile.set(project.file("def-file.def"))
+        }
+      }
+    }
+  }
+}
+```
+
+</tab>
+
+</tabs>
+
+## Visibility changes in Gradle
+
+> This change doesn't impact Groovy DSL users.
+> 
+{type="note"}
+
+In Kotlin %kotlinEapVersion%, we've modified the Kotlin Gradle Plugin for better control and safety in your build scripts. Previously, certain Kotlin DSL functions and properties intended for a specific DSL context would inadvertently leak to other DSL contexts. This leakage could lead to the use of incorrect compiler options, settings being applied multiple times, and other misconfigurations:
+
+```kotlin
+kotlin {
+  jvm {
+// Could not access methods and properties defined in the extension class
+    compilations.configureEach {
+// Could not access methods and properties defined in the extension and Kotlin target classes
+      compileTaskProvider.configure {
+// Could not access methods and properties defined in the extension, Kotlin target, Kotlin compilation classes
+// For example:
+        explicitApi() // ERROR as it is defined in the extension class
+        mavenPublication {} // ERROR as it is defined in the Kotlin target class
+        defaultSourceSet {} // ERROR as it is defined in the Kotlin compilation class
+      }
+    }
+  }
+}
+```
+
+To fix this issue, we've added the [`@KotlinGradlePluginDsl` annotation](https://kotlinlang.org/docs/type-safe-builders.html#scope-control-dslmarker), preventing the exposure of the Kotlin Gradle plugin DSL functions and properties to the levels where they are not intended to be available. The following levels are separated from each other:
+
+* Kotlin extension
+* Kotlin target
+* Kotlin compilation
+* Kotlin compilation task
+
+If your build script is configured incorrectly, you should see compiler warnings with suggestions on how to fix it. For example:
+
+```kotlin
+kotlin {
+  jvm {
+    sourceSets.getByName("jvmMain").dependencies {
+      implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3")
+    }
+  }
+}
+```
+
+In this case, the warning message for `sourceSets` is:
+
+```kotlin
+[DEPRECATION] 'sourceSets: NamedDomainObjectContainer<KotlinSourceSet>' is deprecated.Accessing 'sourceSets' container on the Kotlin target level DSL is deprecated . Consider configuring 'sourceSets' on the Kotlin extension level .
+```
+
+We would appreciate your feedback on this change! Share your comments directly to Kotlin developers in our [#eap Slack channel](https://kotlinlang.slack.com/archives/C0KLZSCHF).
+[Get a Slack invite](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up).
+
 ## New directory for Kotlin data in Gradle projects
 
 > With this change, you may need to add the `.kotlin` directory to your project's `.gitignore` file.
@@ -114,7 +237,7 @@ Add these properties to the `gradle.properties` file in your projects for them t
 
 ## What to expect from upcoming Kotlin EAP releases
 
-The upcoming 2.0.0-Beta3 release will increase stability of the K2 compiler.
+The upcoming 2.0.0-Beta4 release will increase the stability of the K2 compiler.
 If you are currently using K2 in your project, 
 we encourage you to stay updated on Kotlin releases and experiment with the updated K2 compiler. 
 [Share your feedback on using Kotlin K2](#leave-your-feedback-on-the-new-k2-compiler).
@@ -128,9 +251,8 @@ we encourage you to stay updated on Kotlin releases and experiment with the upda
 
 ## How to update to Kotlin %kotlinEapVersion%
 
-Starting from Kotlin 2.0.0-Beta1, the IntelliJ Kotlin plugin is distributed as a bundled plugin only.
-This means that you can't install the plugin from JetBrains Marketplace anymore.
-With this change you will receive more frequent updates, ensuring that the latest stable IntelliJ IDEA and Android Studio versions consistently support the Kotlin versions that are released.
+Starting from IntelliJ IDEA 2023.3 and Android Studio Iguana (2023.2.1) Canary 15, the Kotlin plugin is distributed as a 
+bundled plugin included in your IDE. This means that you can’t install the plugin from JetBrains Marketplace anymore. 
 The bundled plugin supports upcoming Kotlin EAP releases.
 
 To update to the new Kotlin EAP version, [change the Kotlin version](configure-build-for-eap.md) to %kotlinEapVersion% in your build scripts.

--- a/docs/topics/whatsnew-eap.md
+++ b/docs/topics/whatsnew-eap.md
@@ -81,6 +81,10 @@ Currently, the Kotlin K2 compiler supports the following plugins:
 Starting with Kotlin 2.0.0-Beta1, the Kotlin K2 compiler is enabled by default.
 No additional actions are required.
 
+## Try the Kotlin K2 compiler in Kotlin Playground
+
+Kotlin Playground supports the 2.0.0-Beta3 release. [Check it out!](https://pl.kotl.in/czuoQprce)
+
 ## Leave your feedback on the new K2 compiler
 
 We would appreciate any feedback you may have!

--- a/docs/topics/whatsnew-eap.md
+++ b/docs/topics/whatsnew-eap.md
@@ -10,7 +10,7 @@ _[Released: %kotlinEapReleaseDate%](eap.md#build-details)_
 {type="note"}
 
 The Kotlin %kotlinEapVersion% release is out! It mostly covers the stabilization of the [new Kotlin K2 compiler](#kotlin-k2-compiler), 
-which reached its Beta status for all targets since 1.9.20. In addition, there are also improvements for the Gradle build tool.
+which reached its Beta status for all targets since 1.9.20. In addition, there are also [improvements for the Gradle build tool](#gradle-improvements).
 
 ## IDE support
 
@@ -28,7 +28,7 @@ The K2 compiler is in [Beta](components-stability.md) for all target platforms: 
 The JetBrains team has ensured the quality of the new compiler by successfully compiling dozens of user and internal projects.
 A large number of users are also involved in the stabilization process, trying the new K2 compiler in their projects and reporting any problems they find.
 
-## Current K2 compiler limitations
+### Current K2 compiler limitations
 
 Enabling K2 in your Gradle project comes with certain limitations that can affect projects using Gradle versions below 8.3 in the following cases:
 
@@ -56,7 +56,7 @@ If you encounter any of the problems mentioned above, you can take the following
 
 * Update the Gradle version in your project to 8.3 when it becomes available.
 
-## Compiler plugins support
+### Compiler plugins support
 
 Currently, the Kotlin K2 compiler supports the following plugins:
 
@@ -76,16 +76,16 @@ Currently, the Kotlin K2 compiler supports the following plugins:
 >
 {type="tip"}
 
-## How to enable the Kotlin K2 compiler
+### How to enable the Kotlin K2 compiler
 
 Starting with Kotlin 2.0.0-Beta1, the Kotlin K2 compiler is enabled by default.
 No additional actions are required.
 
-## Try the Kotlin K2 compiler in Kotlin Playground
+### Try the Kotlin K2 compiler in Kotlin Playground
 
 Kotlin Playground supports the 2.0.0-Beta3 release. [Check it out!](https://pl.kotl.in/czuoQprce)
 
-## Leave your feedback on the new K2 compiler
+### Leave your feedback on the new K2 compiler
 
 We would appreciate any feedback you may have!
 
@@ -97,7 +97,14 @@ We would appreciate any feedback you may have!
 * [Enable the **Send usage statistics** option](https://www.jetbrains.com/help/idea/settings-usage-statistics.html) to
   allow JetBrains to collect anonymous data about K2 usage.
 
-## Improved Gradle dependency handling for CInteropProcess in Kotlin/Native
+## Gradle improvements
+
+This version brings the following changes:
+* [Improved Gradle dependency handling for CInteropProcess in Kotlin/Native](#improved-gradle-dependency-handling-for-cinteropprocess-in-kotlin-native)
+* [Visibility changes in Gradle](#visibility-changes-in-gradle)
+* [New directory for Kotlin data in Gradle projects](#new-directory-for-kotlin-data-in-gradle-projects)
+
+### Improved Gradle dependency handling for CInteropProcess in Kotlin/Native
 
 In this release, we enhanced the handling of the `defFile` property to ensure better Gradle task dependency management in 
 Kotlin/Native projects. 
@@ -173,7 +180,7 @@ kotlin {
 >
 {type="warning"}
 
-## Visibility changes in Gradle
+### Visibility changes in Gradle
 
 > This change impacts only Kotlin DSL users.
 > 
@@ -239,7 +246,7 @@ In this case, the warning message for `sourceSets` is:
 We would appreciate your feedback on this change! Share your comments directly to Kotlin developers in our [#eap Slack channel](https://kotlinlang.slack.com/archives/C0KLZSCHF).
 [Get a Slack invite](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up).
 
-## New directory for Kotlin data in Gradle projects
+### New directory for Kotlin data in Gradle projects
 
 > With this change, you may need to add the `.kotlin` directory to your project's `.gitignore` file.
 >

--- a/docs/v.list
+++ b/docs/v.list
@@ -6,13 +6,13 @@
 
     <var name="kotlinVersion" value="1.9.22" type="string"/>
 
-    <var name="kotlinEapVersion" value="2.0.0-Beta2" type="string"/>
+    <var name="kotlinEapVersion" value="2.0.0-Beta3" type="string"/>
 
     <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v1.9.22" type="string"/>
 
     <var name="kotlinReleaseDate" value="December 21, 2023" type="string"/>
 
-    <var name="kotlinEapReleaseDate" value="December 15, 2023" type="string"/>
+    <var name="kotlinEapReleaseDate" value="January 18, 2024" type="string"/>
 
     <var name="coroutinesVersion" value="1.7.3" type="string"/>
 


### PR DESCRIPTION
Updated whatsnew-eap.md and eap.md as required by 2.0.0-Beta3 release.