### PR TITLE
fix: invalid kotlin build report config directions

### DIFF
--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -463,7 +463,7 @@ kotlin.build.report.output=file,single_file,http,build_scan,json
 kotlin.build.report.single_file=some_filename
 
 # Mandatory if json output is used. Where to put reports 
-kotlin.build.report.json.directory="my/directory/path"
+kotlin.build.report.json.directory=my/directory/path
 
 # Optional. Output directory for file-based reports. Default: build/reports/kotlin-build/
 kotlin.build.report.file.output_dir=kotlin-reports

--- a/docs/topics/whatsnew20.md
+++ b/docs/topics/whatsnew20.md
@@ -1598,7 +1598,7 @@ To configure JSON output format for your build reports, declare the following pr
 kotlin.build.report.output=json
 
 // The directory to store your build reports
-kotlin.build.report.json.directory="my/directory/path"
+kotlin.build.report.json.directory=my/directory/path
 ```
 
 Alternatively, you can run the following command:


### PR DESCRIPTION
Wrapping the json directory property with quotes results in an error:
```
Kotlin build report cannot be created: '"my/directory/path"' is a file or do not have permissions to create
```

Hit this error while following these docs and also found a relevant ticket on YouTrack that was already closed: https://youtrack.jetbrains.com/issue/KT-71049/Cannot-get-build-report-is-a-file-or-do-not-have-permissions-to-create