### PR TITLE
Add Gradle updates for 2.0.20

### DIFF
--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -13,10 +13,15 @@ On this page, you can learn about the following topics:
 
 ## Incremental compilation
 
-The Kotlin Gradle plugin supports incremental compilation. Incremental compilation tracks changes to source files between
-builds so that only the files affected by these changes are compiled.
+The Kotlin Gradle plugin supports incremental compilation. Incremental compilation tracks changes to files in the classpath
+between builds so that only the files affected by these changes are compiled. Incremental compilation works with [Gradle's
+build cache](#gradle-build-cache-support) and supports [compilation avoidance](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_compile_avoidance).
 
 Incremental compilation is supported for Kotlin/JVM and Kotlin/JS projects, and is enabled by default.
+
+> Kotlin/JS projects use a different incremental compilation approach based on history files. 
+>
+{type="note"}
 
 There are several ways to disable incremental compilation:
 
@@ -33,26 +38,8 @@ Note: Any build with incremental compilation disabled invalidates incremental ca
 >
 {type="tip"}
 
-### A new approach to incremental compilation
-
-The new approach to incremental compilation is available since Kotlin 1.7.0 for the JVM backend in the Gradle build system only. 
-Starting from Kotlin 1.8.20, this is enabled by default. This approach supports changes made inside dependent non-Kotlin modules, 
-includes an improved compilation avoidance, and is compatible with the [Gradle build cache](#gradle-build-cache-support).
-
-All of these enhancements decrease the number of non-incremental builds, making the overall compilation time faster. 
-You will receive the most benefit if you use the build cache, or, frequently make changes in non-Kotlin
-Gradle modules.
-
-To opt out from this new approach, set the following option in your `gradle.properties`:
-
-```none
-kotlin.incremental.useClasspathSnapshot=false
-```
-
-We would appreciate your feedback on this feature in [YouTrack](https://youtrack.jetbrains.com/issue/KT-49682).
-
-Learn how the new approach to incremental compilation is implemented under the hood in
-[this blog post](https://blog.jetbrains.com/kotlin/2022/07/a-new-approach-to-incremental-compilation-in-kotlin/).
+If you'd like to learn more about how our current incremental compilation approach works and compares to the previous one,
+see our [blog post](https://blog.jetbrains.com/kotlin/2022/07/a-new-approach-to-incremental-compilation-in-kotlin/).
 
 ### Precise backup of compilation tasks' outputs
 

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -50,7 +50,8 @@ In the following table, there are the minimum and maximum **fully supported** ve
 
 | KGP version   | Gradle min and max versions           | AGP min and max versions                            |
 |---------------|---------------------------------------|-----------------------------------------------------|
-| 2.0.0         | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 2.0.20        | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 2.0.0         | 6.8.3–8.5                             | 7.1.3–8.3.1                                         |
 | 1.9.20–1.9.25 | 6.8.3–8.1.1                           | 4.2.2–8.1.0                                         |
 | 1.9.0–1.9.10  | 6.8.3–7.6.0                           | 4.2.2–7.4.0                                         |
 | 1.8.20–1.8.22 | 6.8.3–7.6.0                           | 4.1.3–7.4.0                                         |      

--- a/docs/v.list
+++ b/docs/v.list
@@ -20,11 +20,11 @@
 
     <var name="minGradleVersion" value="6.8.3" type="string"/>
 
-    <var name="maxGradleVersion" value="8.5" type="string"/>
+    <var name="maxGradleVersion" value="8.8" type="string"/>
 
     <var name="minAndroidGradleVersion" value="7.1.3" type="string"/>
 
-    <var name="maxAndroidGradleVersion" value="8.3.1" type="string"/>
+    <var name="maxAndroidGradleVersion" value="8.5" type="string"/>
 
     <var name="gradleVersion" value="8.5" type="string"/>
 


### PR DESCRIPTION
This PR updates Gradle versions for 2.0.20 and removes the section about the "new" incremental compilation approach.