### PR TITLE
Remove equals symbol from jvm arg parameters

### DIFF
--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -177,7 +177,7 @@ Each of the following ways to set arguments overrides the ones that came before 
 If nothing is specified, the Kotlin daemon inherits arguments from the Gradle daemon. For example, in the `gradle.properties` file:
 
 ```none
-org.gradle.jvmargs=-Xmx1500m -Xms=500m
+org.gradle.jvmargs=-Xmx1500m -Xms500m
 ```
 
 #### kotlin.daemon.jvm.options system property
@@ -185,7 +185,7 @@ org.gradle.jvmargs=-Xmx1500m -Xms=500m
 If the Gradle daemon's JVM arguments have the `kotlin.daemon.jvm.options` system property – use it in the `gradle.properties` file:
 
 ```none
-org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx1500m,Xms=500m
+org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx1500m,Xms500m
 ```
 
 When passing arguments, follow these rules:
@@ -207,7 +207,7 @@ When passing arguments, follow these rules:
 You can add the `kotlin.daemon.jvmargs` property in the `gradle.properties` file:
 
 ```none
-kotlin.daemon.jvmargs=-Xmx1500m -Xms=500m
+kotlin.daemon.jvmargs=-Xmx1500m -Xms500m
 ```
 
 #### kotlin extension


### PR DESCRIPTION
Including the equal symbol for the `-Xms` arg caused my Kotlin Daemon to crash on startup. I tracked it down to the equal symbol and copying from these help docs.