### PR TITLE
Remove "Decode inlined stack frames" from native-ios-symbolication.md

### DIFF
--- a/docs/topics/native/native-ios-symbolication.md
+++ b/docs/topics/native/native-ios-symbolication.md
@@ -88,20 +88,3 @@ kotlin {
 
 </tab>
 </tabs>
-
-## Decode inlined stack frames
-
-Xcode doesn't seem to properly decode stack trace elements of inlined function
-calls (these aren't only Kotlin `inline` functions but also functions that are
-inlined when optimizing machine code). So some stack trace elements may be
-missing. If this is the case, consider using `lldb` to process crash report
-that is already symbolicated by Xcode, for example:
-
-```bash
-$ lldb -b -o "script import lldb.macosx" -o "crashlog file.crash"
-```
-
-This command should output crash report that is additionally processed and
-includes inlined stack trace elements.
-
-More details can be found in [LLDB documentation](https://lldb.llvm.org/use/symbolication.html).


### PR DESCRIPTION
Remove "Decode inlined stack frames" section from "Symbolicating iOS crash reports".

This section seems obsolete. The command no longer works -- it has to be "command script import lldb.macosx" instead of "script import ...".

But even with this change, it is not of much use: it can't find .dSYM bundles for crashlogs copied from iPhone. Some additional manipulations are required to make this work.

Considering that this part is not even Kotlin-specific and there are many tutorials on that topic on the internet, it seems justified to remove the problematic section instead of expanding it.