### PR TITLE
feature: PausableComposition feature flag for the Compose compiler

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -347,18 +347,22 @@
 		<toc-element toc-title="OSGi" topic="kotlin-osgi.md"/>
 	</toc-element>
 	<toc-element toc-title="Compiler and plugins">
-		<toc-element toc-title="Compiler">
+		<toc-element toc-title="Kotlin compiler">
 			<toc-element accepts-web-file-names="k2-compiler-guide.html" topic="k2-compiler-migration-guide.md"/>
 			<toc-element toc-title="Command-line compiler" topic="command-line.md"/>
 			<toc-element toc-title="Compiler options" topic="compiler-reference.md"/>
 		</toc-element>
-		<toc-element toc-title="Compiler plugins">
+		<toc-element toc-title="Kotlin compiler plugins">
 			<toc-element toc-title="All-open" topic="all-open-plugin.md"/>
 			<toc-element toc-title="No-arg" topic="no-arg-plugin.md"/>
 			<toc-element toc-title="SAM with receiver" topic="sam-with-receiver-plugin.md"/>
 			<toc-element toc-title="kapt" topic="kapt.md"/>
 			<toc-element toc-title="Lombok" topic="lombok.md"/>
 			<toc-element toc-title="Power-assert" topic="power-assert.md"/>
+		</toc-element>
+		<toc-element toc-title="Compose compiler">
+			<toc-element toc-title="Compiler migration guide" topic="compose-compiler-migration-guide.md"/>
+			<toc-element toc-title="Compiler options" topic="compose-compiler-options.md"/>
 		</toc-element>
 		<toc-element toc-title="Kotlin Symbol Processing API">
 			<toc-element toc-title="KSP overview" topic="ksp-overview.md"/>

