### PR TITLE
update: deprecating android target

### DIFF
--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -632,8 +632,8 @@ projects.
 
 Here's the planned deprecation cycle:
 
-* 1.9.0: a deprecation warning is introduced when the `android` name is used in Kotlin Multiplatform projects
-* 2.1.0: report an error in such cases, causing the build to fail
+* 1.9.0: introduce a deprecation warning when the `android` name is used in Kotlin Multiplatform projects
+* 2.1.0: raise this warning to an error
 * 2.2.0: remove the `android` target DSL from the Kotlin Multiplatform Gradle plugin
 
 <anchor name="declaring-multiple-targets"/>

--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -619,18 +619,22 @@ support for the Android target. In the future, this support will be provided via
 Android team from Google.
 
 To open the way for the new solution from Google, we're renaming the `android` block to `androidTarget` in the current
-Kotlin DSL in 1.9.0. This is a temporary change that is necessary to free the short `android` name for the upcoming DSL
+Kotlin DSL. This is a temporary change that is necessary to free the short `android` name for the upcoming DSL
 from Google.
 
 **What's the best practice now?**
 
-Rename all the occurrences of  the `android` block to `androidTarget`. When the new plugin for the Android target support
+Rename all the occurrences of the `android` block to `androidTarget`. When the new plugin for the Android target support
 is available, migrate to the DSL from Google. It will be the preferred option to work with Android in Kotlin Multiplatform
 projects.
 
 **When do the changes take effect?**
 
-In Kotlin 1.9.0, a deprecation warning is introduced when the `android` name is used in Kotlin Multiplatform projects.
+Here's the planned deprecation cycle:
+
+* 1.9.0: a deprecation warning is introduced when the `android` name is used in Kotlin Multiplatform projects
+* 2.1.0: report an error in such cases, causing the build to fail
+* 2.2.0: remove the `android` target DSL from the Kotlin Multiplatform Gradle plugin
 
 <anchor name="declaring-multiple-targets"/>
 ## Declaring several similar targets

--- a/docs/topics/multiplatform/multiplatform-configure-compilations.md
+++ b/docs/topics/multiplatform/multiplatform-configure-compilations.md
@@ -410,8 +410,8 @@ for each build variant, a Kotlin compilation is created under the same name.
 
 Then, for each [Android source set](https://developer.android.com/studio/build/build-variants#sourcesets) compiled for 
 each of the variants, a Kotlin source set is created under that source set name prepended by the target name, like the 
-Kotlin source set `androidDebug` for an Android source set `debug` and the Kotlin target named `android`. These Kotlin 
-source sets are added to the variants' compilations accordingly.
+Kotlin source set `androidDebug` for an Android source set `debug` and the Kotlin target named `androidTarget`.
+These Kotlin source sets are added to the variants' compilations accordingly.
 
 The default source set `commonMain` is added to each production (application or library) variant's compilation. 
 The `commonTest` source set is similarly added to the compilations of unit test and instrumented test variants.
@@ -422,7 +422,7 @@ than within Kotlin source set dependencies.
 
 ```kotlin
 kotlin {
-    android { /* ... */ }
+    androidTarget { /* ... */ }
 }
 
 dependencies {

--- a/docs/topics/multiplatform/multiplatform-discover-project.md
+++ b/docs/topics/multiplatform/multiplatform-discover-project.md
@@ -204,7 +204,7 @@ Consider an example where you need to target all modern Apple devices and Androi
 
 ```kotlin
 kotlin {
-    android()
+    androidTarget()
     iosArm64()   // 64-bit iPhone devices
     macosArm64() // Modern Apple Silicon-based Macs
     watchosX64() // Modern 64-bit Apple Watch devices

--- a/docs/topics/multiplatform/multiplatform-dsl-reference.md
+++ b/docs/topics/multiplatform/multiplatform-dsl-reference.md
@@ -58,7 +58,7 @@ one of the supported platforms. Kotlin provides target presets for each platform
 Each target can have one or more [compilations](#compilations). In addition to default compilations for
 test and production purposes, you can [create custom compilations](multiplatform-configure-compilations.md#create-a-custom-compilation).
 
-The targets of a multiplatform project are described in the corresponding blocks inside `kotlin {}`, for example, `jvm`, `android`, `iosArm64`.
+The targets of a multiplatform project are described in the corresponding blocks inside `kotlin {}`, for example, `jvm`, `androidTarget`, `iosArm64`.
 The complete list of available targets is the following:
 
 <table>
@@ -102,7 +102,7 @@ The complete list of available targets is the following:
     </tr>
     <tr>
         <td>Android applications and libraries</td>
-        <td><code>android</code></td>
+        <td><code>androidTarget</code></td>
         <td>
             <p>Manually apply an Android Gradle plugin: <code>com.android.application</code> or <code>com.android.library</code>.</p>
             <p>You can only create one Android target per Gradle subproject.</p>
@@ -466,7 +466,7 @@ Two functions help you configure [build variants](https://developer.android.com/
 
 ```kotlin
 kotlin {
-    android {
+    androidTarget {
         publishLibraryVariants("release", "debug")
     }
 }
@@ -474,7 +474,7 @@ kotlin {
 
 Learn more about [compilation for Android](multiplatform-configure-compilations.md#compilation-for-android).
 
-> The `android` configuration inside `kotlin` doesn't replace the build configuration of any Android project.
+> The `androidTarget` configuration inside the `kotlin {}` block doesn't replace the build configuration of any Android project.
 > Learn more about writing build scripts for Android projects in [Android developer documentation](https://developer.android.com/studio/build).
 >
 {style="note"}

--- a/docs/topics/multiplatform/multiplatform-dsl-reference.md
+++ b/docs/topics/multiplatform/multiplatform-dsl-reference.md
@@ -467,7 +467,7 @@ Two functions help you configure [build variants](https://developer.android.com/
 ```kotlin
 kotlin {
     androidTarget {
-        publishLibraryVariants("release", "debug")
+        publishLibraryVariants("release")
     }
 }
 ```

--- a/docs/topics/multiplatform/multiplatform-publish-lib.md
+++ b/docs/topics/multiplatform/multiplatform-publish-lib.md
@@ -130,7 +130,7 @@ specify the variant names in the Android target block in the `shared/build.gradl
 ```kotlin
 kotlin {
     androidTarget {
-        publishLibraryVariants("release", "debug")
+        publishLibraryVariants("release")
     }
 }
 


### PR DESCRIPTION
This PR updates the deprecation cycle for the old `android` target and replaces the remaining occurrences in the docs to `androidTarget`