### PR TITLE
fix: change Maven version from 3.5.1 to 3.8.6 as 3.5.1 doesn't exist:)

### DIFF
--- a/docs/topics/lombok.md
+++ b/docs/topics/lombok.md
@@ -151,7 +151,7 @@ In Maven, use the following settings to launch Lombok with Java's compiler:
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-compiler-plugin</artifactId>
-    <version>3.5.1</version>
+    <version>3.8.6</version>
     <configuration>
         <source>1.8</source>
         <target>1.8</target>

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -180,7 +180,7 @@ making sure that the `kotlin` plugin comes before the `maven-compiler-plugin` in
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.5.1</version>
+            <version>3.8.6</version>
             <executions>
                 <!-- Replacing default-compile as it is treated specially by Maven -->
                 <execution>


### PR DESCRIPTION
The version 3.5.1 doesn't exist, see here: https://maven.apache.org/docs/history.html#maven-3-8-x

3.8.6 is chosen by advice from @CherepanovAleksei as we [use](https://jetbrains.team/p/kt/repositories/kotlin/files/ff2fea390bafb765abebc11bb272c8e2e999f46f/libraries/pom.xml?tab=source&line=54&lines-count=1) this version.