### PR TITLE
fix: clearer reference to the KMP plugin

### DIFF
--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -10,10 +10,10 @@ developing projects with Kotlin Multiplatform.
 
 ## Version compatibility
 
-When configuring your project, check the compatibility of a particular Kotlin version (the version of Kotlin Multiplatform Gradle plugin)
+When configuring your project, check the compatibility of a particular version of the Kotlin Multiplatform Gradle plugin (same as the Kotlin version in your project)
 with available Gradle, Xcode, and Android Gradle plugin versions:
 
-| Kotlin version | Gradle    | Android Gradle plugin | Xcode |
+| Kotlin Multiplatform plugin version | Gradle    | Android Gradle plugin | Xcode |
 |----------------|-----------|-----------------------|-------|
 | 2.0.20         | 7.5-8.8*  | 7.4.2–8.5             | 15.3  |
 | 2.0.0          | 7.5-8.5   | 7.4.2–8.3             | 15.3  |

--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -14,10 +14,10 @@ When configuring your project, check the compatibility of a particular version o
 with available Gradle, Xcode, and Android Gradle plugin versions:
 
 | Kotlin Multiplatform plugin version | Gradle    | Android Gradle plugin | Xcode |
-|----------------|-----------|-----------------------|-------|
-| 2.0.20         | 7.5-8.8*  | 7.4.2–8.5             | 15.3  |
-| 2.0.0          | 7.5-8.5   | 7.4.2–8.3             | 15.3  |
-| 1.9.20         | 7.5-8.1.1 | 7.4.2–8.2             | 15.0  |
+|-------------------------------------|-----------|-----------------------|-------|
+| 2.0.20                              | 7.5-8.8*  | 7.4.2–8.5             | 15.3  |
+| 2.0.0                               | 7.5-8.5   | 7.4.2–8.3             | 15.3  |
+| 1.9.20                              | 7.5-8.1.1 | 7.4.2–8.2             | 15.0  |
 
 > Kotlin 2.0.20 is fully compatible with Gradle 6.8.3 through 8.6.
 > Gradle 8.7 and 8.8 are also supported, but you may see deprecation warnings in your multiplatform projects


### PR DESCRIPTION
Minor clarifications to the compatibility page: even though all of these versions are supposed to be the same, referring to them could be better phrased.