### PR TITLE
Update multiplatform-discover-project.md

### DIFF
--- a/docs/topics/multiplatform/multiplatform-discover-project.md
+++ b/docs/topics/multiplatform/multiplatform-discover-project.md
@@ -289,7 +289,7 @@ devices, respectively, you can use the `tvosMain` intermediate source set for al
 ## Integration with tests
 
 Real-life projects also require tests alongside the main production code. This is why all source sets created by
-default have the `Main` and `Test` prefixes. `Main` contains production code, while `Test` contains tests for this code.
+default have the `Main` and `Test` suffixes. `Main` contains production code, while `Test` contains tests for this code.
 The connection between them is established automatically, and tests can use the API provided by the `Main` code without
 additional configuration.
 


### PR DESCRIPTION
This PR corrects the terminology used when referring to source set naming conventions. The current text mentions “prefixes” when it should say “suffixes,” as terms like commonMain and iosArm64Main have “Main” at the end, making “suffix” the correct term.