### PR TITLE
Add KMM AS plugin 0.8.3 release notes

### DIFF
--- a/docs/topics/multiplatform/multiplatform-plugin-releases.md
+++ b/docs/topics/multiplatform/multiplatform-plugin-releases.md
@@ -37,6 +37,25 @@ Compatible Kotlin version
 <tr>
 <td>
 
+**0.8.3**
+
+Released: 23 July, 2024
+
+</td>
+<td>
+
+* Fixes for Xcode compatibility issues.
+
+</td>
+<td>
+
+* [Any of Kotlin plugin versions](releases.md#release-details)
+
+</td>
+</tr>
+<tr>
+<td>
+
 **0.8.2**
 
 Released: 16 May, 2024


### PR DESCRIPTION
This PR adds the 0.8.3 version of the Kotlin Multiplatform plugin for Android Studio.