### PR TITLE
Fix IDE instruction for K2 Kotlin Mode

### DIFF
--- a/docs/topics/releases.md
+++ b/docs/topics/releases.md
@@ -66,7 +66,7 @@ Even with the release of the K2 compiler, IntelliJ IDEA and Android Studio still
 for code analysis, code completion, highlighting, and other IDE-related features.
 
 Starting from 2024.1, IntelliJ IDEA can use the new K2 compiler to analyze your code with its K2 Kotlin mode.
-To enable it, go to **Settings** | **Languages & Frameworks** | **Kotlin** and select the **Enable the K2-based Kotlin plugin** option.
+To enable it, go to **Settings** | **Languages & Frameworks** | **Kotlin** and select the **Enable K2 Kotlin Mode** option.
 
 > The K2 Kotlin mode is in Alpha. The performance and stability of code highlighting and code completion have been significantly improved,
 > but not all IDE features are supported yet.

--- a/docs/topics/whatsnew20.md
+++ b/docs/topics/whatsnew20.md
@@ -646,8 +646,8 @@ Kotlin Playground supports the 2.0.0 release. [Check it out!](https://pl.kotl.in
 By default, IntelliJ IDEA and Android Studio still use the previous compiler for code analysis, code completion,
 highlighting, and other IDE-related features. To get the full Kotlin 2.0 experience in your IDE, enable K2 Kotlin mode.
 
-In your IDE, go to **Settings** | **Languages & Frameworks** | **Kotlin** and select the **Enable the K2-based Kotlin
-plugin** option. The IDE will analyze your code using its K2 Kotlin mode.
+In your IDE, go to **Settings** | **Languages & Frameworks** | **Kotlin** and select the **Enable K2 Kotlin Mode** option.
+The IDE will analyze your code using its K2 Kotlin mode.
 
 > The K2 Kotlin mode is in Alpha and is available starting from 2024.1. The performance and stability of code
 > highlighting and code completion have been significantly improved, but not all IDE features are supported yet.


### PR DESCRIPTION
This PR corrects the UI element name to enable K2 Kotlin Mode in the IDE.