### PR TITLE
KMP compatibility guide: Update deprecation cycle for duplicate targets

### DIFF
--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -762,7 +762,7 @@ the Kotlin Gradle plugin, making it easier to use and maintain the resulting bui
 Here's the planned deprecation cycle:
 
 * 1.9.20: introduce a deprecation warning when multiple similar targets are used in Kotlin Multiplatform projects
-* 2.0: report an error in such cases, causing the build to fail
+* 2.1.0: report an error in such cases, causing the build to fail
 
 <anchor name="jvmWithJava-preset-deprecation"/>
 ## Deprecated jvmWithJava preset


### PR DESCRIPTION
This PR updates the deprecation cycle for the duplicate targets issue in the KMP compatibility guide.