### PR TITLE
Update versions in KMP compatibility guide for 2.1.0

### DIFF
--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -13,14 +13,15 @@ developing projects with Kotlin Multiplatform.
 When configuring your project, check the compatibility of a particular version of the Kotlin Multiplatform Gradle plugin (same as the Kotlin version in your project)
 with available Gradle, Xcode, and Android Gradle plugin versions:
 
-| Kotlin Multiplatform plugin version | Gradle    | Android Gradle plugin | Xcode |
-|-------------------------------------|-----------|-----------------------|-------|
-| 2.0.21                              | 7.5-8.8*  | 7.4.2–8.5             | 16.0  |
-| 2.0.20                              | 7.5-8.8*  | 7.4.2–8.5             | 15.3  |
-| 2.0.0                               | 7.5-8.5   | 7.4.2–8.3             | 15.3  |
-| 1.9.20                              | 7.5-8.1.1 | 7.4.2–8.2             | 15.0  |
+| Kotlin Multiplatform plugin version | Gradle                                 | Android Gradle plugin           | Xcode   |
+|-------------------------------------|----------------------------------------|---------------------------------|---------|
+| 2.1.0                               | %minGradleVersion%–%maxGradleVersion%* | 7.4.2–%maxAndroidGradleVersion% | %xcode% |
+| 2.0.21                              | 7.5-8.8*                               | 7.4.2–8.5                       | 16.0    |
+| 2.0.20                              | 7.5-8.8*                               | 7.4.2–8.5                       | 15.3    |
+| 2.0.0                               | 7.5-8.5                                | 7.4.2–8.3                       | 15.3    |
+| 1.9.20                              | 7.5-8.1.1                              | 7.4.2–8.2                       | 15.0    |
 
-> Kotlin 2.0.20 and 2.0.21 are fully compatible with Gradle 6.8.3 through 8.6.
+> *Kotlin 2.0.20–2.0.21 and Kotlin 2.1.0 are fully compatible with Gradle up to 8.6.
 > Gradle 8.7 and 8.8 are also supported, but you may see deprecation warnings in your multiplatform projects
 > calling the [`withJava()` function in the JVM target](multiplatform-dsl-reference.md#jvm-targets). 
 > For more information, see the issue in [YouTrack](https://youtrack.jetbrains.com/issue/KT-66542/Gradle-JVM-target-with-withJava-produces-a-deprecation-warning).

--- a/docs/v.list
+++ b/docs/v.list
@@ -35,7 +35,7 @@
     <var name="maxGradleVersion" value="8.10" type="string"/>
 
     <var name="minAndroidGradleVersion" value="7.3.1" type="string"/>
-    <var name="maxAndroidGradleVersion" value="8.5" type="string"/>
+    <var name="maxAndroidGradleVersion" value="8.7.2" type="string"/>
 
     <var name="gradleVersion" value="8.10" type="string"/>
     <var name="gradleLanguageVersion" value="KOTLIN_2_0" type="string"/>
@@ -62,5 +62,7 @@
     <var name="kotlinVersion"
          value="1.9.22"
          type="string"/>
+
+    <var name="xcode" value="16.0" type="string"/>
 
 </vars>


### PR DESCRIPTION
This PR updates the compatible versions for KMP in the multiplatform compatibility guide for Kotlin 2.1.0.