### PR TITLE
chore: update core api reference docs (2.0.0)

### DIFF
--- a/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
+++ b/.teamcity/builds/kotlinlang/buidTypes/BuildSitePages.kt
@@ -144,7 +144,7 @@ object BuildSitePages : BuildType({
             }
         }
 
-        artifacts(AbsoluteId("Kotlin_KotlinRelease_1920_LibraryReferenceLegacyDocs")) {
+        artifacts(AbsoluteId("Kotlin_KotlinRelease_200_LibraryReferenceLegacyDocs")) {
             buildRule = tag("publish", """
                 +:<default>
                 +:*

--- a/static/js/page/api/api.js
+++ b/static/js/page/api/api.js
@@ -4,7 +4,7 @@ import Dropdown from '../../com/dropdown'
 import NavTree from '../../com/nav-tree'
 import './api.scss'
 
-const DEFAULT_VERSION = '1.9';
+const DEFAULT_VERSION = '2.0';
 const LOCAL_STORAGE_KEY = 'targetApi';
 const PLATFORM_AVAILABILITY = {
     'jvm': '1.0',
@@ -194,7 +194,8 @@ function initializeSelects() {
       '1.6': '1.6',
       '1.7': '1.7',
       '1.8': '1.8',
-      '1.9': '1.9'
+      '1.9': '1.9',
+      '2.0': '2.0'
     },
     selected: state.version != null ? state.version : DEFAULT_VERSION,
     onSelect: (version) => {


### PR DESCRIPTION
- use core api reference docs built with legacy Dokka from 2.0.0 project
- add version selector 2.0 for stdlib docs