### PR TITLE
Update Coding Conventions to match Compose conventions

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -181,12 +181,11 @@ class MyTestCase {
 ### Property names
 
 Names of constants (properties marked with `const`, or top-level or object `val` properties with no custom `get` function
-that hold deeply immutable data) should use uppercase underscore-separated ([screaming snake case](https://en.wikipedia.org/wiki/Snake_case))
-names:
+that hold deeply immutable data) should use upper camel case names:
 
 ```kotlin
-const val MAX_COUNT = 8
-val USER_NAME_FIELD = "UserName"
+const val MaxCount = 8
+val UserNameField = "UserName"
 ```
 
 Names of top-level or object properties which hold objects with behavior or mutable data should use camel case names:
@@ -201,8 +200,11 @@ Names of properties holding references to singleton objects can use the same nam
 val PersonComparator: Comparator<Person> = /*...*/
 ```
 
-For enum constants, it's OK to use either uppercase underscore-separated names ([screaming snake case](https://en.wikipedia.org/wiki/Snake_case))
-(`enum class Color { RED, GREEN }`) or upper camel case names, depending on the usage. 
+Enum constants should also use upper camel case names: 
+
+```kotlin
+enum class Color { Red, Green }
+```
    
 ### Names for backing properties
 


### PR DESCRIPTION
While [discussing on Slack](https://kotlinlang.slack.com/archives/CQ3GFJTU1/p1679332632581359), there was an overall consensus that the current `SCREAMING_SNAKE_CASE` convention is inconsistent for a few reasons:

1. It shouts at the readers and calls their attention first thing for things that shouldn't get more attention than other parts of the code. Enums, singletons, and constants do not hold any special characteristic that would require the reader to inspect the value of the variable or where it's being used. They don't represent unsafe, sensitive, or experimental code*. 
2. Compose, along with most of their plugins, libraries, and extensions, use the `PascalCase` convention. They have their own convention and reasoning for it written down [here](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-api-guidelines.md#singletons_constants_sealed-class-and-enum-class-values).
    * Given that Compose is one of the most-used frameworks, it fragments the community towards either their or Kotlin's official convention, which is bad.
4. Having either `PascalCase` and `SCREAMING_SNAKE_CASE` allowed for enums isn't a good convention because it allows developers to make individual decisions on which style to pick and leads the project to a mixed (or no?) convention ([Ktor's public enums are an example](https://github.com/search?q=repo%3Aktorio%2Fktor+public+enum+class&type=code)), defeating the purpose of a convention, which is to standardize the way developers write code and eliminate bike-shedding. 

Given that Kotlin 2.0 is about to be released, this is the perfect time to make this change, and the community, as well as some JetBrains team members, have voted in favor of this change. I will be linking the PR on the Slack thread so the community and the Kotlin team are up-to-date and can add feedback. 

---

\* On a side note, the current convention is likely inherited from Java, which in turn inherited it from the C/C++ convention for macros, as they were used for constants. However, macros indeed require more attention because of arbitrary code expansion, so the shouting makes sense.