### PR TITLE
delete launching example that doesnt print anything

### DIFF
--- a/docs/topics/numbers.md
+++ b/docs/topics/numbers.md
@@ -173,15 +173,10 @@ As a consequence, smaller types _are NOT implicitly converted_ to bigger types.
 This means that assigning a value of type `Byte` to an `Int` variable requires an explicit conversion:
 
 ```kotlin
-fun main() {
-//sampleStart
-    val b: Byte = 1 // OK, literals are checked statically
-    // val i: Int = b // ERROR
-    val i1: Int = b.toInt()
-//sampleEnd
-}
+val b: Byte = 1 // OK, literals are checked statically
+// val i: Int = b // ERROR
+val i1: Int = b.toInt()
 ```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
 All number types support conversions to other types:
 


### PR DESCRIPTION
Hi!
Launching this example is useless, moreover, when launching it, it becomes visible that the variable is unused:
<img width="775" alt="Screenshot 2024-03-04 at 20 46 11" src="https://github.com/JetBrains/kotlin-web-site/assets/78360457/01bd4611-0810-4b49-aced-722cf346080c">
<img width="750" alt="Screenshot 2024-03-04 at 20 46 18" src="https://github.com/JetBrains/kotlin-web-site/assets/78360457/7e506c86-94ff-4d99-9c8c-4450eb48b698">
