### PR TITLE
fix: `when` must have `else` branch if its subject is a enum/sealed/Boolean AND it's nullable

### DIFF
--- a/docs/topics/control-flow.md
+++ b/docs/topics/control-flow.md
@@ -92,7 +92,7 @@ val numericValue = when (getRandomBit()) {
 
 In `when` _statements_, the `else` branch is mandatory in the following conditions:
 * `when` has a subject of a `Boolean`, [`enum`](enum-classes.md),
-or [`sealed`](sealed-classes.md) type, or their nullable counterparts.
+or [`sealed`](sealed-classes.md) type, and their nullable counterparts.
 * branches of `when` don't cover all possible cases for this subject.
 
 ```kotlin


### PR DESCRIPTION
This is the important moment) Or maybe I don't know English:))

Ok:
<img width="578" alt="Screenshot 2024-03-21 at 11 54 42" src="https://github.com/JetBrains/kotlin-web-site/assets/78360457/693ccdd0-23ea-46e1-9628-511b70e37b0e">

Nullable `Bit` and an absent `else` branch, not ok:
<img width="892" alt="Screenshot 2024-03-21 at 11 54 59" src="https://github.com/JetBrains/kotlin-web-site/assets/78360457/1ea1a6fb-0182-488c-8453-58fdaf418f2e">
