### PR TITLE
docs(kotlin-tour-classes.md): Remove unused variables from copy example

### DIFF
--- a/docs/topics/tour/kotlin-tour-classes.md
+++ b/docs/topics/tour/kotlin-tour-classes.md
@@ -227,8 +227,6 @@ data class User(val name: String, val id: Int)
 fun main() {
     //sampleStart
     val user = User("Alex", 1)
-    val secondUser = User("Alex", 1)
-    val thirdUser = User("Max", 2)
 
     // Creates an exact copy of user
     println(user.copy())       


### PR DESCRIPTION
It seems `secondUser` and `thirdUser` variables of `copy` example are unused and unnecessary.

https://kotlinlang.org/docs/kotlin-tour-classes.html#copy-instance