### PR TITLE
Update KGP variants for 2.0.0

### DIFF
--- a/docs/topics/gradle/gradle-plugin-variants.md
+++ b/docs/topics/gradle/gradle-plugin-variants.md
@@ -21,7 +21,9 @@ Currently, there are the following variants of the Kotlin Gradle plugin:
 | `gradle75`     | 7.5                           |
 | `gradle76`     | 7.6                           |
 | `gradle80`     | 8.0                           |
-| `gradle81`     | 8.1.1 and higher              |
+| `gradle81`     | 8.1.1                         |
+| `gradle82`     | 8.2.1–8.4                     |
+| `gradle85`     | 8.5 and higher                |
 
 In future Kotlin releases, more variants will be added.
 


### PR DESCRIPTION
This PR updates the table of KGP variants to include those for Kotlin 2.0.0.