### PR TITLE
update: rename KMP get started

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -126,7 +126,7 @@
     </toc-element>
 
     <toc-element toc-title="Multiplatform development">
-        <toc-element id="multiplatform-get-started.md" accepts-web-file-names="building-mpp-with-gradle.html,intro-to-kotlin-mpp.html,mpp-intro.html,mpp-get-started.html,multiplatform-tutorials.html"/>
+        <toc-element id="multiplatform-get-started.md" accepts-web-file-names="building-mpp-with-gradle.html,intro-to-kotlin-mpp.html,mpp-intro.html,mpp-get-started.html,multiplatform-tutorials.html" toc-title="Introduction"/>
         <toc-element id="multiplatform-discover-project.md" accepts-web-file-names="mpp-discover-project.html" toc-title="Understand basic project structure"/>
         <toc-element id="multiplatform-advanced-project-structure.md" toc-title="Explore advanced project structure"/>
         <toc-element id="multiplatform-set-up-targets.md" toc-title="Set up targets" accepts-web-file-names="mpp-set-up-targets.html"/>

--- a/docs/topics/multiplatform/multiplatform-get-started.md
+++ b/docs/topics/multiplatform/multiplatform-get-started.md
@@ -1,4 +1,4 @@
-[//]: # (title: Get started with Kotlin Multiplatform)
+[//]: # (title: Introduction to Kotlin Multiplatform)
 [//]: # (description: Learn how to create your first Kotlin cross-platform app or library benefiting from Kotlin Multiplatform.)
 
 Support for multiplatform programming is one of Kotlin's key benefits. It reduces time spent writing and maintaining the 


### PR DESCRIPTION
a temporary workaround for the duplicated Get Started issue: the renamed page will one day be a technical overview with the "How it works" title. For now, the introduction title looks better.