### PR TITLE
Update Groovy syntax from using the set() function

### DIFF
--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -254,7 +254,7 @@ tasks.withType<CompileUsingKotlinDaemon>().configureEach {
 <tab title="Groovy" group-key="groovy">
 
 ```groovy
-tasks.withType(CompileUsingKotlinDaemon::class).configureEach { task ->
+tasks.withType(CompileUsingKotlinDaemon).configureEach { task ->
     task.kotlinDaemonJvmArguments = ["-Xmx1g", "-Xms512m"]
 }
 ```

--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -255,7 +255,7 @@ tasks.withType<CompileUsingKotlinDaemon>().configureEach {
 
 ```groovy
 tasks.withType(CompileUsingKotlinDaemon::class).configureEach { task ->
-    task.kotlinDaemonJvmArguments.set(["-Xmx1g", "-Xms512m"])
+    task.kotlinDaemonJvmArguments = ["-Xmx1g", "-Xms512m"]
 }
 ```
 
@@ -354,7 +354,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 tasks.withType(CompileUsingKotlinDaemon)
     .configureEach {
-        compilerExecutionStrategy.set(KotlinCompilerExecutionStrategy.IN_PROCESS)
+        compilerExecutionStrategy = KotlinCompilerExecutionStrategy.IN_PROCESS
     }
 ```
 

--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -112,7 +112,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 tasks.named('compileKotlin', KotlinCompilationTask) {
     compilerOptions {
-        suppressWarnings.set(true)
+        suppressWarnings = true
     }
 }
 ```

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -317,7 +317,7 @@ kotlin {
 ```groovy
 kotlin {
     jvmToolchain {
-        languageVersion = JavaLanguageVersion.of(<MAJOR_JDK_VERSION>))
+        languageVersion = JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)
     }
     // Or shorter:
     jvmToolchain(<MAJOR_JDK_VERSION>)

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -317,7 +317,7 @@ kotlin {
 ```groovy
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>))
+        languageVersion = JavaLanguageVersion.of(<MAJOR_JDK_VERSION>))
     }
     // Or shorter:
     jvmToolchain(<MAJOR_JDK_VERSION>)
@@ -350,7 +350,7 @@ java {
 ```groovy
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)) 
+        languageVersion = JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)
     }
 }
 ```
@@ -419,7 +419,7 @@ project.tasks.withType<UsesKotlinJavaToolchain>().configureEach {
 ```groovy
 JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class)
 Provider<JavaLauncher> customLauncher = service.launcherFor {
-    it.languageVersion.set(JavaLanguageVersion.of(<MAJOR_JDK_VERSION>))
+    it.languageVersion = JavaLanguageVersion.of(<MAJOR_JDK_VERSION>)
 }
 tasks.withType(UsesKotlinJavaToolchain::class).configureEach { task ->
     task.kotlinJavaToolchain.toolchain.use(customLauncher)

--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -512,7 +512,7 @@ browser {
 browser {
     commonWebpackConfig {
         cssSupport {
-            it.enabled.set(true)
+            it.enabled = true
         }
     }
 }
@@ -556,19 +556,19 @@ browser {
 browser {
     webpackTask {
         cssSupport {
-            it.enabled.set(true)
+            it.enabled = true
         }
     }
     runTask {
         cssSupport {
-            it.enabled.set(true)
+            it.enabled = true
         }
     }
     testTask {
         useKarma {
             // ...
             webpackConfig.cssSupport {
-                it.enabled.set(true)
+                it.enabled = true
             }
         }
     }
@@ -845,7 +845,7 @@ kotlin {
     js {
         browser {
             distribution {
-                outputDirectory.set(file("$projectDir/output"))
+                outputDirectory = file("$projectDir/output")
             }
         }
         binaries.executable()


### PR DESCRIPTION
This PR updates any instances in our docs where Groovy syntax uses the `set()` function and replaces it with an assignment operator.