### PR TITLE
fix: outdated compilation configuration

### DIFF
--- a/docs/topics/multiplatform/multiplatform-configure-compilations.md
+++ b/docs/topics/multiplatform/multiplatform-configure-compilations.md
@@ -91,8 +91,10 @@ kotlin {
 kotlin {
     jvm {
         val main by compilations.getting {
-            compilerOptions.configure {
-                jvmTarget.set(JvmTarget.JVM_1_8)
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_1_8)
+                }
             }
         }
     }
@@ -106,8 +108,10 @@ kotlin {
 kotlin {
     jvm {
         compilations.main {
-            compilerOptions.configure {
-                jvmTarget = JvmTarget.JVM_1_8
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget = JvmTarget.JVM_1_8
+                }
             }
         }
     }

--- a/docs/topics/multiplatform/multiplatform-dsl-reference.md
+++ b/docs/topics/multiplatform/multiplatform-dsl-reference.md
@@ -729,9 +729,11 @@ A compilation has the following parameters:
 kotlin {
     jvm {
         val main by compilations.getting {
-            compilerOptions.configure { 
-                // Set up the Kotlin compiler options for the 'main' compilation:
-                jvmTarget.set(JvmTarget.JVM_1_8)
+            compileTaskProvider.configure {
+                compilerOptions {
+                    // Set up the Kotlin compiler options for the 'main' compilation:
+                    jvmTarget.set(JvmTarget.JVM_1_8)
+                }
             }
         
             compileKotlinTask // get the Kotlin task 'compileKotlinJvm' 
@@ -754,9 +756,13 @@ kotlin {
 ```groovy
 kotlin {
     jvm {
-        compilations.main.compilerOptions.configure { 
-            // Setup the Kotlin compiler options for the 'main' compilation:
-            jvmTarget = JvmTarget.JVM_1_8
+        compilations.main {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    // Setup the Kotlin compiler options for the 'main' compilation:
+                    jvmTarget = JvmTarget.JVM_1_8
+                }
+            }
         }
 
         compilations.main.compileKotlinTask // get the Kotlin task 'compileKotlinJvm' 


### PR DESCRIPTION
[KT-74321](https://youtrack.jetbrains.com/issue/KT-74321): This PR updates the configuration of specific compilation according to [Compilation unit level﻿ docs](https://kotlinlang.org/docs/gradle-compiler-options.html#compilation-unit-level) 