### PR TITLE
Fix String array mapped type on Java interop page

### DIFF
--- a/docs/topics/jvm/java-interop.md
+++ b/docs/topics/jvm/java-interop.md
@@ -552,10 +552,10 @@ Collection types may be read-only or mutable in Kotlin, so Java's collections ar
 
 Java's arrays are mapped as mentioned [below](java-interop.md#java-arrays):
 
-| **Java type** | **Kotlin type**  |
-|---------------|------------------|
-| `int[]`       | `kotlin.IntArray!` |
-| `String[]`    | `kotlin.Array<(out) String>!` |
+| **Java type** | **Kotlin type**                |
+|---------------|--------------------------------|
+| `int[]`       | `kotlin.IntArray!`             |
+| `String[]`    | `kotlin.Array<(out) String!>!` |
 
 >The static members of these Java types are not directly accessible on the [companion objects](object-declarations.md#companion-objects)
 >of the Kotlin types. To call them, use the full qualified names of the Java types, e.g. `java.lang.Integer.toHexString(foo)`.


### PR DESCRIPTION
This PR corrects the mapped type for `String[]` on the Java interop page.