### PR TITLE
update: change wasm interop page

### DIFF
--- a/docs/topics/wasm/wasm-js-interop.md
+++ b/docs/topics/wasm/wasm-js-interop.md
@@ -270,9 +270,6 @@ kotlin {
 >
 {type="warning"}
 
-Additionally, you can use unsigned primitive types inside [exported](js-to-kotlin-interop.md#jsexport-annotation) and [external](js-interop.md#external-modifier) declarations.
-You can export functions with unsigned primitives as a return or parameter type and consume external declarations that return unsigned primitives.
-
 ## Type correspondence
 
 Kotlin/Wasm allows only certain types in signatures of JavaScript interop declarations.
@@ -280,18 +277,18 @@ These limitations apply uniformly to declarations with `external`, `= js("code")
 
 See how Kotlin types correspond to Javascript types:
 
-| Kotlin                                      | JavaScript                        |
-|---------------------------------------------|-----------------------------------|
-| `Byte`, `Short`, `Int`, `Char`              | `Number`                          |
-| `Float`, `Double`,                          | `Number`                          |
-| `Long`,                                     | `BigInt`                          |
-| `Boolean`,                                  | `Boolean`                         |
-| `String`,                                   | `String`                          |
-| `Unit` in return position                   | `undefined`                       |
-| Function type, for example `(String) -> Int` | Function                          |
-| `JsAny` and subtypes                        | Any JavaScript value              |
-| `JsReference`                               | Opaque reference to Kotlin object |
-| Other types                                 | Not supported                     |
+| Kotlin                                                  | JavaScript                        |
+|---------------------------------------------------------|-----------------------------------|
+| `Byte`, `Short`, `Int`, `Char`, `UByte`, `UShort`, `UInt` | `Number`                          |
+| `Float`, `Double`,                                      | `Number`                          |
+| `Long`, `ULong`                                                | `BigInt`                          |
+| `Boolean`,                                              | `Boolean`                         |
+| `String`,                                               | `String`                          |
+| `Unit` in return position                               | `undefined`                       |
+| Function type, for example `(String) -> Int`            | Function                          |
+| `JsAny` and subtypes                                    | Any JavaScript value              |
+| `JsReference`                                           | Opaque reference to Kotlin object |
+| Other types                                             | Not supported                     |
 
 You can use nullable versions of these types as well.
 

--- a/docs/topics/wasm/wasm-js-interop.md
+++ b/docs/topics/wasm/wasm-js-interop.md
@@ -248,11 +248,11 @@ exports.addOne(10)
 ```
 
 The Kotlin/Wasm compiler is capable of generating TypeScript definitions from any `@JsExport` declarations in your Kotlin code. 
-These definitions can be used by IDEs and JavaScript tools to provide code autocompletion, help with type-checks, and make it easier to include Kotlin code in JavaScript.
+These definitions can be used by IDEs and JavaScript tools to provide code autocompletion, help with type-checks, and make it easier to consume Kotlin code from JavaScript and TypeScript.
 
 The Kotlin/Wasm compiler collects any top-level functions marked with the `@JsExport` annotation and automatically generates TypeScript definitions in a `.d.ts` file.
 
-To generate TypeScript definitions, in your `build.gradle.kts` file in the `wasmJs` section, add the `generateTypeScriptDefinitions()` function:
+To generate TypeScript definitions, in your `build.gradle.kts` file in the `wasmJs{}` block, add the `generateTypeScriptDefinitions()` function:
 
 ```kotlin
 kotlin {
@@ -270,7 +270,7 @@ kotlin {
 >
 {type="warning"}
 
-Additionally, the `@JsExport` annotation lets you use unsigned primitive types inside external declarations and functions.
+Additionally, you can use unsigned primitive types inside [exported](js-to-kotlin-interop.md#jsexport-annotation) and [external](js-interop.md#external-modifier) declarations.
 You can export functions with unsigned primitives as a return or parameter type and consume external declarations that return unsigned primitives.
 
 ## Type correspondence

--- a/docs/topics/wasm/wasm-js-interop.md
+++ b/docs/topics/wasm/wasm-js-interop.md
@@ -277,18 +277,18 @@ These limitations apply uniformly to declarations with `external`, `= js("code")
 
 See how Kotlin types correspond to Javascript types:
 
-| Kotlin                                                  | JavaScript                        |
-|---------------------------------------------------------|-----------------------------------|
-| `Byte`, `Short`, `Int`, `Char`, `UByte`, `UShort`, `UInt` | `Number`                          |
-| `Float`, `Double`,                                      | `Number`                          |
-| `Long`, `ULong`                                                | `BigInt`                          |
-| `Boolean`,                                              | `Boolean`                         |
-| `String`,                                               | `String`                          |
-| `Unit` in return position                               | `undefined`                       |
-| Function type, for example `(String) -> Int`            | Function                          |
-| `JsAny` and subtypes                                    | Any JavaScript value              |
-| `JsReference`                                           | Opaque reference to Kotlin object |
-| Other types                                             | Not supported                     |
+| Kotlin                                                     | JavaScript                        |
+|------------------------------------------------------------|-----------------------------------|
+| `Byte`, `Short`, `Int`, `Char`, `UByte`, `UShort`, `UInt`, | `Number`                          |
+| `Float`, `Double`,                                         | `Number`                          |
+| `Long`, `ULong`,                                           | `BigInt`                          |
+| `Boolean`,                                                 | `Boolean`                         |
+| `String`,                                                  | `String`                          |
+| `Unit` in return position                                  | `undefined`                       |
+| Function type, for example `(String) -> Int`               | Function                          |
+| `JsAny` and subtypes                                       | Any JavaScript value              |
+| `JsReference`                                              | Opaque reference to Kotlin object |
+| Other types                                                | Not supported                     |
 
 You can use nullable versions of these types as well.
 

--- a/docs/topics/wasm/wasm-js-interop.md
+++ b/docs/topics/wasm/wasm-js-interop.md
@@ -256,12 +256,12 @@ To generate TypeScript definitions, in your `build.gradle.kts` file in the `wasm
 
 ```kotlin
 kotlin {
-  wasmJs {
-    binaries.executable()
-    browser {
+    wasmJs {
+        binaries.executable()
+        browser {
+        }
+        generateTypeScriptDefinitions()
     }
-    generateTypeScriptDefinitions()
-  }
 }
 ```
 

--- a/docs/topics/wasm/wasm-js-interop.md
+++ b/docs/topics/wasm/wasm-js-interop.md
@@ -247,6 +247,32 @@ import exports from "./module.mjs"
 exports.addOne(10)
 ```
 
+The Kotlin/Wasm compiler is capable of generating TypeScript definitions from any `@JsExport` declarations in your Kotlin code. 
+These definitions can be used by IDEs and JavaScript tools to provide code autocompletion, help with type-checks, and make it easier to include Kotlin code in JavaScript.
+
+The Kotlin/Wasm compiler collects any top-level functions marked with the `@JsExport` annotation and automatically generates TypeScript definitions in a `.d.ts` file.
+
+To generate TypeScript definitions, in your `build.gradle.kts` file in the `wasmJs` section, add the `generateTypeScriptDefinitions()` function:
+
+```kotlin
+kotlin {
+  wasmJs {
+    binaries.executable()
+    browser {
+    }
+    generateTypeScriptDefinitions()
+  }
+}
+```
+
+> Generating TypeScript declaration files in Kotlin/Wasm is [Experimental](components-stability.md#stability-levels-explained).
+> It may be dropped or changed at any time.
+>
+{type="warning"}
+
+Additionally, the `@JsExport` annotation lets you use unsigned primitive types inside external declarations and functions.
+You can export functions with unsigned primitives as a return or parameter type and consume external declarations that return unsigned primitives.
+
 ## Type correspondence
 
 Kotlin/Wasm allows only certain types in signatures of JavaScript interop declarations.


### PR DESCRIPTION
This PR contains additions to the Wasm interop page about the @JsExport annotation, according to the 2.0.0 release.