### PR TITLE
Remove outdated KSP limitation

### DIFF
--- a/docs/topics/ksp/ksp-why-ksp.md
+++ b/docs/topics/ksp/ksp-why-ksp.md
@@ -74,7 +74,3 @@ The following are not goals of KSP:
 * Examining expression-level information of source code.
 * Modifying source code.
 * 100% compatibility with the Java Annotation Processing API.
-
-We are also exploring several additional features. These features are currently unavailable:
-
-* IDE integration: Currently IDEs know nothing about the generated code.


### PR DESCRIPTION
The [explanation in the KSP Quickstart page](https://kotlinlang.org/docs/ksp-quickstart.html#make-ide-aware-of-generated-code) seems to contradict that this is not yet implemented:

> Generated source files are registered automatically since KSP 1.8.0-1.0.9.