### PR TITLE
Privacy manifests update

### DIFF
--- a/docs/topics/native/apple-privacy-manifest.md
+++ b/docs/topics/native/apple-privacy-manifest.md
@@ -28,17 +28,9 @@ app that fall under the [required reasons](https://developer.apple.com/documenta
 category.
 
 Ideally, all SDKs that your app uses provide their own privacy manifest, and you don't need to worry about that.
-But if some of your dependencies don't do this, your App Store submission will be flagged.
-
-> As of April 22, the App Store does not check API usage in dynamically linked libraries, so only static dependencies affect the check;
-> however, this may change in the future.
->
-{type="note"}
+But if some of your dependencies don't do this, your App Store submission may be flagged.
 
 ## How to resolve
-
-To ensure that your Kotlin Multiplatform app meets the App Store requirements, you can list all of the required reason
-APIs in the app's privacy manifest.
 
 After you have tried to submit your app and received a detailed issue list from the App Store, you can build your manifest
 following the Apple documentation:
@@ -54,25 +46,57 @@ valid values for each field.
 If a new privacy manifest doesn't help satisfy App Store requirements or you cannot figure out how to go through the steps,
 contact us and share your case in [this YouTrack issue](https://youtrack.jetbrains.com/issue/KT-67603).
 
-## Tool for searching usages of required reason API in dependencies
+## Finding required reason APIs in the dependencies of your Kotlin framework
+
+Kotlin code in your app may access required reason APIs from libraries such as `platform.posix`. For example, if your Kotlin code or one the dependencies accesses API such as `fstat`:
+```kotlin
+import platform.posix.fstat
+
+fun useRequiredReasonAPI() {
+  fstat(...)
+}
+```
 
 In some cases, it may be hard for you to find out from which dependency the required reason API usage comes from. To assist you, we've built a simple tool.
 
-To use it, run the following command in the directory of your project where Kotlin framework declaration (TODO not sure if it's comprehensible) is located
-```python3 -c "$(curl -fsSL https://github.com/JetBrains/kotlin/raw/rrf_v0.0.1/libraries/tools/required-reason-finder/required_reason_finder.py)"```
-You also may download the script separately, inspect it, and run it via `python3`.
+To use it, run the following command in the directory of your project where the Kotlin framework is declared:
+```
+/usr/bin/python3 -c "$(curl -fsSL https://github.com/JetBrains/kotlin/raw/rrf_v0.0.1/libraries/tools/required-reason-finder/required_reason_finder.py)"
+```
+You may also download the script separately, inspect it, and run it via `python3`.
+
+## Placing PrivacyInfo.xcprivacy in your Kotlin artifacts
+
+If you need to bundle `PrivacyInfo.xcprivacy` file with your Kotlin artifacts, use `apple-privacy-manifests` plugin:
+```
+plugins {
+  kotlin("multiplatform")
+  kotlin("apple-privacy-manifests") version "1.0.0"
+}
+
+kotlin {
+  privacyManifests {
+    embed(
+      privacyManifest = layout.projectDirectory.file("PrivacyInfo.xcprivacy").asFile,
+    )
+  }
+}
+```
+
+The plugin will copy the privacy manifest file to the [corresponding](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk?language=objc) output location.
 
 ### Known usages
 
 #### Compose Multiplatform
 
-Compose Multiplatform rendering engine, Skia, is using `stat` and `fstat` symbols at the moment. Please follow [the issue](https://github.com/JetBrains/compose-multiplatform/issues/4738) for updates.
+Using Compose Multiplatform may result in `fstat`, `stat` and `mach_absolute_time` usages in your binary. In Compose Multiplatform these function are not used for tracking or fingerprinting and are not sent off the device. 
 
-Currently, we recommend specifying TODO reason in the privacy manifest for this usage.
+If you must specify a reason for `stat` and `fstat` usages, use `0A2A.1`. For `mach_absolute_time`, use `35F9.1`.
 
+For further updates on Compose required reasons APIs please follow [this issue](https://github.com/JetBrains/compose-multiplatform/issues/4738).
 
 #### Kotlin/Native runtime in versions 1.9.10 or lower
 
 There is a usage of `mach_absolute_time` in `mimalloc` allocator in K/N runtime. This allocator was enabled by default in version 1.9.10 and lower.
 
-We recommend upgrading your Kotlin version or changing the [allocator setting](TODO proper link) if the upgrade is not possible.
+We recommend upgrading your Kotlin version to 1.9.20 or higher, or changing the [allocator setting](https://kotlinlang.org/docs/native-memory-manager.html#adjust-memory-consumption) if the upgrade is not possible.

--- a/docs/topics/native/apple-privacy-manifest.md
+++ b/docs/topics/native/apple-privacy-manifest.md
@@ -53,3 +53,26 @@ valid values for each field.
 
 If a new privacy manifest doesn't help satisfy App Store requirements or you cannot figure out how to go through the steps,
 contact us and share your case in [this YouTrack issue](https://youtrack.jetbrains.com/issue/KT-67603).
+
+## Tool for searching usages of required reason API in dependencies
+
+In some cases, it may be hard for you to find out from which dependency the required reason API usage comes from. To assist you, we've built a simple tool.
+
+To use it, run the following command in the directory of your project where Kotlin framework declaration (TODO not sure if it's comprehensible) is located
+```python3 -c "$(curl -fsSL https://github.com/JetBrains/kotlin/raw/rrf_v0.0.1/libraries/tools/required-reason-finder/required_reason_finder.py)"```
+You also may download the script separately, inspect it, and run it via `python3`.
+
+### Known usages
+
+#### Compose Multiplatform
+
+Compose Multiplatform rendering engine, Skia, is using `stat` and `fstat` symbols at the moment. Please follow [the issue](https://github.com/JetBrains/compose-multiplatform/issues/4738) for updates.
+
+Currently, we recommend specifying TODO reason in the privacy manifest for this usage.
+
+
+#### Kotlin/Native runtime in versions 1.9.10 or lower
+
+There is a usage of `mach_absolute_time` in `mimalloc` allocator in K/N runtime. This allocator was enabled by default in version 1.9.10 and lower.
+
+We recommend upgrading your Kotlin version or changing the [allocator setting](TODO proper link) if the upgrade is not possible.


### PR DESCRIPTION
This PR updates the documentation on privacy manifests. We implemented two new tools related to privacy manifests:
* a script to find required reason APIs in the dependencies of a Kotlin librariy
* a plugin to help with embedding of a privacy manifest in a Kotlin framework