### PR TITLE
Update delegated-properties.md

### DIFF
--- a/docs/topics/delegated-properties.md
+++ b/docs/topics/delegated-properties.md
@@ -25,12 +25,12 @@ For example:
 import kotlin.reflect.KProperty
 
 class Delegate {
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): String {
-        return "$thisRef, thank you for delegating '${property.name}' to me!"
+    operator fun getValue(ref: Any?, property: KProperty<*>): String {
+        return "$ref, thank you for delegating '${property.name}' to me!"
     }
  
-    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: String) {
-        println("$value has been assigned to '${property.name}' in $thisRef.")
+    operator fun setValue(ref: Any?, property: KProperty<*>, value: String) {
+        println("$value has been assigned to '${property.name}' with this $ref.")
     }
 }
 ```


### PR DESCRIPTION
**Minor improvement: Using 'ref' for delegate receiver**

This pull request suggests a small change to use `ref` instead of `thisRef` in the `Delegate` class documentation on the Kotlinlang.org website.

Using `ref` aligns better with common Kotlin practices for referencing delegate receivers and improves code readability.
