### PR TITLE
Update Docs home page

### DIFF
--- a/docs/topics/home.xml
+++ b/docs/topics/home.xml
@@ -23,26 +23,21 @@
             <a href="command-line.md" description="Download and install the Kotlin compiler">Command-line compiler</a>
         </main-group>
         <highlighted-group>
-            <title>Featured topics</title>
-            <a href="https://kotlinlang.org/api/latest/jvm/stdlib/" description="Living essentials for everyday work with Kotlin: IO, files, threading, collections, and much more">Standard library API reference</a>
-            <a href="gradle.md" description="A build system to automate and manage your building process">Gradle</a>
-            <a href="basic-types.md" description="Kotlin type system: numbers, strings, arrays, and other built-in types">Basic types</a>
-            <a href="collections-overview.md" description="Collections: lists, sets, and maps">Collections</a>
-            <a href="scope-functions.md" description="Scope functions: let, with, run, apply, and also">Scope functions</a>
-            <a href="coroutines-overview.md" description="Concurrency: coroutines, flows, channels">Coroutines</a>
+            <title>Kotlin Multiplatform</title>
+            <a href="https://www.jetbrains.com/kotlin-multiplatform/" description="Learn how Kotlin Multiplatform helps you share code between your applications">Why Kotlin Multiplatform</a>
+            <a href="https://kmp.jetbrains.com/" description="Quickly create and download a multiplatform project template">Kotlin Multiplatform Wizard</a>
+            <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-getting-started.html" description="Create a mobile app that works on both Android and iOS">Get started with Kotlin Multiplatform</a>
+            <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-getting-started.html" description="Use Compose Multiplatform to implement one user interface across mobile, desktop, and web">Get started with Compose Multiplatform</a>
         </highlighted-group>
         <custom-groups>
             <group type="cards" display="wide">
-                <title>What's new</title>
+                <title>Featured topics</title>
                 <a href="whatsnew20.md" description="Latest features: the new Kotlin K2 compiler, better interoperability with JavaScript, improved Gradle build tool, and lots more">What's New in Kotlin 2.0.0</a>
-                <a href="roadmap.md" description="Future plans on Kotlin development">Kotlin public roadmap</a>
-            </group>
-            <group type="cards" display="wide">
-                <title>Kotlin Multiplatform</title>
-                <a href="https://www.jetbrains.com/kotlin-multiplatform/" description="Learn how Kotlin Multiplatform helps you share code between your applications">Why Kotlin Multiplatform</a>
-                <a href="https://kmp.jetbrains.com/" description="Quickly create and download a multiplatform project template">Kotlin Multiplatform Wizard</a>
-                <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-getting-started.html" description="Create a mobile app that works on both Android and iOS">Get started with Kotlin Multiplatform</a>
-                <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-getting-started.html" description="Use Compose Multiplatform to implement one user interface across all platforms">Get started with Compose Multiplatform</a>
+                <a href="releases.md" description="The latest Kotlin releases and instructions on how to update to them">Kotlin releases</a>
+                <a href="https://kotlinlang.org/api/latest/jvm/stdlib/" description="Living essentials for everyday work with Kotlin: IO, files, threading, collections, and much more">Standard library API reference</a>
+                <a href="basic-types.md" description="Kotlin type system: numbers, strings, arrays, and other built-in types">Basic types</a>
+                <a href="collections-overview.md" description="Collections: lists, sets, and maps">Collections</a>
+                <a href="coroutines-overview.md" description="Concurrency: coroutines, flows, channels">Coroutines</a>
             </group>
         </custom-groups>
     </section-starting-page>


### PR DESCRIPTION
This PR is to update the Docs home page:
* Move KMP section higher
* Collapse What's new and Featured topics sections into one
* Remove two featured topics
* Replace Public roadmap with Releases