### PR TITLE
feat: static accessors for the default hierarchy

### DIFF
--- a/docs/topics/multiplatform/multiplatform-android-dependencies.md
+++ b/docs/topics/multiplatform/multiplatform-android-dependencies.md
@@ -11,8 +11,10 @@ set. For that, update your `build.gradle(.kts)` file in the `shared` directory o
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-sourceSets["androidMain"].dependencies {
-    implementation("com.example.android:app-magic:12.3")
+sourceSets {
+    androidMain.dependencies {
+        implementation("com.example.android:app-magic:12.3")
+    }
 }
 ```
 
@@ -36,13 +38,13 @@ Moving what was a top-level dependency in an Android project to a specific sourc
 might be difficult if the top-level dependency had a non-trivial configuration name. For example, to move
 a `debugImplementation` dependency from the top level of an Android project, you'll need to add an implementation
 dependency to the source set named `androidDebug`. To minimize the effort you have to put in to deal with migration
-problems like this, you can add a `dependencies {}` block inside the `android {}` block:
+problems like this, you can add a `dependencies {}` block inside the `androidTarget {}` block:
 
 <tabs group="build-script">
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-android {
+androidTarget {
     //...
     dependencies {
         implementation("com.example.android:app-magic:12.3")
@@ -54,7 +56,7 @@ android {
 <tab title="Groovy" group-key="groovy">
 
 ```groovy
-android {
+androidTarget {
     //...
     dependencies {
         implementation 'com.example.android:app-magic:12.3'

--- a/docs/topics/multiplatform/multiplatform-hierarchy.md
+++ b/docs/topics/multiplatform/multiplatform-hierarchy.md
@@ -21,7 +21,7 @@ This is a more low-level approach: it's more flexible but requires more effort a
 
 ## Default hierarchy template
 
-Starting with Kotlin 1.9.20, the Kotlin Gradle plugin has a built-in default [hierarchy template](#see-the-full-hierarchy-template).
+The Kotlin Gradle plugin has a built-in default [hierarchy template](#see-the-full-hierarchy-template).
 It contains predefined intermediate source sets for some popular use cases.
 The plugin sets up those source sets automatically based on the targets specified in your project.
 
@@ -64,8 +64,10 @@ are no watchOS targets in the project.
 If you add a watchOS target, like `watchosArm64`, the `watchos` source set is created, and the code
 from the `apple`, `native`, and `common` source sets is compiled to `watchosArm64` as well.
 
-The Kotlin Gradle plugin creates type-safe accessors for all of the source sets from the default hierarchy template,
-so you can reference them without `by getting` or `by creating` constructions compared to the [manual configuration](#manual-configuration):
+The Kotlin Gradle plugin provides both type-safe and static accessors for all of the source sets from the default hierarchy
+template, so you can reference them without `by getting` or `by creating` constructions compared to the [manual configuration](#manual-configuration).
+
+If you try to access the source set without declaring the corresponding target first, you'll see a warning:
 
 <tabs group="build-script">
 <tab title="Kotlin" group-key="kotlin">
@@ -80,6 +82,8 @@ kotlin {
         iosMain.dependencies {
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
         }
+        linuxX64Main { } // Warning: accessing source set
+                         // without declaring the target
     }
 }
 ```
@@ -99,6 +103,8 @@ kotlin {
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%'
             }
         }
+        linuxX64Main { } // Warning: accessing source set
+                         // without registering the target
     }
 }
 ```

--- a/docs/topics/multiplatform/multiplatform-hierarchy.md
+++ b/docs/topics/multiplatform/multiplatform-hierarchy.md
@@ -65,7 +65,7 @@ If you add a watchOS target, like `watchosArm64`, the `watchos` source set is cr
 from the `apple`, `native`, and `common` source sets is compiled to `watchosArm64` as well.
 
 The Kotlin Gradle plugin provides both type-safe and static accessors for all of the source sets from the default hierarchy
-template, so you can reference them without `by getting` or `by creating` constructions compared to the [manual configuration](#manual-configuration).
+template, so you can reference them without `by getting` or `by creating` constructs compared to the [manual configuration](#manual-configuration).
 
 If you try to access the source set without declaring the corresponding target first, you'll see a warning:
 
@@ -82,8 +82,8 @@ kotlin {
         iosMain.dependencies {
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
         }
-        linuxX64Main { } // Warning: accessing source set
-                         // without declaring the target
+        // Warning: accessing source set without declaring the target
+        linuxX64Main { }
     }
 }
 ```
@@ -103,8 +103,8 @@ kotlin {
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%'
             }
         }
-        linuxX64Main { } // Warning: accessing source set
-                         // without registering the target
+        // Warning: accessing source set without declaring the target
+        linuxX64Main { }
     }
 }
 ```


### PR DESCRIPTION
This PR changes the description of the default source set hierarchy, following [KT-56566](https://youtrack.jetbrains.com/issue/KT-56566), plus fixes mentions of the Android target