### PR TITLE
Update K2 plugin support in whatsnew-eap

### DIFF
--- a/docs/topics/whatsnew-eap.md
+++ b/docs/topics/whatsnew-eap.md
@@ -58,19 +58,22 @@ If you encounter any of the problems mentioned above, you can take the following
 
 ### Compiler plugins support
 
-Currently, the Kotlin K2 compiler supports the following plugins:
+Currently, the Kotlin K2 compiler supports the following Kotlin compiler plugins:
 
-* [kapt](whatsnew1920.md#preview-kapt-compiler-plugin-with-k2)
-* [serialization](serialization.md)
 * [`all-open`](all-open-plugin.md)
-* [`no-arg`](no-arg-plugin.md)
-* [SAM with receiver](sam-with-receiver-plugin.md)
-* [Lombok](lombok.md)
 * [AtomicFU](https://github.com/Kotlin/kotlinx-atomicfu)
-* [Jetpack Compose compiler plugin](https://developer.android.com/jetpack/compose)
-* [Kotlin Symbol Processing (KSP) plugin](ksp-overview.md)
 * [`jvm-abi-gen`](https://github.com/JetBrains/kotlin/tree/master/plugins/jvm-abi-gen)
+* [kapt](whatsnew1920.md#preview-kapt-compiler-plugin-with-k2)
+* [Lombok](lombok.md)
+* [`no-arg`](no-arg-plugin.md)
 * [Parcelize](https://plugins.gradle.org/plugin/org.jetbrains.kotlin.plugin.parcelize)
+* [SAM with receiver](sam-with-receiver-plugin.md)
+* [serialization](serialization.md)
+
+In addition, the Kotlin K2 compiler supports:
+* the [Jetpack Compose](https://developer.android.com/jetpack/compose) 1.5.0 compiler plugin and later versions.
+* the [Kotlin Symbol Processing (KSP) plugin](ksp-overview.md)
+since [KSP2](https://android-developers.googleblog.com/2023/12/ksp2-preview-kotlin-k2-standalone.html).
 
 > If you use any additional compiler plugins, check their documentation to see if they are compatible with K2.
 >


### PR DESCRIPTION
This PR tidies up the list of K2 compiler supported plugins by separating Kotlin compiler plugins from the rest and providing versions/information for non-Kotlin compiler plugins.