### PR TITLE
Docs: Improve Sample Code

### DIFF
--- a/docs/topics/delegation.md
+++ b/docs/topics/delegation.md
@@ -64,7 +64,7 @@ interface Base {
     fun print()
 }
 
-class BaseImpl(val x: Int) : Base {
+class BaseImpl(x: Int) : Base {
     override val message = "BaseImpl: x = $x"
     override fun print() { println(message) }
 }

--- a/docs/topics/delegation.md
+++ b/docs/topics/delegation.md
@@ -17,8 +17,8 @@ class BaseImpl(val x: Int) : Base {
 class Derived(b: Base) : Base by b
 
 fun main() {
-    val b = BaseImpl(10)
-    Derived(b).print()
+    val base = BaseImpl(10)
+    Derived(base).print()
 }
 ```
 {kotlin-runnable="true"}
@@ -48,9 +48,9 @@ class Derived(b: Base) : Base by b {
 }
 
 fun main() {
-    val b = BaseImpl(10)
-    Derived(b).printMessage()
-    Derived(b).printMessageLine()
+    val base = BaseImpl(10)
+    Derived(base).printMessage()
+    Derived(base).printMessageLine()
 }
 ```
 {kotlin-runnable="true"}


### PR DESCRIPTION
- renamed the local variables:
name `b` was used as the constructor parameter AND a local variable.
- removed `val` from the constructor parameter
![image](https://github.com/JetBrains/kotlin-web-site/assets/66462458/b69f32bb-0db9-46db-abf7-796f4b55d81f)
