### PR TITLE
Update Guangzhou KUG URL

### DIFF
--- a/data/user-groups.yml
+++ b/data/user-groups.yml
@@ -415,7 +415,7 @@
       lng: 119.1535778
   - name: Guangzhou KUG
     country: China Mainland
-    url: https://gzkug.com/
+    url: https://gzkug.github.io/
     position:
       lat: 26.5962666
       lng: 106.551573


### PR DESCRIPTION
The organizer of Guangzhou KUG wants to update the website URL. Just a minor change of user group list yaml file.