### PR TITLE
chore: updating lets plot links

### DIFF
--- a/docs/topics/data-analysis/data-analysis-libraries.md
+++ b/docs/topics/data-analysis/data-analysis-libraries.md
@@ -111,7 +111,7 @@ or Java libraries when working on [Kotlin data projects](data-analysis-overview.
   </tr>
   <tr>
     <td>
-      <a href="https://github.com/JetBrains/lets-plot"><strong>Lets-Plot</strong></a>
+      <a href="https://lets-plot.org/kotlin/get-started.html"><strong>Lets-Plot</strong></a>
     </td>
     <td>
       <list>


### PR DESCRIPTION
Changing lets-plot link from github to https://lets-plot.org/kotlin/get-started.html in data analysis docs for [KT-69493](https://youtrack.jetbrains.com/issue/KT-69493) 