### PR TITLE
Update jvm-spring-boot-add-db-support.md

### DIFF
--- a/docs/topics/jvm/jvm-spring-boot-add-db-support.md
+++ b/docs/topics/jvm/jvm-spring-boot-add-db-support.md
@@ -248,7 +248,7 @@ Extend the functionality of the application to retrieve the individual messages 
             Message(response.getString("id"), response.getString("text"))
         }
     
-        fun findMessageById(id: String): List<Message> = db.query("select * from messages where id = ?", id) { response, _ ->
+        fun findMessageById(id: String): List<Message> = db.query("select * from messages where id = ?", arrayOf(id), intArrayOf(Types.VARCHAR)) { response, _ ->
             Message(response.getString("id"), response.getString("text"))
         }
     
@@ -292,13 +292,14 @@ Extend the functionality of the application to retrieve the individual messages 
        <p>The message <code>id</code> is retrieved from the context path by the Spring Framework as you annotated the new function by <code>@GetMapping(&quot;/{id}&quot;)</code>. By annotating the function argument with <code>@PathVariable</code>, you tell the framework to use the retrieved value as a function argument. The new function makes a call to <code>MessageService</code> to retrieve the individual message by its id.</p>
     </def>
     <def title="vararg argument position in the parameter list">
-        <p>The <code>query()</code> function takes three arguments:</p>
+        <p>The <code>query()</code> function takes four arguments:</p>
         <list>
             <li>SQL query string that requires a parameter to run</li>
-            <li>`id`, which is a parameter of type String</li>
+            <li>`arrayOf(id)`, args array contains the actual values for the query parameters</li>
+            <li>int[] argTypes contains the SQL types of the parameters (in this case, Types.VARCHAR for a string)</li>
             <li><code>RowMapper</code> instance is implemented by a lambda expression</li>
         </list>
-        <p>The second parameter for the <code>query()</code> function is declared as a <i>variable argument</i> (<code>vararg</code>). In Kotlin, the position of the variable arguments parameter is not required to be the last in the parameters list.</p>
+        <p>The second parameter for the <code>query()</code> function is declared as <i>variable arguments</i> (<code>varargs</code>). In Kotlin, the position of the variable arguments parameter is not required to be the last in the parameters list if arg types are provided in the third parameter.</p>
     </def>
     </deflist>
 
@@ -347,7 +348,7 @@ class MessageService(val db: JdbcTemplate) {
         Message(response.getString("id"), response.getString("text"))
     }
 
-    fun findMessageById(id: String): List<Message> = db.query("select * from messages where id = ?", id) { response, _ ->
+    fun findMessageById(id: String): List<Message> = db.query("select * from messages where id = ?", arrayOf(id), intArrayOf(Types.VARCHAR)) { response, _ ->
         Message(response.getString("id"), response.getString("text"))
     }
 


### PR DESCRIPTION
When I follow this tutorial to [this part](https://kotlinlang.org/docs/jvm-spring-boot-add-db-support.html#retrieve-messages-by-id), it cannot work in my local environment and give the following error:
```
Task :compileKotlin FAILED
e: KotlinSpringbootDemoApplication.kt:51:54 Type mismatch: inferred type is Unit but List<Message> was expected
e: KotlinSpringbootDemoApplication.kt:51:57 Type mismatch: inferred type is Unit but List<Message> was expected
e: KotlinSpringbootDemoApplication.kt:51:102 Type mismatch: inferred type is String but RowCallbackHandler was expected
e: KotlinSpringbootDemoApplication.kt:51:106 Passing value as a vararg is only allowed inside a parenthesized argument list
e: KotlinSpringbootDemoApplication.kt:51:108 Cannot infer a type for this parameter. Please specify it explicitly.
e: KotlinSpringbootDemoApplication.kt:51:118 Cannot infer a type for this parameter. Please specify it explicitly.
```
My local `build.gradle`:
```
import org.jetbrains.kotlin.gradle.tasks.KotlinCompile // For `KotlinCompile` task below

plugins {
    id 'org.springframework.boot' version '3.2.2'
    id 'io.spring.dependency-management' version '1.1.4'
    id 'org.jetbrains.kotlin.jvm' version '1.9.22' // The version of Kotlin to use
    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.22' // The Kotlin Spring plugin
}

group = 'org.example'
version = '0.0.1-SNAPSHOT'

java {
    sourceCompatibility = '17'
}

repositories {
    mavenCentral()
}

dependencies {
    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
    implementation 'org.springframework.boot:spring-boot-starter-web'
    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin' // Jackson extensions for Kotlin for working with JSON
    implementation 'org.jetbrains.kotlin:kotlin-reflect' // Kotlin reflection library, required for working with Spring
    runtimeOnly 'com.h2database:h2'
    testImplementation 'org.springframework.boot:spring-boot-starter-test'
}

tasks.withType(KotlinCompile) { // Settings for `KotlinCompile` tasks
    kotlinOptions { // Kotlin compiler options
        freeCompilerArgs += '-Xjsr305=strict' // `-Xjsr305=strict` enables the strict mode for JSR-305 annotations
        jvmTarget = '17' // This option specifies the target version of the generated JVM bytecode
    }
}

tasks.named('test') {
    useJUnitPlatform()
}
```
After investigating into the `query` function, I saw the following:
```
    @Deprecated
    public void query(String sql, @Nullable Object[] args, RowCallbackHandler rch) throws DataAccessException {
        this.query(sql, this.newArgPreparedStatementSetter(args), rch);
    }
```
I guess the error is because this function is not supported in latest version, but I am not sure for I am just a new learner.  Anyway after I changed the code as shown in this PR, then it worked. So, I create this PR to update the tutorial.