### PR TITLE
Fixes for K2 compiler migration guide, type checks and casts, tour - control flow

### DIFF
--- a/docs/topics/k2-compiler-migration-guide.md
+++ b/docs/topics/k2-compiler-migration-guide.md
@@ -293,6 +293,8 @@ fun main(input: Rho) {
     var unknownObject: Rho = input
 
     // Check if unknownObject inherits from the Tau interface
+    // Note, it's possible that unKnownObject inherits from both
+    // Rho and Tau interfaces.
     if (unknownObject is Tau) {
 
         // Use the overloaded inc() operator from interface Rho,

--- a/docs/topics/tour/kotlin-tour-control-flow.md
+++ b/docs/topics/tour/kotlin-tour-control-flow.md
@@ -405,7 +405,7 @@ fun main() {
                 number % 15 == 0 -> "fizzbuzz"
                 number % 3 == 0 -> "fizz"
                 number % 5 == 0 -> "buzz"
-                else -> number.toString()
+                else -> "$number"
             }
         )
     }

--- a/docs/topics/typecasts.md
+++ b/docs/topics/typecasts.md
@@ -262,8 +262,9 @@ val x: String = y as String
 
 If the cast isn't possible, the compiler throws an exception. This is why it's called _unsafe_.
 
-In the previous example, if `y` is `null`, the code above also throws an exception. This is because `null` can't be cast to `String`, as `null` isn't [nullable](null-safety.md).
-To make the example work for possible null values, use a nullable type on the right-hand side of the cast:
+In the previous example, if `y` is `null`, the code above also throws an exception. This is because `null` can't be cast
+to `String`, as `String` isn't [nullable](null-safety.md). To make the example work for possible null values, use a nullable
+type on the right-hand side of the cast:
 
 ```kotlin
 val x: String? = y as String?

--- a/docs/topics/whatsnew20.md
+++ b/docs/topics/whatsnew20.md
@@ -327,6 +327,8 @@ fun main(input: Rho) {
     var unknownObject: Rho = input
 
     // Check if unknownObject inherits from the Tau interface
+    // Note, it's possible that unKnownObject inherits from both
+    // Rho and Tau interfaces.
     if (unknownObject is Tau) {
 
         // Uses the overloaded inc() operator from interface Rho,


### PR DESCRIPTION
This PR contains minor fixes for content in the K2 compiler migration guide, what's new for Kotlin 2.0.0, type checks and casts, and the tour - control flow.