### PR TITLE
chore: set default height and width of hero image for slow network

### DIFF
--- a/blocks/main/hero/hero.tsx
+++ b/blocks/main/hero/hero.tsx
@@ -61,6 +61,8 @@ export const HeroSection: FC<Props> = ({ children, title }) => {
                             src={HeroImg.src}
                             srcSet={`${HeroImg2x.src} 2x`}
                             alt="kotlin"
+                            height="560"
+                            width="560"
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Before:

https://github.com/JetBrains/kotlin-web-site/assets/242514/4a476a5f-92c4-4926-92ef-391a2abe6b61

