### PR TITLE
Fix typo in Compatibility guide 2.0

### DIFF
--- a/docs/topics/compatibility-guides/compatibility-guide-20.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-20.md
@@ -170,8 +170,6 @@ perspective
 >
 > **Incompatible change type**: behavioral
 >
-> **Short summary**:
->
 > **Deprecation cycle**:
 >
 > - 2.0.0: new overload resolution behavior; function calls are consistently prioritized over invoke conventions


### PR DESCRIPTION
This PR fixes a small typo in the Compatibility guide for 2.0.0.