### PR TITLE
Update Visibility section in Calling Kotlin from Java page

### DIFF
--- a/docs/topics/jvm/java-to-kotlin-interop.md
+++ b/docs/topics/jvm/java-to-kotlin-interop.md
@@ -391,7 +391,8 @@ with `@JvmDefaultWithoutCompatibility` (see [this YouTrack issue](https://youtra
 The Kotlin visibility modifiers map to Java in the following way:
 
 * `private` members are compiled to `private` members
-* `private` top-level declarations are compiled to package-local declarations
+* `private` top-level declarations are compiled to `private` top-level declarations. Package-private accessors are also included,
+if accessed from within a class. 
 * `protected` remains `protected` (note that Java allows accessing protected members from other classes in the same package
 and Kotlin doesn't, so Java classes will have broader access to the code)
 * `internal` declarations become `public` in Java. Members of `internal` classes go through name mangling, to make


### PR DESCRIPTION
This change fixes [KT-64908](https://youtrack.jetbrains.com/issue/KT-64908/Private-top-level-property-and-function-are-compiled-into-JVM-private-members-while-documentation-says-different).