### PR TITLE
Add details for Kotlin 2.0.20-RC2 release

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -34,7 +34,7 @@
 
     <toc-element toc-title="What's new in Kotlin">
         <toc-element id="whatsnew20.md" toc-title="Kotlin 2.0.0" accepts-web-file-names="whatsnew.html"/>
-        <toc-element id="whatsnew-eap.md" toc-title="Kotlin 2.0.20-RC"/>
+        <toc-element id="whatsnew-eap.md" toc-title="Kotlin 2.0.20-RC2"/>
         <toc-element toc-title="Earlier versions">
             <toc-element id="whatsnew1920.md" toc-title="Kotlin 1.9.20"/>
             <toc-element id="whatsnew19.md" toc-title="Kotlin 1.9.0"/>

--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -46,13 +46,13 @@ check [our instructions on how to configure your build to support this version](
         <th>Build highlights</th>
     </tr>
     <tr>
-        <td><strong>2.0.20-RC</strong>
-            <p>Released: <strong>July 30, 2024</strong></p>
-            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.20-RC" target="_blank">Release on GitHub</a></p>
+        <td><strong>2.0.20-RC2</strong>
+            <p>Released: <strong>August 13, 2024</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.20-RC2" target="_blank">Release on GitHub</a></p>
         </td>
         <td>
             <p>A tooling release for Kotlin 2.0.0</p>
-            <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.20-RC">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.0.20-RC</a>.</p>
+            <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.0.20-RC2">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.0.20-RC2</a>.</p>
         </td>
     </tr>
 </table>

--- a/docs/topics/whatsnew-eap.md
+++ b/docs/topics/whatsnew-eap.md
@@ -166,7 +166,7 @@ is automatically applied to all Kotlin Multiplatform projects.
 And for all of the source sets from the default hierarchy template, the Kotlin Gradle plugin provided type-safe accessors.
 That way, you could finally access source sets for all the specified targets without having to use `by getting` or `by creating` constructions.
 
-Kotlin 2.0.20 aims to improve your IDE experience even further. It now provides static assessors in 
+Kotlin 2.0.20 aims to improve your IDE experience even further. It now provides static accessors in 
 the `sourceSets {}` block for all the source sets from the default hierarchy template. 
 We believe this change will make accessing source sets by name easier and more predictable.
 
@@ -316,18 +316,18 @@ Bitcode embedding was deprecated in Xcode 14 and removed in Xcode 15 for all App
 Now, the `embedBitcode` parameter for the framework configuration, 
 as well as the `-Xembed-bitcode` and `-Xembed-bitcode-marker` command line arguments are deprecated.
 
-If you still use earlier versions of Xcode but want to upgrade to %kotlinEapVersion%, 
+If you still use earlier versions of Xcode but want to upgrade to Kotlin %kotlinEapVersion%, 
 disable bitcode embedding in your Xcode projects.
 
 ### Changes to monitoring GC performance with signposts
 
-Kotlin 2.0.0 made it possible to monitor the performance of Kotlin/Native garbage collector 
+Kotlin 2.0.0 has made it possible to monitor the performance of Kotlin/Native garbage collector 
 (GC) through Xcode Instruments. Instruments include the signposts tool, which can show GC pauses as events. 
 This comes in handy when checking GC-related freezes in your iOS apps.
 
 The feature was enabled by default, but unfortunately, 
 it sometimes led to crashes when the application was run simultaneously with Xcode Instruments. 
-Starting with %kotlinEapVersion%, it requires an explicit opt-in with the following compilation option:
+Starting with %kotlinEapVersion%, it requires an explicit opt-in with the following compiler option:
 
 ```none
 -Xbinary=enableSafepointSignposts=true
@@ -336,7 +336,7 @@ Starting with %kotlinEapVersion%, it requires an explicit opt-in with the follow
 <!-- Uncomment for the final release
 Learn more about GC performance analysis in the [documentation](native-memory-manager.md#monitor-gc-performance). -->
 
-### Calling Kotlin suspending function from Swift/Objective-C on non-main threads
+### Calling Kotlin suspending functions from Swift/Objective-C on non-main threads
 
 Previously, Kotlin/Native had a default restriction, limiting the ability to call Kotlin suspending functions from Swift
 and Objective-C to only the main thread. Kotlin %kotlinEapVersion% lifts that limitation, allowing you to run Kotlin 
@@ -558,9 +558,8 @@ kotlin.jvm.addClassesVariant=true
 
 By default, this property is set to false and the `apiElements` variant in Gradle requests the compressed JAR artifact.
 
-> Gradle has a related property that you can use in your Java-only projects to only expose the  
-> compressed JAR artifact during compilation **instead** of the directories containing compiled
-> `.class` files:
+> Gradle has a related property that you can use in your Java-only projects to only expose the compressed JAR artifact 
+> during compilation **instead** of the directories containing compiled `.class` files:
 >
 > ```none
 > org.gradle.java.compile-classpath-packaging=true

--- a/docs/topics/whatsnew-eap.md
+++ b/docs/topics/whatsnew-eap.md
@@ -10,7 +10,7 @@ _[Released: %kotlinEapReleaseDate%](eap.md#build-details)_
 {type="note"}
 
 The Kotlin %kotlinEapVersion% release is out!
-This document contains some details of this EAP release.
+This document contains some details about this EAP release.
 
 ## IDE support
 
@@ -24,15 +24,13 @@ See [Update to a new release](releases.md#update-to-a-new-release) for details.
 
 ### Data class copy function to have the same visibility as constructor
 
-Currently, if you create a data class using a `private` constructor, 
-the automatically generated `.copy()` function doesn't have the same visibility. 
-This can cause problems later in your code. 
-In future Kotlin releases, we will introduce the behavior that the default visibility of the `.copy()` function is the same as the constructor.
-This change will be introduced gradually to help you migrate your code as smoothly as possible.
+Currently, if you create a data class using a `private` constructor, the automatically generated `.copy()` function doesn't
+have the same visibility. This can cause problems later in your code. In future Kotlin releases, we will introduce the 
+behavior that the default visibility of the `.copy()` function is the same as the constructor. This change will be 
+introduced gradually to help you migrate your code as smoothly as possible.
 
-Our migration plan starts with Kotlin %kotlinEapVersion%, 
-where we issue warnings in your code where the visibility will change in the future. 
-For example:
+Our migration plan starts with Kotlin %kotlinEapVersion%, where we issue warnings in your code where the visibility will
+change in the future. For example:
 
 ```kotlin
 // Triggers a warning in %kotlinEapVersion%
@@ -51,10 +49,9 @@ fun main() {
 }
 ```
 
-For the latest information about our migration plan,
-see the corresponding issue in [YouTrack](https://youtrack.jetbrains.com/issue/KT-11914).
+For the latest information about our migration plan, see the corresponding issue in [YouTrack](https://youtrack.jetbrains.com/issue/KT-11914).
 
-To give you more control over this behavior, in Kotlin %kotlinEapVersion% we’ve introduced two annotations:
+To give you more control over this behavior, in Kotlin %kotlinEapVersion% we've introduced two annotations:
 
 * `@ConsistentCopyVisibility` to opt in to the behavior now before we make it the default in a later release.
 * `@ExposedCopyVisibility` to opt out of the behavior and suppress warnings at the declaration site. 
@@ -167,7 +164,7 @@ If you use context receivers in your code, we recommend that you migrate your co
 Since Kotlin 1.9.20, the [default hierarchy template](multiplatform-hierarchy.md#default-hierarchy-template) 
 is automatically applied to all Kotlin Multiplatform projects. 
 And for all of the source sets from the default hierarchy template, the Kotlin Gradle plugin provided type-safe accessors.
-That way you could finally access source sets for all the specified targets without having to use `by getting` or `by creating` constructions.
+That way, you could finally access source sets for all the specified targets without having to use `by getting` or `by creating` constructions.
 
 Kotlin 2.0.20 aims to improve your IDE experience even further. It now provides static assessors in 
 the `sourceSets {}` block for all the source sets from the default hierarchy template. 
@@ -209,7 +206,7 @@ Due to compatibility issues between the Kotlin Multiplatform Gradle plugin and t
 [Java Library](https://docs.gradle.org/current/userguide/java_library_plugin.html), 
 and [Application](https://docs.gradle.org/current/userguide/application_plugin.html), 
 Kotlin %kotlinEapVersion% introduces a deprecation warning when you apply these plugins in the same project.
-In future Kotlin releases, the warning will be increased to an error.
+In future Kotlin releases, the warning will be raised to an error.
 
 If you want to use both the Kotlin Multiplatform Gradle plugin in combination with these Gradle plugins for Java in your multiplatform project, 
 we recommend that you:
@@ -291,12 +288,11 @@ Your parent project is now set up to work with both plugins.
 ### Concurrent marking in garbage collector
 
 In Kotlin %kotlinEapVersion%, the JetBrains team takes another step toward improving Kotlin/Native runtime performance.
-We add experimental support for concurrent marking in the garbage collector (GC).
+We've added experimental support for concurrent marking in the garbage collector (GC).
 
-By default, application threads must be paused when GC is marking objects in the heap. 
-This greatly affects the duration of the GC pause time,
-which is important for the performance of latency-critical applications,
-such as UI applications built with Compose Multiplatform.
+By default, application threads must be paused when GC is marking objects in the heap. This greatly affects the duration
+of the GC pause time, which is important for the performance of latency-critical applications, such as UI applications 
+built with Compose Multiplatform.
 
 Now, the marking phase of the garbage collection can be run simultaneously with application threads.
 This should significantly shorten the GC pause time and help improve app responsiveness.
@@ -340,15 +336,24 @@ Starting with %kotlinEapVersion%, it requires an explicit opt-in with the follow
 <!-- Uncomment for the final release
 Learn more about GC performance analysis in the [documentation](native-memory-manager.md#monitor-gc-performance). -->
 
+### Calling Kotlin suspending function from Swift/Objective-C on non-main threads
+
+Previously, Kotlin/Native had a default restriction, limiting the ability to call Kotlin suspending functions from Swift
+and Objective-C to only the main thread. Kotlin %kotlinEapVersion% lifts that limitation, allowing you to run Kotlin 
+`suspend` functions from Swift/Objective-C on any thread.
+
+If you've previously switched the default behavior for non-main threads with the `kotlin.native.binary.objcExportSuspendFunctionLaunchThreadRestriction=none`
+binary option, you can now remove it from your `gradle.properties` file.
+
 ## Kotlin/Wasm
 
 ### Error in default export usage
 
-As part of the migration towards named exports, 
-a warning message was previously printed to the console when using a default import for Kotlin/Wasm exports in JavaScript.
+As part of the migration towards named exports, a warning message was previously printed to the console when using a default
+import for Kotlin/Wasm exports in JavaScript.
 
-To fully support named exports, this warning has now upgraded to an error. 
-If you use a default import, you encounter the following error message:
+To fully support named exports, this warning has now been upgraded to an error. If you use a default import, you encounter
+the following error message:
 
 ```text
 Do not use default import. Use the corresponding named import instead.
@@ -356,14 +361,14 @@ Do not use default import. Use the corresponding named import instead.
 
 This change is part of a deprecation cycle to migrate towards named exports. Here's what you can expect during each phase:
 
-* **In version 2.0.0**: a warning message is printed to the console, explaining that exporting entities via default exports is deprecated.
-* **In version 2.0.20**: an error occurs, requesting the use of the corresponding named import.
-* **In version 2.1.0**: the use of default imports is completely removed.
+* **In version 2.0.0**: A warning message is printed to the console, explaining that exporting entities via default exports is deprecated.
+* **In version 2.0.20**: An error occurs, requesting the use of the corresponding named import.
+* **In version 2.1.0**: The use of default imports is completely removed.
 
 ### New location of ExperimentalWasmDsl annotation
 
-Previously, the `@ExperimentalWasmDsl` annotation for WebAssembly (Wasm) 
-features was placed in this location within the Kotlin Gradle plugin:
+Previously, the `@ExperimentalWasmDsl` annotation for WebAssembly (Wasm) features was placed in this location within the
+Kotlin Gradle plugin:
 
 ```Kotlin
 org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
@@ -377,8 +382,7 @@ org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 The previous location is now deprecated and might lead to build failures with unresolved references.
 
-To reflect the new location of the `@ExperimentalWasmDsl` annotation, 
-update the import statement in your Gradle build scripts. 
+To reflect the new location of the `@ExperimentalWasmDsl` annotation, update the import statement in your Gradle build scripts. 
 Use an explicit import for the new `@ExperimentalWasmDsl` location:
 
 ```kotlin
@@ -391,12 +395,88 @@ Alternatively, remove this star import statement from the old package:
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
 ```
 
+## Kotlin/JS
+
+### Support for static members in JavaScript
+
+> This feature is [Experimental](components-stability.md#stability-levels-explained). It may be dropped or changed at any time.
+> Use it only for evaluation purposes. We would appreciate your feedback on it in [YouTrack](https://youtrack.jetbrains.com/issue/KT-18891/JS-provide-a-way-to-declare-static-members-JsStatic).
+>
+{type="warning"}
+
+Starting with Kotlin %kotlinEapVersion%, you can use the `@JsStatic` annotation. It works similarly to [@JvmStatic](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-static/)
+and instructs the compiler to generate additional static methods for the target declaration. This helps you use static 
+members from your Kotlin code directly in JavaScript.
+
+You can use the `@JsStatic` annotation for functions defined in named objects, as well as in companion objects declared 
+inside classes and interfaces. The compiler generates both a static method of the object and an instance method in the 
+object itself. For example:
+
+```kotlin
+class C {
+    companion object {
+        @JsStatic fun callStatic() {}
+        fun callNonStatic() {}
+    }
+}
+```
+
+Now, `callStatic()` is static in JavaScript while `callNonStatic()` is not:
+
+```javascript
+C.callStatic();              // Works, accessing the static function
+C.callNonStatic();           // Error, not a static function in the generated JavaScript
+C.Companion.callStatic();    // Instance method remains
+C.Companion.callNonStatic(); // The only way it works
+```
+
+It's also possible to apply the `@JsStatic` annotation on a property of an object or a companion object, making its getter
+and setter methods static members in that object or the class containing the companion object.
+
+### Creating Kotlin collections from JavaScript
+
+> This feature is [Experimental](components-stability.md#stability-levels-explained). It may be dropped or changed at any time.
+> Use it only for evaluation purposes. We would appreciate your feedback on it in [YouTrack](https://youtrack.jetbrains.com/issue/KT-69133/Kotlin-JS-Add-support-for-collection-instantiation-in-JavaScript).
+>
+{type="warning"}
+
+Kotlin 2.0.0 introduced the ability to export Kotlin collections to JavaScript (and TypeScript). Now, the JetBrains team
+is taking another step to improve collection interoperability. Starting with Kotlin %kotlinEapVersion%, it's possible to
+create Kotlin collections directly from the JavaScript/TypeScript side.
+
+You can create Kotlin collections from JavaScript and pass them as arguments to the exported constructors or functions.
+As soon as you mention a collection inside an exported declaration, Kotlin generates a factory for the collection that 
+is available in JavaScript/TypeScript.
+
+Take a look at the following exported function:
+
+```kotlin
+// Kotlin
+@JsExport
+fun consumeMutableMap(map: MutableMap<String, Int>)
+```
+
+Since the `MutableMap` collection is mentioned, Kotlin generates an object with a factory method available from JavaScript/TypeScript.
+This factory method then creates a `MutableMap` from a JavaScript's `Map`:
+
+```javascript
+// JavaScript
+import { consumeMutableMap } from "an-awesome-kotlin-module"
+import { KtMutableMap } from "an-awesome-kotlin-module/kotlin-kotlin-stdlib"
+
+consumeMutableMap(
+    KtMutableMap.fromJsMap(new Map([["First", 1], ["Second", 2]]))
+)
+```
+
+This feature is available for `Set`, `Map`, and `List` Kotlin collection types and their mutable counterparts.
+
 ## Gradle improvements
 
 ### Gradle support for versions 8.6–8.8
 
 Kotlin %kotlinEapVersion% is fully compatible with Gradle 6.8.3 through 8.6. 
-Gradle 8.7 and 8.8 are also supported, with only one exception: if you use the Kotlin Multiplatform Gradle plugin, 
+Gradle 8.7 and 8.8 are also supported, with only one exception: If you use the Kotlin Multiplatform Gradle plugin, 
 you may see deprecation warnings in your multiplatform projects
 if you use the [`withJava()` function in the JVM target](multiplatform-dsl-reference.md#jvm-targets). 
 We plan to fix this issue as soon as possible. 
@@ -418,12 +498,11 @@ Given that the new incremental compilation approach has been used by default for
 the `kotlin.incremental.useClasspathSnapshot` Gradle property is deprecated in Kotlin %kotlinEapVersion%.
 Therefore, if you use it to opt out, you will see a deprecation warning.
 
-### Added task dependency for a rare case when compile task is missing one on an artifact
+### Added task dependency for rare cases when the compile task lacks one on an artifact
 
-Prior to %kotlinEapVersion%, 
-we found that there were scenarios where a compile task was missing a task dependency for one of its artifact inputs.
-This meant that the result of the dependent compile task was unstable, as sometimes the artifact had been generated in time,
-but sometimes it hadn't.
+Prior to %kotlinEapVersion%, we found that there were scenarios where a compile task was missing a task dependency for one
+of its artifact inputs. This meant that the result of the dependent compile task was unstable, as sometimes the artifact
+had been generated in time, but sometimes, it hadn't.
 
 To fix this issue, the Kotlin Gradle plugin now automatically adds the required task dependency in these scenarios.
 
@@ -444,9 +523,8 @@ Circular dependency between the following tasks:
 
 To fix this circular dependency error, we've added a Gradle property: `archivesTaskOutputAsFriendModule`.
 
-By default, this property is set to `true` to track the task dependency. 
-To disable the use of the artifact in the compilation task, so that no task dependency is required, 
-add the following in your `gradle.properties` file:
+By default, this property is set to `true` to track the task dependency. To disable the use of the artifact in the compilation
+task, so that no task dependency is required, add the following in your `gradle.properties` file:
 
 ```kotlin
 kotlin.build.archivesTaskOutputAsFriendModule=false
@@ -464,11 +542,10 @@ For more information, see the issue in [YouTrack](https://youtrack.jetbrains.com
 {type="warning"}
 
 In Kotlin %kotlinEapVersion%, we introduce a new approach that changes the way the outputs of Kotlin/JVM compilations, 
-such as JAR files, are shared between projects. 
-With this approach, Gradle's `apiElements` configuration now has a secondary variant 
-that provides access to the directory containing compiled `.class` files. 
-When configured, your project uses this directory instead of requesting the compressed JAR artifact during compilation. 
-This reduces the number of times JAR files are compressed and decompressed, especially for incremental builds.
+such as JAR files, are shared between projects. With this approach, Gradle's `apiElements` configuration now has a secondary
+variant that provides access to the directory containing compiled `.class` files. When configured, your project uses this
+directory instead of requesting the compressed JAR artifact during compilation. This reduces the number of times JAR files
+are compressed and decompressed, especially for incremental builds.
 
 Our testing shows that this new approach can provide build performance improvements for Linux and macOS hosts. 
 However, on Windows hosts, we have seen a degradation in performance due to how Windows handles I/O operations when working with files.
@@ -499,7 +576,7 @@ Let us know by adding a comment in [YouTrack](https://youtrack.jetbrains.com/iss
 
 ## Compose compiler
 
-In %kotlinEapVersion%, the Compose compiler gets a few improvements.
+In Kotlin %kotlinEapVersion%, the Compose compiler gets a few improvements.
 
 ### Fixed the unnecessary recompositions issue introduced in 2.0.0
 
@@ -514,10 +591,8 @@ To prevent this, update your dependencies to versions built with the same Compos
 ### New way to configure compiler options
 
 We have introduced a new option configuration mechanism to avoid churn of top-level parameters:
-it's harder for the Compose compiler team to test things out
-by creating or removing top-level entries for the `composeCompiler {}` block.
+it's harder for the Compose compiler team to test things out by creating or removing top-level entries for the `composeCompiler {}` block.
 So options such as strong skipping mode and non-skipping group optimizations are now enabled through the `featureFlags` property.
-
 This property will be used to test new Compose compiler options that will eventually become default.
 
 This change has also been applied to the Compose compiler Gradle plugin. To configure feature flags going forward,
@@ -541,10 +616,9 @@ Or, if you are configuring the Compose compiler directly, use the following synt
 
 The `enableIntrinsicRemember`, `enableNonSkippingGroupOptimization`, and `enableStrongSkippingMode` properties have been therefore deprecated.
 
-We would appreciate any feedback
-you have on this new approach in [YouTrack](https://youtrack.jetbrains.com/issue/KT-68651/Compose-provide-a-single-place-in-extension-to-configure-all-compose-flags).
+We would appreciate any feedback you have on this new approach in [YouTrack](https://youtrack.jetbrains.com/issue/KT-68651/Compose-provide-a-single-place-in-extension-to-configure-all-compose-flags).
 
-### strongSkipping mode enabled by default
+### Strong skipping mode enabled by default
 
 Strong skipping mode for the Compose compiler is now enabled by default.
 
@@ -557,18 +631,16 @@ For more details, see the [strong skipping mode documentation](https://developer
 
 ### Non-skipping group optimizations
 
-This release includes a new compiler option: when enabled,
-non-skippable and non-restartable composable functions will no longer generate a group around the body of the composable.
-This leads to less allocations and thus to improved performance.
+This release includes a new compiler option: when enabled, non-skippable and non-restartable composable functions will no
+longer generate a group around the body of the composable. This leads to less allocations and thus to improved performance.
 This option is experimental and disabled by default but can be enabled with the feature flag `OptimizeNonSkippingGroups`
 as shown [above](#new-way-to-configure-compiler-options).
 
-This feature flag is now ready for wider testing.
-Any issues found when enabling the feature can be filed on the [Google issue tracker](https://goo.gle/compose-feedback).
+This feature flag is now ready for wider testing. Any issues found when enabling the feature can be filed on the [Google issue tracker](https://goo.gle/compose-feedback).
 
-### open and abstract Composable functions support default parameters
+### abstract Composable functions support default parameters
 
-You can now add default parameters to open and abstract Composable functions.
+You can now add default parameters to abstract Composable functions.
 
 Previously, the Compose compiler would report an error when attempting to do this even though it is valid Kotlin.
 We have now added support for this in the Compose compiler, and the restriction has been removed.
@@ -580,6 +652,9 @@ abstract class Composables {
     abstract fun Composable(modifier: Modifier = Modifier)
 }
 ```
+
+Default parameters for open Composable functions are still restricted in %kotlinEapVersion%. This restriction will be 
+addressed in future releases.
 
 ## How to update to Kotlin %kotlinEapVersion%
 

--- a/docs/v.list
+++ b/docs/v.list
@@ -6,13 +6,13 @@
 
     <var name="kotlinVersion" value="2.0.10" type="string"/>
 
-    <var name="kotlinEapVersion" value="2.0.20-RC" type="string"/>
+    <var name="kotlinEapVersion" value="2.0.20-RC2" type="string"/>
 
     <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.0.10" type="string"/>
 
     <var name="kotlinReleaseDate" value="August 6, 2024" type="string"/>
 
-    <var name="kotlinEapReleaseDate" value="July 30, 2024" type="string"/>
+    <var name="kotlinEapReleaseDate" value="August 13, 2024" type="string"/>
 
     <var name="coroutinesVersion" value="1.8.1" type="string"/>
 


### PR DESCRIPTION
This PR adds information about the Kotlin 2.0.20-RC2 release.