### PR TITLE
update: binary options removed

### DIFF
--- a/docs/topics/whatsnew21.md
+++ b/docs/topics/whatsnew21.md
@@ -656,13 +656,6 @@ kotlin {
             // Collapse exported dependency rule
             flattenPackage = "com.subproject.library"
         }
-
-        // Configure Swift export binaries
-        binaries {
-            linkTaskProvider.configure {
-                freeCompilerArgs += "-opt-in=some.value"
-            }
-        }
     }
 }
 ```


### PR DESCRIPTION
This PR removes the `binaries` section from Swift export documentation: [KT-73449](https://youtrack.jetbrains.com/issue/KT-73449)