### PR TITLE
Sync KMP compatibility guide changes on duplicate targets content

### DIFF
--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -762,7 +762,7 @@ the Kotlin Gradle plugin, making it easier to use and maintain the resulting bui
 Here's the planned deprecation cycle:
 
 * 1.9.20: introduce a deprecation warning when multiple similar targets are used in Kotlin Multiplatform projects
-* 2.1.0: report an error in such cases, causing the build to fail
+* 2.1.0: report an error in such cases, except for Kotlin/JS targets; to learn more about this exception, see the issue in [YouTrack](https://youtrack.jetbrains.com/issue/KT-47038/KJS-MPP-Split-JS-target-into-JsBrowser-and-JsNode)
 
 <anchor name="jvmWithJava-preset-deprecation"/>
 ## Deprecated jvmWithJava preset


### PR DESCRIPTION
This PR aligns the updated KMP compatibility guide changes about duplicate targets on master (needed for EAP what's new) with the `2-1-0-doc-update` branch.