### PR TITLE
Update user-groups.yml

### DIFF
--- a/data/user-groups.yml
+++ b/data/user-groups.yml
@@ -1092,3 +1092,9 @@
     position:
       lat: 31.791702
       lng: -7.09262
+  - name: Kotlin Cameroun User Group
+    country: Cameroun
+    url: https://www.linkedin.com/company/kotlin-cameroun
+    position:
+      lat: 4.0511
+      lng: 9.7085


### PR DESCRIPTION
Add Kotlin Cameroun User Group

Name: Kotlin Cameroun User Group

Country: Cameroon

URL: [Kotlin Cameroun on LinkedIn](https://www.linkedin.com/company/kotlin-cameroun)

Position:

Latitude: 4.0511
Longitude: 9.7085
Description: This commit adds the details for the Kotlin Cameroun User Group, a community dedicated to the learning, sharing, and promotion of Kotlin in Cameroon. The group aims to bring together Kotlin enthusiasts, promote the adoption of the language for mobile and backend applications, and foster a collaborative environment for developers to learn and grow.

Impact:

Helps users easily find the Kotlin community in Cameroon via LinkedIn and other channels. Facilitates connections with local members interested in Kotlin, encouraging interaction and mutual support. Positions Douala as a central hub for Kotlin developers in the region, boosting the local tech ecosystem.