### PR TITLE
Kotlin daemon JVM args - clearing up inheritance and defaults

### DIFF
--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -163,19 +163,20 @@ Each of the following ways to set arguments overrides the ones that came before 
 
 #### Gradle daemon arguments inheritance
 
-The Kotlin daemon inherits a specific set of arguments from the Gradle daemon and then overwrites them with JVM args specified for the Kotlin daemon. For example, in the `gradle.properties` file:
+By default, the Kotlin daemon inherits a specific set of arguments from the Gradle daemon but overwrites them with any 
+JVM arguments specified directly for the Kotlin daemon. For example, if you add the following JVM arguments in the `gradle.properties` file:
 
 ```none
 org.gradle.jvmargs=-Xmx1500m -Xms500m -XX:MaxMetaspaceSize=1g
 ```
 
-would then result in the Kotlin daemon's JVM args being similar to:
+These arguments are then added to the Kotlin daemon's JVM arguments:
 
 ```none
 -Xmx1500m -XX:ReservedCodeCacheSize=320m -XX:MaxMetaspaceSize=1g -XX:UseParallelGC -ea -XX:+UseCodeCacheFlushing -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Djava.rmi.server.hostname=127.0.0.1 --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
 ```
 
-> Learn more about [Kotlin daemon's behavior with JVM arguments](#kotlin-daemon-s-behavior-with-jvm-arguments).
+> To learn more about the Kotlin daemon's default behavior with JVM arguments, see [Kotlin daemon's behavior with JVM arguments](#kotlin-daemon-s-behavior-with-jvm-arguments).
 >
 {style="note"}
 
@@ -203,11 +204,13 @@ When passing arguments, follow these rules:
 
 #### kotlin.daemon.jvmargs property
 
-You can add the `kotlin.daemon.jvmargs` property in the `gradle.properties` file. Note that if you do not specify `ReservedCodeCacheSize` here or in Gradle's JVM args, a default will be applied by the Kotlin Gradle plugin:
+You can add the `kotlin.daemon.jvmargs` property in the `gradle.properties` file:
 
 ```none
 kotlin.daemon.jvmargs=-Xmx1500m -Xms500m
 ```
+
+Note that if you don't specify the `ReservedCodeCacheSize` argument here or in Gradle's JVM arguments, the Kotlin Gradle plugin applies a default value of `320m`:
 
 ```none
 -Xmx1500m -XX:ReservedCodeCacheSize=320m -Xms500m
@@ -280,21 +283,23 @@ When configuring the Kotlin daemon's JVM arguments, note that:
   >
   {style="note"}
 
-If the following arguments are not specified, the Kotlin daemon will inherit them from the Gradle daemon:
+If the following arguments aren't specified, the Kotlin daemon inherits them from the Gradle daemon:
 
-* -Xmx
-* -XX:MaxMetaspaceSize
-* -XX:ReservedCodeCacheSize (Defaults to 320m if not inherited and unspecified)
+* `-Xmx`
+* `-XX:MaxMetaspaceSize`
+* `-XX:ReservedCodeCacheSize`. If not specified or inherited, the default value is `320m`.
 
-The Kotlin daemon also has a number of defaults:
-* -XX:UseParallelGC (if no other garbage collector was set)
-* -ea
-* -XX:+UseCodeCacheFlushing
-* -Djava.awt.headless=true
-* -D{java.servername.property}={localhostip}
-* --add-exports=java.base/sun.nio.ch=ALL-UNNAMED (Only for JDK 16+)
+The Kotlin daemon has the following default JVM arguments:
+* `-XX:UseParallelGC`. This argument is only applied if no other garbage collector is specified.
+* `-ea`
+* `-XX:+UseCodeCacheFlushing`
+* `-Djava.awt.headless=true`
+* `-D{java.servername.property}={localhostip}`
+* `--add-exports=java.base/sun.nio.ch=ALL-UNNAMED`. This argument is only applied for JDK versions 16 or higher.
 
-The list of defaults is considered an implementation detail of the Kotlin daemon and may vary between versions. You can use a tool like [VisualVM](https://visualvm.github.io/) to verify what the actual settings of a running JVM process like the Kotlin daemon are.
+> The list of default JVM arguments for the Kotlin daemon may vary between versions. You can use a tool like [VisualVM](https://visualvm.github.io/) to check the actual settings of a running JVM process, like the Kotlin daemon.
+>
+{style="note"}
 
 ## Rolling back to the previous compiler
 

--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -177,7 +177,7 @@ would then result in the Kotlin daemon's JVM args being similar to:
 
 > Learn more about [Kotlin daemon's behavior with JVM arguments](#kotlin-daemon-s-behavior-with-jvm-arguments).
 >
-{type="note"}
+{style="note"}
 
 #### kotlin.daemon.jvm.options system property
 
@@ -278,7 +278,7 @@ When configuring the Kotlin daemon's JVM arguments, note that:
   > If you are already running a Kotlin daemon that has enough heap size to handle the compilation request,
   > even if other requested JVM arguments are different, this daemon will be reused instead of starting a new one.
   >
-  {type="note"}
+  {style="note"}
 
 If the following arguments are not specified, the Kotlin daemon will inherit them from the Gradle daemon:
 

--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -295,7 +295,7 @@ The Kotlin daemon also has a number of defaults:
 * -D{java.servername.property}={localhostip}
 * --add-exports=java.base/sun.nio.ch=ALL-UNNAMED (Only for JDK 16+)
 
-You can use a tool like [VisualVM](https://visualvm.github.io/) to verify what the actual settings of a running JVM process like the Kotlin daemon are.
+The list of defaults is considered an implementation detail of the Kotlin daemon and may vary between versions. You can use a tool like [VisualVM](https://visualvm.github.io/) to verify what the actual settings of a running JVM process like the Kotlin daemon are.
 
 ## Rolling back to the previous compiler
 

--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -169,7 +169,7 @@ The Kotlin daemon inherits a specific set of arguments from the Gradle daemon an
 org.gradle.jvmargs=-Xmx1500m -Xms500m -XX:MaxMetaspaceSize=1g
 ```
 
-would then result in the Kotlin daemon's JVM args being:
+would then result in the Kotlin daemon's JVM args being similar to:
 
 ```none
 -Xmx1500m -XX:ReservedCodeCacheSize=320m -XX:MaxMetaspaceSize=1g -XX:UseParallelGC -ea -XX:+UseCodeCacheFlushing -XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true -Djava.rmi.server.hostname=127.0.0.1 --add-exports=java.base/sun.nio.ch=ALL-UNNAMED

--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -290,7 +290,6 @@ The Kotlin daemon also has a number of defaults:
 * -XX:UseParallelGC (if no other garbage collector was set)
 * -ea
 * -XX:+UseCodeCacheFlushing
-* -XX:+HeapDumpOnOutOfMemoryError
 * -Djava.awt.headless=true
 * -D{java.servername.property}={localhostip}
 * --add-exports=java.base/sun.nio.ch=ALL-UNNAMED (Only for JDK 16+)


### PR DESCRIPTION
I filed [KT-71564](https://youtrack.jetbrains.com/issue/KT-71564/Kotlin-Daemon-JVM-args-behavior-does-not-match-documentation) the other day because my previous understanding (and that of some of the AndroidX team) was that all Gradle JVM args would be inherited if no Kotlin JVM args were specified. I did some digging in the Kotlin Gradle Plugin and Kotlin Daemon sources to find how that process works and think this should clear everything up.