### PR TITLE
fix: wrong period position inside inline code

### DIFF
--- a/docs/topics/tour/kotlin-tour-control-flow.md
+++ b/docs/topics/tour/kotlin-tour-control-flow.md
@@ -271,7 +271,7 @@ The most common way to create a range in Kotlin is to use the `..` operator. For
 
 To declare a range that doesn't include the end value, use the `..<` operator. For example, `1..<4` is equivalent to `1, 2, 3`.
 
-To declare a range in reverse order, use `downTo.` For example, `4 downTo 1` is equivalent to `4, 3, 2, 1`.
+To declare a range in reverse order, use `downTo`. For example, `4 downTo 1` is equivalent to `4, 3, 2, 1`.
 
 To declare a range that increments in a step that isn't 1, use `step` and your desired increment value.
 For example, `1..5 step 2` is equivalent to `1, 3, 5`.


### PR DESCRIPTION
```diff
-To declare a range in reverse order, use `downTo.` For example, `4 downTo 1` is equivalent to `4, 3, 2, 1`.
+To declare a range in reverse order, use `downTo`. For example, `4 downTo 1` is equivalent to `4, 3, 2, 1`.
```