### PR TITLE
chore: update the roadmap update date

### DIFF
--- a/docs/topics/roadmap.md
+++ b/docs/topics/roadmap.md
@@ -7,7 +7,7 @@
     </tr>
     <tr>
         <td><strong>Next update</strong></td>
-        <td><strong>June 2024</strong></td>
+        <td><strong>August 2024</strong></td>
     </tr>
 </table>
 


### PR DESCRIPTION
Since we are still working on the Kotlin and its ecosystem strategy after the Kotlin 2.0.0 release, we (the JetBrains team) decided to move the date.