### PR TITLE
Remove `@Builder` from supported annotations list

### DIFF
--- a/docs/topics/lombok.md
+++ b/docs/topics/lombok.md
@@ -19,7 +19,6 @@ Learn more about [how to configure the Lombok compiler plugin](#using-the-lombok
 
 The plugin supports the following annotations:
 * `@Getter`, `@Setter`
-* `@Builder`
 * `@NoArgsConstructor`, `@RequiredArgsConstructor`, and `@AllArgsConstructor`
 * `@Data`
 * `@With`


### PR DESCRIPTION
On the [plugin README.md](https://github.com/JetBrains/kotlin/tree/23cef7579d00fa845dace3c84b8d99e729723fa4/plugins/lombok#readme), it is mentioned that `@Builder` "will not be supported in the current prototype"