### PR TITLE
Update data-analysis-libraries.md: Replace OptaPlanner with Timefold

### DIFF
--- a/docs/topics/data-analysis/data-analysis-libraries.md
+++ b/docs/topics/data-analysis/data-analysis-libraries.md
@@ -354,7 +354,7 @@ Here are some examples of such libraries:
   </tr>
   <tr>
     <td>
-      <a href="https://www.optaplanner.org/"><strong>OptaPlanner</strong></a>
+      <a href="https://github.com/TimefoldAI/"><strong>Timefold</strong></a>
     </td>
     <td>
       <list>


### PR DESCRIPTION
Timefold is the successor of OptaPlanner
OptaPlanner is discontinued: https://access.redhat.com/articles/7060671