### PR TITLE
Update native-cocoapods.md

### DIFF
--- a/docs/topics/native/native-cocoapods.md
+++ b/docs/topics/native/native-cocoapods.md
@@ -51,7 +51,7 @@ Install the [CocoaPods dependency manager](https://cocoapods.org/) using the ins
 4. Install CocoaPods:
 
     ```bash
-    sudo gem install cocoapods
+    sudo gem install -n /usr/local/bin cocoapods
     ```
 
 </tab>


### PR DESCRIPTION
It is better to install CocoaPods to `/usr/local/bin`, so they will always be available in PATH, and it will be possible to use them from Xcode