### PR TITLE
Update Gradle supported versions for 2.0.0

### DIFF
--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -50,7 +50,8 @@ In the following table, there are the minimum and maximum **fully supported** ve
 
 | KGP version   | Gradle min and max versions           | AGP min and max versions                            |
 |---------------|---------------------------------------|-----------------------------------------------------|
-| 1.9.20–1.9.23 | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 2.0.0         | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 1.9.20–1.9.23 | 6.8.3–8.1.1                           | 4.2.2–8.1.0                                         |
 | 1.9.0–1.9.10  | 6.8.3–7.6.0                           | 4.2.2–7.4.0                                         |
 | 1.8.20–1.8.22 | 6.8.3–7.6.0                           | 4.1.3–7.4.0                                         |      
 | 1.8.0–1.8.11  | 6.8.3–7.3.3                           | 4.1.3–7.2.1                                         |   

--- a/docs/v.list
+++ b/docs/v.list
@@ -20,13 +20,13 @@
 
     <var name="minGradleVersion" value="6.8.3" type="string"/>
 
-    <var name="maxGradleVersion" value="8.1.1" type="string"/>
+    <var name="maxGradleVersion" value="8.5" type="string"/>
 
-    <var name="minAndroidGradleVersion" value="4.2.2" type="string"/>
+    <var name="minAndroidGradleVersion" value="7.1.3" type="string"/>
 
-    <var name="maxAndroidGradleVersion" value="8.1.0" type="string"/>
+    <var name="maxAndroidGradleVersion" value="8.3.1" type="string"/>
 
-    <var name="gradleVersion" value="8.1.1" type="string"/>
+    <var name="gradleVersion" value="8.5" type="string"/>
 
     <var name="gradleLanguageVersion" value="KOTLIN_2_0" type="string"/>
 


### PR DESCRIPTION
This PR updates the max/min supported Gradle versions and AGP versions for Kotlin 2.0.0.