### PR TITLE
Add information about how to use default import.

### DIFF
--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -91,3 +91,20 @@ The new exception handling proposal is activated using the `-Xwasm-use-new-excep
 > [Kotlin/Wasm examples](https://github.com/Kotlin/kotlin-wasm-examples#readme).
 >
 {type="tip"}
+
+## Use default import
+
+To [import Kotlin/Wasm code into Javascript](wasm-js-interop.md), we have introduced named exports while moving away from default exports.
+
+If you still want to use a default import, you can generate a new JavaScript wrapper module. Create a `.mjs` file with the following snippet:
+
+```Javascript
+import * as moduleExports from "./wasm-test.mjs"; // path to main mjs file
+
+export { moduleExports as default };
+```
+
+You can place this `.mjs` file in the resources folder, and it will automatically be placed next to your main `.mjs` file during the build process.
+
+You can also place this `.mjs` file in a custom location. In this case, you need to either manually move it next to the main `.mjs` file or 
+adjust the relative path in the import statement to match its location.

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -99,12 +99,13 @@ To [import Kotlin/Wasm code into Javascript](wasm-js-interop.md), we have introd
 If you still want to use a default import, you can generate a new JavaScript wrapper module. Create a `.mjs` file with the following snippet:
 
 ```Javascript
-import * as moduleExports from "./wasm-test.mjs"; // path to main mjs file
+// Specifies the path to the main .mjs file
+import * as moduleExports from "./wasm-test.mjs";
 
 export { moduleExports as default };
 ```
 
-You can place this `.mjs` file in the resources folder, and it will automatically be placed next to your main `.mjs` file during the build process.
+You can place your new `.mjs` file in the resources folder, and it will automatically be placed next to the main `.mjs` file during the build process.
 
-You can also place this `.mjs` file in a custom location. In this case, you need to either manually move it next to the main `.mjs` file or 
-adjust the relative path in the import statement to match its location.
+You can also place your `.mjs` file in a custom location. In this case, you need to either manually move it next to the main `.mjs` file or 
+adjust the path in the import statement to match its location.

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -94,9 +94,9 @@ The new exception handling proposal is activated using the `-Xwasm-use-new-excep
 
 ## Use default import
 
-To [import Kotlin/Wasm code into Javascript](wasm-js-interop.md), we have introduced named exports while moving away from default exports.
+[Importing Kotlin/Wasm code into Javascript](wasm-js-interop.md) has shifted to named exports, moving away from default exports.
 
-If you still want to use a default import, you can generate a new JavaScript wrapper module. Create a `.mjs` file with the following snippet:
+If you still want to use a default import, generate a new JavaScript wrapper module. Create a `.mjs` file with the following snippet:
 
 ```Javascript
 // Specifies the path to the main .mjs file


### PR DESCRIPTION
This PR contains doc updates for the Kotlin 2.0.20 release. The updates include adding information about how to use default import.