--- a/docs/topics/compose-compiler-migration-guide.md
+++ b/docs/topics/compose-compiler-migration-guide.md
@@ -1,0 +1,74 @@
+[//]: # (title: Compose compiler migration guide)
+
+The Compose compiler is supplemented by a Gradle plugin, which simplifies setup and offers
+easier access to compiler options.
+When applied with the Android Gradle plugin (AGP), this Compose compiler plugin will override the coordinates
+of the Compose compiler supplied automatically by AGP.
+
+The Compose compiler has been merged into the Kotlin repository since Kotlin 2.0.0.
+This helps smooth the migration of your projects to Kotlin 2.0.0 and later, as the Compose compiler ships
+simultaneously with Kotlin and will always be compatible with Kotlin of the same version.
+
+To use the new Compose compiler plugin in your project, apply it for each module that uses Compose.
+Read on for details on how to [migrate a Jetpack Compose project](#migrating-a-jetpack-compose-project). For a Compose Multiplatform project, 
+refer to the [multiplatform migration guide](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html#migrating-a-compose-multiplatform-project).
+
+## Migrating a Jetpack Compose project
+
+When migrating to Kotlin 2.0.0 or newer from 1.9, you should adjust your project configuration depending on the way you deal with
+the Compose compiler. We recommend using the Kotlin Gradle plugin and the Compose compiler Gradle plugin
+to automate configuration management.
+
+### Managing the Compose compiler with Gradle plugins
+
+For Android modules:
+
+1. Add the Compose compiler Gradle plugin to the [Gradle version catalog](https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml):
+
+ ```
+ [versions]
+ # ...
+ kotlin = "%kotlinVersion%"
+ 
+ [plugins]
+ # ...
+ org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ ```
+
+2. Add the Gradle plugin to the root `build.gradle.kts` file:
+
+ ```kotlin
+ plugins {
+     // ...
+     alias(libs.plugins.compose.compiler) apply false
+ }
+ ```
+
+3. Apply the plugin to every module that uses Jetpack Compose:
+
+ ```kotlin
+ plugins {
+     // ...
+     alias(libs.plugins.compose.compiler)
+ }
+ ```
+
+4. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
+   See [the list of compiler options](compose-compiler-options.md) for reference.
+
+5. If you reference Compose compiler artifacts directly, you can remove these references and let the Gradle plugins
+   take care of things.
+
+### Using Compose compiler without Gradle plugins
+
+If you are not using Gradle plugins to manage the Compose compiler, update any direct references to old Maven
+artifacts in your project:
+
+* Change `androidx.compose.compiler:compiler` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable`
+* Change `androidx.compose.compiler:compiler-hosted` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin`
+
+## What's next
+
+* See [Google's announcement](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html) about the Compose compiler moving to the Kotlin repository.
+* If you are using Jetpack Compose to build an Android app, check out [our guide on how to make it multiplatform](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-integrate-in-existing-app.html).

--- a/docs/topics/compose-compiler-options.md
+++ b/docs/topics/compose-compiler-options.md
@@ -194,6 +194,27 @@ and functions that are implicitly not skippable (inline functions and functions 
 >
 {style="warning"}
 
+### PausableComposition
+
+> The feature flag affects behavior only with a version of Compose runtime that supports pausable composition,
+> starting with `androidx.compose.runtime` 1.8.0-alpha02.
+> With older versions, the feature flag has no effect.
+>
+{style="note"}
+
+**Default**: disabled
+
+If enabled, changes code generation of composable functions to enable pausing when part of a pausable composition.
+This allows Compose runtime to suspend composition on the skipping points,
+letting long-running compositions be split across multiple frames.
+
+Pausable composition is used in Lazy lists and other performance intensive components for prefetching content
+that might cause visual jank when executed in a blocking manner.
+
+> This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.
+>
+{style="warning"}
+
 ### StrongSkipping
 
 **Default**: enabled

--- a/docs/topics/compose-compiler-options.md
+++ b/docs/topics/compose-compiler-options.md
@@ -181,6 +181,10 @@ This results in fewer slots being used and fewer comparisons being made at runti
 
 ### OptimizeNonSkippingGroups
 
+> This feature is considered [Experimental](components-stability.md#stability-levels-explained).
+>
+{style="warning"}
+
 **Default**: disabled
 
 If enabled, remove groups around non-skipping composable functions.
@@ -190,17 +194,11 @@ unnecessary groups around composables which do not skip (and thus do not require
 This optimization will remove the groups, for example, around functions explicitly marked as `@NonSkippableComposable`
 and functions that are implicitly not skippable (inline functions and functions that return a non-`Unit` value such as `remember`).
 
-> This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.
->
-{style="warning"}
-
 ### PausableComposition
 
-> The feature flag affects behavior only with a version of Compose runtime that supports pausable composition,
-> starting with `androidx.compose.runtime` 1.8.0-alpha02.
-> Older versions ignore the feature flag.
+> This feature is considered [Experimental](components-stability.md#stability-levels-explained).
 >
-{style="note"}
+{style="warning"}
 
 **Default**: disabled
 
@@ -211,9 +209,11 @@ splitting long-running compositions across multiple frames.
 Lazy lists and other performance intensive components use pausable composition to prefetch content
 that might cause visual jank when executed in a blocking manner.
 
-> This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.
+> The feature flag affects behavior only with a version of Compose runtime that supports pausable composition,
+> starting with `androidx.compose.runtime` 1.8.0-alpha02.
+> Older versions ignore the feature flag.
 >
-{style="warning"}
+{style="note"}
 
 ### StrongSkipping
 

--- a/docs/topics/compose-compiler-options.md
+++ b/docs/topics/compose-compiler-options.md
@@ -198,17 +198,17 @@ and functions that are implicitly not skippable (inline functions and functions 
 
 > The feature flag affects behavior only with a version of Compose runtime that supports pausable composition,
 > starting with `androidx.compose.runtime` 1.8.0-alpha02.
-> With older versions, the feature flag has no effect.
+> Older versions ignore the feature flag.
 >
 {style="note"}
 
 **Default**: disabled
 
-If enabled, changes code generation of composable functions to enable pausing when part of a pausable composition.
-This allows Compose runtime to suspend composition on the skipping points,
-letting long-running compositions be split across multiple frames.
+If enabled, changes the code generation of composable functions to allow pausing when part of a pausable composition.
+This lets Compose runtime suspend composition at skipping points,
+splitting long-running compositions across multiple frames.
 
-Pausable composition is used in Lazy lists and other performance intensive components for prefetching content
+Lazy lists and other performance intensive components use pausable composition to prefetch content
 that might cause visual jank when executed in a blocking manner.
 
 > This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.

--- a/docs/topics/compose-compiler-options.md
+++ b/docs/topics/compose-compiler-options.md
@@ -1,0 +1,207 @@
+[//]: # (title: Compose compiler options DSL)
+
+The Compose compiler Gradle plugin offers a DSL for various compiler options.
+You can use it to configure the compiler in the `composeCompiler {}` block of the `build.gradle.kts` file for the module
+you're applying the plugin to.
+
+There are two kinds of options you can specify:
+
+* General compiler settings.
+* Feature flags that enable or disable new and experimental features, which should eventually become part of the baseline.
+
+Here's an example configuration:
+
+```kotlin
+composeCompiler {
+   includeSourceInformation = true
+
+   featureFlags = setOf(
+           ComposeFeatureFlag.StrongSkipping.disabled(),
+           ComposeFeatureFlag.OptimizeNonSkippingGroups
+   )
+}
+```
+
+> The Gradle plugin provides defaults for several Compose compiler options that were only specified manually before.
+> If you have any of them set up with `freeCompilerArgs`, for example, Gradle will report a duplicate options error.
+>
+{style="warning"}
+
+## General settings
+
+### generateFunctionKeyMetaClasses
+
+**Type**: `Property<Boolean>`
+
+**Default**: `false`
+
+If `true`, generate function key meta classes with annotations indicating the functions and their group keys.
+
+### includeSourceInformation
+
+**Type**: `Property<Boolean>`
+
+**Default**: `false` (`true` for Android)
+
+If `true`, include source information in generated code.
+
+Records source information that can be used for tooling to determine the source location of the corresponding composable function.
+This option does not affect the presence of symbols or line information normally added by the Kotlin compiler;
+it only controls source information added by the Compose compiler.
+
+### metricsDestination
+
+**Type**: `DirectoryProperty`
+
+When a directory is specified, the Compose compiler will use the directory to dump [compiler metrics](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/compiler-metrics.md#reports-breakdown).
+They can be useful for debugging and optimizing your application's runtime performance:
+the metrics show which composable functions are skippable, restartable, read-only, and so on.
+
+The [reportsDestination](#reportsdestination) option allows dumping descriptive reports as well.
+
+For a deep dive into the compiler metrics, see this [Composable metrics blog post](https://chrisbanes.me/posts/composable-metrics/).
+
+### reportsDestination
+
+**Type**: `DirectoryProperty`
+
+When a directory is specified, the Compose compiler will use the directory to dump [compiler metrics reports](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/compiler-metrics.md#reports-breakdown).
+They can be useful for optimizing your application's runtime performance:
+the reports show which composable functions are skippable, restartable, read-only, and so on.
+
+The [metricsDestination](#metricsdestination) option allows dumping raw metrics.
+
+For a deep dive into the compiler metrics, see this [Composable metrics blog post](https://chrisbanes.me/posts/composable-metrics/).
+
+### stabilityConfigurationFile
+
+> _Deprecated_ in Kotlin 2.1.0-Beta1 in favor of [stabilityConfigurationFiles](#stabilityconfigurationfiles),
+> which allows using more than one stability configuration file.
+>
+{style="warning"}
+
+**Type**: `RegularFileProperty`
+
+A stability configuration file contains a list of classes, which should be considered stable.
+For details, see [Stability configuration file](https://developer.android.com/develop/ui/compose/performance/stability/fix#configuration-file)
+in the Jetpack Compose documentation.
+
+### stabilityConfigurationFiles
+
+**Type**: `ListProperty<RegularFile>`
+
+Stability configuration files to be used for the current module.
+
+Stability configuration files contain a list of classes that should be considered stable by the compiler.
+For details, see [Stability configuration file](https://developer.android.com/develop/ui/compose/performance/stability/fix#configuration-file)
+in the Jetpack Compose documentation.
+
+Here's an example of specifying paths to several files:
+
+```kotlin
+composeCompiler {
+    stabilityConfigurationFiles.addAll(
+        project.layout.projectDirectory.file("configuration-file1.conf"),
+        project.layout.projectDirectory.file("configuration-file2.conf"),
+    )
+}
+```
+
+### includeTraceMarkers
+
+**Type**: `Property<Boolean>`
+
+**Default**: `true`
+
+If `true`, include composition trace markers in the generated code.
+
+The Compose compiler can inject additional tracing information into the bytecode, which allows it to show composable functions
+in the Android Studio system trace profiler.
+
+For details, see this [Android Developers blog post](https://medium.com/androiddevelopers/jetpack-compose-composition-tracing-9ec2b3aea535).
+
+### targetKotlinPlatforms
+
+**Type**: `SetProperty<KotlinPlatformType>`
+
+Indicates Kotlin platforms to which the Compose compiler Gradle plugin should be applied.
+By default, the plugin is applied to all Kotlin platforms.
+
+To enable only one specific Kotlin platform, for example, Kotlin/JVM:
+
+```kotlin
+composeCompiler {
+   targetKotlinPlatforms.set(setOf(KotlinPlatformType.jvm))
+}
+```
+
+To disable the Gradle plugin for one or more Kotlin platforms, for example, Kotlin/Native and Kotlin/JS:
+
+```kotlin
+composeCompiler {
+    targetKotlinPlatforms.set(
+       KotlinPlatformType.values()
+           .filterNot { it == KotlinPlatformType.native || it == KotlinPlatformType.js }
+           .asIterable()
+    )
+}
+```
+
+## Feature flags
+
+Feature flags are organized into a separate set to minimize changes to top-level properties as new flags
+are continuously rolled out and deprecated.
+
+To enable a feature flag that is disabled by default, specify it in the set, for example:
+
+```kotlin
+featureFlags = setOf(ComposeFeatureFlag.OptimizeNonSkippingGroups)
+```
+
+To disable a feature flag that is enabled by default, call the `disabled()` function on it, for example:
+
+```kotlin
+featureFlags = setOf(ComposeFeatureFlag.StrongSkipping.disabled())
+```
+
+If you are configuring the Compose compiler directly, use the following syntax to pass feature flags to it:
+
+```none
+-P plugin:androidx.compose.compiler.plugins.kotlin:featureFlag=<flag name>
+```
+
+### IntrinsicRemember
+
+**Default**: enabled
+
+If enabled, turns on intrinsic remember performance optimization.
+
+Intrinsic remember is an optimization mode that inlines `remember` invocations and, where possible, replaces `.equals()` comparisons for keys with comparisons of the `$changed` meta parameter.
+This results in fewer slots being used and fewer comparisons being made at runtime.
+
+### OptimizeNonSkippingGroups
+
+**Default**: disabled
+
+If enabled, remove groups around non-skipping composable functions.
+
+This optimization improves the runtime performance of your application by skipping
+unnecessary groups around composables which do not skip (and thus do not require a group).
+This optimization will remove the groups, for example, around functions explicitly marked as `@NonSkippableComposable`
+and functions that are implicitly not skippable (inline functions and functions that return a non-`Unit` value such as `remember`).
+
+> This feature is considered [Experimental](components-stability.md#stability-levels-explained) and is disabled by default.
+>
+{style="warning"}
+
+### StrongSkipping
+
+**Default**: enabled
+
+If enabled, turns on strong skipping mode.
+
+Strong skipping mode improves the runtime performance of your application by applying optimizations previously reserved only for stable values of composable functions whose parameters haven't changed.
+For example, composables with unstable parameters become skippable, and lambdas with unstable captures are memoized.
+
+For details, see the [description of strong skipping mode](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/strong-skipping.md)
+in the Kotlin GitHub repository.


### PR DESCRIPTION
From this dev issue: https://youtrack.jetbrains.com/issue/KT-71227/Compose-Add-PausableComposition-feature-flag-to-the-Compose-Gradle-Plugin

This PR contains:
* a cherry-pick of https://github.com/JetBrains/kotlin-web-site/pull/4517
* an almost exact copy of approved changes from https://github.com/JetBrains/kotlin-web-site/pull/4546

After the 2.1.0 release we'll replace the warning notes for feature flags with "Experimental" labels.