### PR TITLE
Update Docs home page - Kotlin Multiplatform section

### DIFF
--- a/docs/topics/home.xml
+++ b/docs/topics/home.xml
@@ -37,11 +37,12 @@
                 <a href="whatsnew1920.md" description="Latest features: Kotlin K2 is in Beta and Stable Kotlin Multiplatform">What's New in Kotlin 1.9.20</a>
                 <a href="roadmap.md" description="Future plans on Kotlin development">Kotlin public roadmap</a>
             </group>
-            <group type="cards">
+            <group type="cards" display="wide">
                 <title>Kotlin Multiplatform</title>
-                <a href="multiplatform-get-started.md" description="Useful links to help you start using the SDK">Get started</a>
-                <a href="multiplatform-plugin-releases.md" description="Features of the Kotlin Multiplatform Mobile plugin">Plugin releases for Android Studio</a>
-                <a href="https://www.youtube.com/playlist?list=PLlFc5cFwUnmy_oVc9YQzjasSNoAk4hk_C" description="Videos about Kotlin Multiplatform on our YouTube channel">Kotlin Multiplatform Multiverse</a>
+                <a href="https://www.jetbrains.com/kotlin-multiplatform/" description="Learn how Kotlin Multiplatform helps you share code between your applications">Why Kotlin Multiplatform</a>
+                <a href="https://kmp.jetbrains.com/" description="Quickly create and download a multiplatform project template">Kotlin Multiplatform Wizard</a>
+                <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-getting-started.html" description="Create a mobile app that works on both Android and iOS">Get started with Kotlin Multiplatform</a>
+                <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-getting-started.html" description="Use Compose Multiplatform to implement one user interface across all platforms">Get started with Compose Multiplatform</a>
             </group>
             <group type="links" display="normal">
                 <link-collection>


### PR DESCRIPTION
This PR updates the links provided under the Kotlin Multiplatform section on the Docs home page.