### PR TITLE
Add incremental compilation section in Wasm Troubleshooting

### DIFF
--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -109,3 +109,26 @@ You can place your new `.mjs` file in the resources folder, and it will automati
 
 You can also place your `.mjs` file in a custom location. In this case, you need to either manually move it next to the main `.mjs` file or 
 adjust the path in the import statement to match its location.
+
+## Use incremental compilation
+
+When you change something to your Kotlin code, 
+the Kotlin/Wasm toolchain doesn't need to recompile the entire codebase. 
+
+Wasm targets support incremental compilation, which enables the compiler to recompile only files relevant to changes 
+from the last compilation.
+
+The use of incremental compilation reduces the compilation time. It doubles 
+the development speed for now, with plans to improve it further in future releases.
+
+In the current setup, incremental compilation for the Wasm targets is disabled by default.
+To enable it, add the following line to your project's `local.properties` or `gradle.properties` file:
+
+```text
+kotlin.incremental.wasm=true
+```
+
+> Try out the Kotlin/Wasm incremental compilation and [share your feedback](https://youtrack.jetbrains.com/issue/KT-72158/Kotlin-Wasm-incremental-compilation-feedback).
+> Your insights help make this feature [Stable](components-stability.md) and enabled by default sooner.
+>
+{style="note"}

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -110,15 +110,15 @@ You can place your new `.mjs` file in the resources folder, and it will automati
 You can also place your `.mjs` file in a custom location. In this case, you need to either manually move it next to the main `.mjs` file or 
 adjust the path in the import statement to match its location.
 
-## Use incremental compilation
+## Slow Kotlin/Wasm compilation
 
-When you change something to your Kotlin code, 
-the Kotlin/Wasm toolchain doesn't need to recompile the entire codebase. 
+When working on Kotlin/Wasm projects, you may experience slow compilation times. This happens because the Kotlin/Wasm 
+toolchain recompiles the entire codebase every time you make a change.
 
-Wasm targets support incremental compilation, which enables the compiler to recompile only files relevant to changes 
-from the last compilation.
+To mitigate this issue, Kotlin/Wasm targets support incremental compilation, which enables the compiler to recompile only 
+those files relevant to changes from the last compilation.
 
-The use of incremental compilation reduces the compilation time. It doubles 
+Using incremental compilation reduces the compilation time. It doubles 
 the development speed for now, with plans to improve it further in future releases.
 
 In the current setup, incremental compilation for the Wasm targets is disabled by default.

--- a/docs/topics/wasm/wasm-troubleshooting.md
+++ b/docs/topics/wasm/wasm-troubleshooting.md
@@ -129,6 +129,6 @@ kotlin.incremental.wasm=true
 ```
 
 > Try out the Kotlin/Wasm incremental compilation and [share your feedback](https://youtrack.jetbrains.com/issue/KT-72158/Kotlin-Wasm-incremental-compilation-feedback).
-> Your insights help make this feature [Stable](components-stability.md) and enabled by default sooner.
+> Your insights help make the feature stable and enabled by default sooner.
 >
 {style="note"}


### PR DESCRIPTION
This PR adds a section about incremental compilation to the Wasm's Troubleshooting page. This update is part of 2.1.0 release. 