### PR TITLE
feature: PausableComposition feature flag in CCGP

### DIFF
--- a/docs/labels.list
+++ b/docs/labels.list
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE labels SYSTEM "https://resources.jetbrains.com/writerside/1.0/labels-list.dtd">
+<labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/labels.xsd">
+
+    <primary-label id="experimental-general" name="Experimental" short-name="Experimental" href="components-stability.html#stability-levels-explained" color="red">The feature is Experimental. It may be dropped or changed at any time. Use it only for evaluation purposes.</primary-label>
+    <primary-label id="experimental-opt-in" name="Experimental" short-name="Experimental" href="components-stability.html#stability-levels-explained" color="red" >The feature is Experimental. It may be dropped or changed at any time. Opt-in is required (see the details below), and you should use it only for evaluation purposes.</primary-label>
+    <primary-label id="alpha" name="Alpha" short-name="α" href="components-stability.html#stability-levels-explained" color="strawberry">The feature is in Alpha. It may change incompatibly and require manual migration in the future.</primary-label>
+    <primary-label id="beta" name="Beta" short-name="β" href="components-stability.html#stability-levels-explained" color="tangerine">The feature is in Beta. It is almost stable, but migration steps may be required in the future. We'll do our best to minimize any changes you have to make.</primary-label>
+
+    <secondary-label id="eap" name="EAP">This functionality is available only in the latest EAP version.</secondary-label>
+</labels>

--- a/docs/topics/compose-compiler-options.md
+++ b/docs/topics/compose-compiler-options.md
@@ -194,6 +194,27 @@ and functions that are implicitly not skippable (inline functions and functions 
 >
 {style="warning"}
 
+### PausableComposition
+
+> The feature flag affects behavior only with a version of Compose runtime that supports pausable composition,
+> starting with `androidx.compose.runtime` 1.8.0-alpha02.
+> With older versions, the feature flag has no effect.
+>
+{style="note"}
+
+**Default**: disabled
+
+If enabled, changes code generation of composable functions to enable pausing when part of a pausable composition.
+This allows Compose runtime to suspend composition on the skipping points,
+letting long-running compositions be split across multiple frames.
+
+Pausable composition is used in Lazy lists and other performance intensive components for prefetching content
+that might cause visual jank when executed in a blocking manner.
+
+> This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.
+>
+{style="warning"}
+
 ### StrongSkipping
 
 **Default**: enabled

--- a/docs/topics/compose-compiler-options.md
+++ b/docs/topics/compose-compiler-options.md
@@ -181,6 +181,8 @@ This results in fewer slots being used and fewer comparisons being made at runti
 
 ### OptimizeNonSkippingGroups
 
+<primary-label ref="experimental-general"/>
+
 **Default**: disabled
 
 If enabled, remove groups around non-skipping composable functions.
@@ -190,11 +192,9 @@ unnecessary groups around composables which do not skip (and thus do not require
 This optimization will remove the groups, for example, around functions explicitly marked as `@NonSkippableComposable`
 and functions that are implicitly not skippable (inline functions and functions that return a non-`Unit` value such as `remember`).
 
-> This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.
->
-{style="warning"}
-
 ### PausableComposition
+
+<primary-label ref="experimental-general"/>
 
 > The feature flag affects behavior only with a version of Compose runtime that supports pausable composition,
 > starting with `androidx.compose.runtime` 1.8.0-alpha02.
@@ -210,10 +210,6 @@ splitting long-running compositions across multiple frames.
 
 Lazy lists and other performance intensive components use pausable composition to prefetch content
 that might cause visual jank when executed in a blocking manner.
-
-> This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.
->
-{style="warning"}
 
 ### StrongSkipping
 

--- a/docs/topics/compose-compiler-options.md
+++ b/docs/topics/compose-compiler-options.md
@@ -198,17 +198,17 @@ and functions that are implicitly not skippable (inline functions and functions 
 
 > The feature flag affects behavior only with a version of Compose runtime that supports pausable composition,
 > starting with `androidx.compose.runtime` 1.8.0-alpha02.
-> With older versions, the feature flag has no effect.
+> Older versions ignore the feature flag.
 >
 {style="note"}
 
 **Default**: disabled
 
-If enabled, changes code generation of composable functions to enable pausing when part of a pausable composition.
-This allows Compose runtime to suspend composition on the skipping points,
-letting long-running compositions be split across multiple frames.
+If enabled, changes the code generation of composable functions to allow pausing when part of a pausable composition.
+This lets Compose runtime suspend composition at skipping points,
+splitting long-running compositions across multiple frames.
 
-Pausable composition is used in Lazy lists and other performance intensive components for prefetching content
+Lazy lists and other performance intensive components use pausable composition to prefetch content
 that might cause visual jank when executed in a blocking manner.
 
 > This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.


### PR DESCRIPTION
Mentioning the PausableComposition flag in the Compose Compiler Gradle plugin reference: https://youtrack.jetbrains.com/issue/KT-71227/Compose-Add-PausableComposition-feature-flag-to-the-Compose-Gradle-Plugin