### PR TITLE
chore: fix typo in 1.9.20. Kotlin version

### DIFF
--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -24,7 +24,7 @@ the new WasmGC by default or if you need to make changes to the environment.
   2. Enable **WebAssembly Garbage Collection**.
   3. Relaunch your browser.
 
-  In addition to updating the browser settings, make sure you use a Kotlin version before 1.9.20.
+  In addition to updating the browser settings, make sure you use a Kotlin version after 1.9.20.
 
 ### Chromium-based
 
@@ -38,7 +38,7 @@ Including Chromium-based browsers such as Edge, Brave, Opera, or Samsung Interne
 
   Run the application with the `--js-flags=--experimental-wasm-gc` command line argument.
 
-  In addition to updating the browser settings, make sure you use a Kotlin version before 1.9.20.
+  In addition to updating the browser settings, make sure you use a Kotlin version after 1.9.20.
 
 ### Firefox
 


### PR DESCRIPTION
Changed 'before' to 'after 1.9.20.