### PR TITLE
Introduce information about DslMarker with function types

### DIFF
--- a/docs/topics/type-safe-builders.md
+++ b/docs/topics/type-safe-builders.md
@@ -243,7 +243,7 @@ html {
 ```
 
 You can also apply the `@DslMarker` annotation directly to [function types](lambdas.md#function-types).
-To do so, annotate a `@DslMarker` annotation with `@Target(AnnotationTarget.TYPE)`:
+Simply annotate the `@DslMarker` annotation with `@Target(AnnotationTarget.TYPE)`:
 
 ```kotlin
 @Target(AnnotationTarget.TYPE)
@@ -251,7 +251,7 @@ To do so, annotate a `@DslMarker` annotation with `@Target(AnnotationTarget.TYPE
 annotation class HtmlTagMarker
 ```
 
-This allows the `@DslMarker` annotation to be applied to function types, most commonly to lambdas with receivers. For example:
+As a result, the `@DslMarker` annotation can be applied to function types, most commonly to lambdas with receivers. For example:
 
 ```kotlin
 fun html(init: @HtmlTagMarker HTML.() -> Unit): HTML { ... }
@@ -273,7 +273,7 @@ html {
 }
 ```
 
-This ensures that only the nearest receiver’s members and extensions are accessible within a lambda, preventing unintended interactions between nested scopes.
+Only the nearest receiver's members and extensions are accessible within a lambda, preventing unintended interactions between nested scopes.
 
 ### Full definition of the com.example.html package
 

--- a/docs/topics/type-safe-builders.md
+++ b/docs/topics/type-safe-builders.md
@@ -254,32 +254,26 @@ annotation class HtmlTagMarker
 This allows the `@DslMarker` annotation to be applied to function types, most commonly to lambdas with receivers. For example:
 
 ```kotlin
-fun HTML.head(init: @HtmlTagMarker Head.() -> Unit): Head {
-    val head = Head()
-    head.init()
-    return head
-}
+fun html(init: @HtmlTagMarker HTML.() -> Unit): HTML { ... }
 
-fun Head.title(init: @HtmlTagMarker Title.() -> Unit): Title {
-    val title = Title()
-    title.init()
-    return title
-}
+fun HTML.head(init: @HtmlTagMarker Head.() -> Unit): Head { ... }
+
+fun Head.title(init: @HtmlTagMarker Title.() -> Unit): Title { ... }
 ```
 
-When you call these functions, the `@DslMarker` annotation restricts access to outer receivers unless you specify them explicitly:
+When you call these functions, the `@DslMarker` annotation restricts access to outer receivers in the body of a lambda marked with it unless you specify them explicitly:
 
 ```kotlin
 html {
     head {
         title {
-            // Access to head or outer html members is restricted here.
+            // Access to title, head or other functions of outer receivers is restricted here.
         }
     }
 }
 ```
 
-This ensures that only the nearest receiver’s members are accessible within a lambda, preventing unintended interactions between nested scopes.
+This ensures that only the nearest receiver’s members and extensions are accessible within a lambda, preventing unintended interactions between nested scopes.
 
 ### Full definition of the com.example.html package
 

--- a/docs/topics/type-safe-builders.md
+++ b/docs/topics/type-safe-builders.md
@@ -242,7 +242,46 @@ html {
 }
 ```
 
-## Full definition of the com.example.html package
+You can also apply the `@DslMarker` annotation directly to [function types](lambdas.md#function-types).
+To do so, annotate a `@DslMarker` annotation with `@Target(AnnotationTarget.TYPE)`:
+
+```kotlin
+@Target(AnnotationTarget.TYPE)
+@DslMarker
+annotation class HtmlTagMarker
+```
+
+This allows the `@DslMarker` annotation to be applied to function types, most commonly to lambdas with receivers. For example:
+
+```kotlin
+fun HTML.head(init: @HtmlTagMarker Head.() -> Unit): Head {
+    val head = Head()
+    head.init()
+    return head
+}
+
+fun Head.title(init: @HtmlTagMarker Title.() -> Unit): Title {
+    val title = Title()
+    title.init()
+    return title
+}
+```
+
+When you call these functions, the `@DslMarker` annotation restricts access to outer receivers unless you specify them explicitly:
+
+```kotlin
+html {
+    head {
+        title {
+            // Access to head or outer html members is restricted here.
+        }
+    }
+}
+```
+
+This ensures that only the nearest receiver’s members are accessible within a lambda, preventing unintended interactions between nested scopes.
+
+### Full definition of the com.example.html package
 
 This is how the package `com.example.html` is defined (only the elements used in the example above).
 It builds an HTML tree. It makes heavy use of [extension functions](extensions.md) and
@@ -345,4 +384,3 @@ fun html(init: HTML.() -> Unit): HTML {
     return html
 }
 ```
-


### PR DESCRIPTION
This PR is created to introduce information on how to apply the `@DslMarker` annotation to function types, most commonly lambdas with receivers, to restrict implicit access to outer receivers in Kotlin DSLs and ensure scoped and safe interactions.

Related ticket: [KT-73249](https://youtrack.jetbrains.com/issue/KT-73249/)