### PR TITLE
Remove outdated course from Get started - Android

### DIFF
--- a/docs/topics/getting-started.md
+++ b/docs/topics/getting-started.md
@@ -116,9 +116,7 @@ If you've encountered any difficulties or problems, report an issue to our [issu
 
 <tab id="android" title="Android">
 
-* If you want to start using Kotlin for Android development, read [Google's recommendation for getting started with Kotlin on Android](https://developer.android.com/kotlin/get-started).
-
-* If you're new to Android and want to learn to create applications with Kotlin, check out [this Udacity course](https://www.udacity.com/course/developing-android-apps-with-kotlin--ud9012).
+To start using Kotlin for Android development, read [Google's recommendation for getting started with Kotlin on Android](https://developer.android.com/kotlin/get-started).
 
 Follow Kotlin on ![Twitter](twitter.svg){width=18}{type="joined"} [Twitter](https://twitter.com/kotlin), ![Reddit](reddit.svg){width=25}{type="joined"} [Reddit](https://www.reddit.com/r/Kotlin/), and ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw), and don't miss any important ecosystem updates.
 


### PR DESCRIPTION
This PR removes the outdated Udacity course link from the Android tab on the Get started page.