### PR TITLE
update: cinterop limitation and test requirements

### DIFF
--- a/docs/topics/multiplatform/multiplatform-publish-lib.md
+++ b/docs/topics/multiplatform/multiplatform-publish-lib.md
@@ -50,24 +50,30 @@ in the publication's scope.
 ## Host requirements
 
 Kotlin/Native supports cross-compilation, allowing any host to produce necessary `.klib` artifacts.
+However, there are still some specifics you should keep in mind.
+
+### Compilation for Apple targets
+<primary-label ref="experimental-opt-in"/>
 
 To produce artifacts for projects with Apple targets, you'd normally need an Apple machine.
-However, if you want to use other hosts, you can set this [Experimental](components-stability.md#stability-levels-explained)
-option in your `gradle.properties` file:
+However, if you want to use other hosts, set this option in your `gradle.properties` file:
 
 ```none
 kotlin.native.enableKlibsCrossCompilation=true
 ```
 
-> To build [final binaries](multiplatform-build-native-binaries.md) for Apple targets, you still need to use a Mac machine.
->
-{style="note"}
+Cross-compilation is currently Experimental and has some limitations. You still need to use a Mac machine if:
+
+* Your library has a [cinterop dependency](native-c-interop.md).
+* You need to build or test [final binaries](multiplatform-build-native-binaries.md) for Apple targets.
+
+### Duplicating publications
 
 To avoid any issues during publication, publish all artifacts from a single host to avoid duplicating publications in the
 repository. Maven Central, for example, explicitly forbids duplicate publications and fails the process.
 <!-- TBD: add the actual error -->
   
-### If you use Kotlin 1.7.0 or earlier {initial-collapse-state="collapsed" collapsible="true"}
+#### If you use Kotlin 1.7.0 or earlier {initial-collapse-state="collapsed" collapsible="true"}
 
 Before 1.7.20, the Kotlin/Native compiler didn't support all cross-compilation options. If you use earlier versions, you may need
 to publish multiplatform projects from multiple hosts: a Windows host to compile a Windows target, a Linux host to compile a Linux target, and so on.

--- a/docs/topics/multiplatform/multiplatform-publish-lib.md
+++ b/docs/topics/multiplatform/multiplatform-publish-lib.md
@@ -65,6 +65,7 @@ kotlin.native.enableKlibsCrossCompilation=true
 Cross-compilation is currently Experimental and has some limitations. You still need to use a Mac machine if:
 
 * Your library has a [cinterop dependency](native-c-interop.md).
+* You have [CocoaPods integration](native-cocoapods.md) set up in your project.
 * You need to build or test [final binaries](multiplatform-build-native-binaries.md) for Apple targets.
 
 ### Duplicating publications

--- a/docs/topics/whatsnew21.md
+++ b/docs/topics/whatsnew21.md
@@ -693,13 +693,14 @@ The Kotlin compiler produces `.klib` artifacts for publishing Kotlin libraries.
 Previously, you could get the necessary artifacts from any host, except for Apple platform targets that required a Mac machine. 
 That put a special restraint on Kotlin Multiplatform projects that targeted iOS, macOS, tvOS, and watchOS targets.
 
-Kotlin 2.1.0 lifts this restriction, achieving full support for cross-compilation.
+Kotlin 2.1.0 lifts this restriction, adding support for cross-compilation.
 Now you can use any host to produce `.klib` artifacts,
 which should greatly simplify the publishing process for Kotlin and Kotlin Multiplatform libraries.
 
-> To build [final binaries](multiplatform-build-native-binaries.md) for Apple targets, you still need to use a Mac machine.
->
-{style="note"}
+Cross-compilation is currently Experimental and has some limitations. You still need to use a Mac machine if:
+
+* Your library has a [cinterop dependency](native-c-interop.md).
+* You need to build or test [final binaries](multiplatform-build-native-binaries.md) for Apple targets.
 
 For more information, see [Publishing multiplatform libraries](https://kotlinlang.org/docs/multiplatform-publish-lib.html).
 

--- a/docs/topics/whatsnew21.md
+++ b/docs/topics/whatsnew21.md
@@ -697,27 +697,26 @@ Kotlin 2.1.0 lifts this restriction, adding support for cross-compilation.
 Now you can use any host to produce `.klib` artifacts,
 which should greatly simplify the publishing process for Kotlin and Kotlin Multiplatform libraries.
 
-Cross-compilation is currently Experimental and has some limitations. You still need to use a Mac machine if:
+#### How to enable publishing libraries from any host
 
-* Your library has a [cinterop dependency](native-c-interop.md).
-* You need to build or test [final binaries](multiplatform-build-native-binaries.md) for Apple targets.
-
-For more information, see [Publishing multiplatform libraries](https://kotlinlang.org/docs/multiplatform-publish-lib.html).
-
-#### How to enable the publishing Kotlin libraries from any host feature
-
-This feature is currently [Experimental](components-stability.md#stability-levels-explained).
-To try it out in your project, add the following binary option to your `gradle.properties` file:
+To try cross-compilation out in your project, add the following binary option to your `gradle.properties` file:
 
 ```none
 # gradle.properties
 kotlin.native.enableKlibsCrossCompilation=true
 ```
 
-#### Leave feedback on the publishing Kotlin libraries from any host feature
+This feature is currently Experimental and has some limitations. You still need to use a Mac machine if:
+
+* Your library has a [cinterop dependency](native-c-interop.md).
+* You need to build or test [final binaries](multiplatform-build-native-binaries.md) for Apple targets.
+
+#### Leave feedback on publishing libraries from any host
 
 We're planning to stabilize this feature and further improve library publication in future Kotlin releases.
 Please leave your feedback in our issue tracker [YouTrack](https://youtrack.jetbrains.com/issue/KT-71290).
+
+For more information, see [Publishing multiplatform libraries](https://kotlinlang.org/docs/multiplatform-publish-lib.html).
 
 ### Support for non-packed klibs
 

--- a/docs/topics/whatsnew21.md
+++ b/docs/topics/whatsnew21.md
@@ -709,6 +709,7 @@ kotlin.native.enableKlibsCrossCompilation=true
 This feature is currently Experimental and has some limitations. You still need to use a Mac machine if:
 
 * Your library has a [cinterop dependency](native-c-interop.md).
+* You have [CocoaPods integration](native-cocoapods.md) set up in your project.
 * You need to build or test [final binaries](multiplatform-build-native-binaries.md) for Apple targets.
 
 #### Leave feedback on publishing libraries from any host
@@ -716,7 +717,7 @@ This feature is currently Experimental and has some limitations. You still need 
 We're planning to stabilize this feature and further improve library publication in future Kotlin releases.
 Please leave your feedback in our issue tracker [YouTrack](https://youtrack.jetbrains.com/issue/KT-71290).
 
-For more information, see [Publishing multiplatform libraries](https://kotlinlang.org/docs/multiplatform-publish-lib.html).
+For more information, see [Publishing multiplatform libraries](multiplatform-publish-lib.md).
 
 ### Support for non-packed klibs
 


### PR DESCRIPTION
This PR clarifies the current limitations of the klib cross-compilation:
* [KT-73574](https://youtrack.jetbrains.com/issue/KT-73574) cinterop dependencies
* #4597