### PR TITLE
Add --no-daemon flag to "kotlinx-metadata-jvm API reference"

### DIFF
--- a/.teamcity/builds/apiReferences/kotlinx/metadataJvm/KotlinxMetadataJvmBuildApiReference.kt
+++ b/.teamcity/builds/apiReferences/kotlinx/metadataJvm/KotlinxMetadataJvmBuildApiReference.kt
@@ -72,7 +72,7 @@ object KotlinxMetadataJvmBuildApiReference : BuildType({
         script {
             name = "build api reference"
             scriptContent = """
-                ./gradlew :kotlinx-metadata-jvm:dokkaHtml -PkotlinxMetadataDeployVersion=${KOTLINX_METADATA_JVM_RELEASE_TAG}
+                ./gradlew :kotlinx-metadata-jvm:dokkaHtml -PkotlinxMetadataDeployVersion=${KOTLINX_METADATA_JVM_RELEASE_TAG} --no-daemon
             """.trimIndent()
         }
     }


### PR DESCRIPTION
"build api reference" step leak a Gradle daemon process which may cause any builds on the same agent to fail 

^KTI-1650