### PR TITLE
docs(kotlin-tour-hello-world.md): Update link of string templates to jump to the exact section

### DIFF
--- a/docs/topics/tour/kotlin-tour-hello-world.md
+++ b/docs/topics/tour/kotlin-tour-hello-world.md
@@ -100,7 +100,7 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="kotlin-tour-string-templates"}
 
-For more information, see [String templates](strings.md).
+For more information, see [String templates](strings.md#string-templates).
 
 You will notice that there aren't any types declared for variables. Kotlin has inferred the type itself: `Int`. This tour
 explains the different Kotlin basic types and how to declare them in the [next chapter](kotlin-tour-basic-types.md).


### PR DESCRIPTION
According to [Kotlin documentation guidelines - Links to specific places in other articles](https://docs.google.com/document/d/1mUuxK4xwzs3jtDGoJ5_zwYLaSEl13g_SuhODdFuh2Dc/edit?tab=t.0#heading=h.5jqgnjcnsu4w), update link to specific section https://kotlinlang.org/docs/strings.html#string-templates  instead of https://kotlinlang.org/docs/strings.html page itself.

In the following place, it also leads to string template section.

https://github.com/JetBrains/kotlin-web-site/blob/d03e9256d0659486a81367c6805bdbfa774c167a/docs/topics/tour/kotlin-tour-functions.md?plain=1#L72