### PR TITLE
KTL-1504 No redirect from /api/latest/kotlin.test to /api/latest/kotlin.test/

### DIFF
--- a/docs/topics/multiplatform/multiplatform-discover-project.md
+++ b/docs/topics/multiplatform/multiplatform-discover-project.md
@@ -299,7 +299,7 @@ source sets, such as `jvmTest`, are used to write platform-specific tests, for e
 need JVM APIs.
 
 Besides having a source set to write your common test, you also need a multiplatform testing framework. Kotlin
-provides a default [`kotlin.test`](https://kotlinlang.org/api/latest/kotlin.test) library that comes with
+provides a default [`kotlin.test`](https://kotlinlang.org/api/latest/kotlin.test/) library that comes with
 the `@kotlin.Test` annotation and various assertion methods like `assertEquals` and `assertTrue`.
 
 You can write platform-specific tests like regular tests for each platform in their respective source sets. Like with


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1504/No-redirect-from-api-latest-kotlin.test-to-api-latest-kotlin.test

I searched all the documentation for a similar link, but this is the only place to fix it.