### PR TITLE
equality.md: add a clarification to the section on structural equality

### DIFF
--- a/docs/topics/equality.md
+++ b/docs/topics/equality.md
@@ -14,6 +14,10 @@ By convention, an expression like `a == b` is translated to:
 a?.equals(b) ?: (b === null)
 ```
 
+While this equality operator is called structural equality to distinguish it from *explicit*, referential equality (`===`), 
+it's important to note that the underlying implementation of `equals`, and thus `==`, may still be referential in nature. 
+In fact, this is the default for all classes except for [data classes](https://kotlinlang.org/docs/data-classes.html).
+
 If `a` is not `null`, it calls the `equals(Any?)` function, otherwise (`a` is `null`) it checks that `b`
 is referentially equal to `null`.
 


### PR DESCRIPTION
Because the structural equality operator `==` desugars to `equals`, there are some cases in which its underlying behavior will actually be *referential*. In fact, this is the default for non-data classes.

The name "structural equality", while it makes sense when considering data classes, may lead to confusion for this reason. I've added a note to clarify that, in spite of the name of the operator, there may be cases in which the underlying behavior of the comparison is not strictly structural in nature.