### PR TITLE
Fix typo in mapping-primitive-data-types-from-c.md

### DIFF
--- a/docs/topics/native/mapping-primitive-data-types-from-c.md
+++ b/docs/topics/native/mapping-primitive-data-types-from-c.md
@@ -30,7 +30,7 @@ There are also more specific types:
 - `size_t` and `ptrdiff_t` (also `ssize_t`)
 - fixed width integer types, such as `int32_t` or `uint64_t` (from [C99](https://en.wikipedia.org/wiki/C99))
 
-There are also the following type qualifiers in the C language: `const`, `volatile`, `restruct`, `atomic`.
+There are also the following type qualifiers in the C language: `const`, `volatile`, `restrict`, `atomic`.
 
 The best way to see what C data types are visible in Kotlin is to try it.
 


### PR DESCRIPTION
This is a small fix to change typo in description of C keywords.