### PR TITLE
update: recommendations on platform-specific kotlinx libraries removed

### DIFF
--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -1112,44 +1112,7 @@ see [this issue in the Compatibility Guide](compatibility-guide-15.md#do-not-mix
 
 ### Set a dependency on a kotlinx library
 
-If you use a [`kotlinx` library](https://github.com/Kotlin/kotlinx.coroutines) and need a platform-specific dependency, 
-you can use platform-specific variants of libraries with suffixes such as `-jvm` or `-js`, for example, 
-`kotlinx-coroutines-core-jvm`. You can also use the library's base artifact name instead – `kotlinx-coroutines-core`.
-
-<tabs group="build-script">
-<tab title="Kotlin" group-key="kotlin">
-
-```kotlin
-kotlin {
-    sourceSets {
-        val jvmMain by getting {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:%coroutinesVersion%")
-            }
-        }
-    }
-}
-```
-
-</tab>
-<tab title="Groovy" group-key="groovy">
-
-```groovy
-kotlin {
-    sourceSets {
-        jvmMain {
-            dependencies {
-                implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:%coroutinesVersion%'
-            }
-        }
-    }
-}
-```
-
-</tab>
-</tabs>
-
-If you use a multiplatform library and need to depend on the shared code, set the dependency only once, in the shared
+If you use a multiplatform library and need to depend on the shared code, set the dependency only once in the shared
 source set. Use the library's base artifact name, such as `kotlinx-coroutines-core` or `ktor-client-core`.
 
 <tabs group="build-script">
@@ -1174,6 +1137,42 @@ kotlin {
 kotlin {
     sourceSets {
         commonMain {
+            dependencies {
+                implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%'
+            }
+        }
+    }
+}
+```
+
+</tab>
+</tabs>
+
+If you need a kotlinx library for a platform-specific dependency, you can still use the library's base artifact name in
+the corresponding source set:
+
+<tabs group="build-script">
+<tab title="Kotlin" group-key="kotlin">
+
+```kotlin
+kotlin {
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
+            }
+        }
+    }
+}
+```
+
+</tab>
+<tab title="Groovy" group-key="groovy">
+
+```groovy
+kotlin {
+    sourceSets {
+        jvmMain {
             dependencies {
                 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%'
             }

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -733,10 +733,8 @@ To add a dependency on a library, set the dependency of the required [type](#dep
 ```kotlin
 kotlin {
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation("com.example:my-library:1.0")
-            }
+        commonMain.dependencies {
+            implementation("com.example:my-library:1.0")
         }
     }
 }
@@ -977,10 +975,8 @@ Kotlin/Native targets do not require additional test dependencies, and the `kotl
 ```kotlin
 kotlin {
     sourceSets {
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test")) // This brings all the platform dependencies automatically
-            }
+         commonTest.dependencies {
+             implementation(kotlin("test")) // This brings all the platform dependencies automatically
         }
     }
 }
@@ -1032,10 +1028,8 @@ kotlin {
         }
     }
     sourceSets {
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test"))
-            }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 }
@@ -1121,10 +1115,8 @@ source set. Use the library's base artifact name, such as `kotlinx-coroutines-co
 ```kotlin
 kotlin {
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
-            }
+        commonMain.dependencies {
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
         }
     }
 }
@@ -1157,10 +1149,8 @@ the corresponding source set:
 ```kotlin
 kotlin {
     sourceSets {
-        val jvmMain by getting {
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
-            }
+        jvmMain.dependencies {
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
         }
     }
 }

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -1102,12 +1102,12 @@ kotlin.test.infer.jvm.variant=false
 
 If you have used a variant of `kotlin("test")` in your build script explicitly and your project build stopped working with
 a compatibility conflict,
-see [this issue in the Compatibility Guide](compatibility-guide-15.md#do-not-mix-several-jvm-variants-of-kotlin-test-in-a-single-project).
+see [this issue in the Compatibility guide](compatibility-guide-15.md#do-not-mix-several-jvm-variants-of-kotlin-test-in-a-single-project).
 
 ### Set a dependency on a kotlinx library
 
 If you use a multiplatform library and need to depend on the shared code, set the dependency only once in the shared
-source set. Use the library's base artifact name, such as `kotlinx-coroutines-core` or `ktor-client-core`.
+source set. Use the library's base artifact name, such as `kotlinx-coroutines-core` or `ktor-client-core`:
 
 <tabs group="build-script">
 <tab title="Kotlin" group-key="kotlin">
@@ -1141,7 +1141,7 @@ kotlin {
 </tabs>
 
 If you need a kotlinx library for a platform-specific dependency, you can still use the library's base artifact name in
-the corresponding source set:
+the corresponding platform source set:
 
 <tabs group="build-script">
 <tab title="Kotlin" group-key="kotlin">

--- a/docs/topics/multiplatform/multiplatform-add-dependencies.md
+++ b/docs/topics/multiplatform/multiplatform-add-dependencies.md
@@ -92,7 +92,7 @@ kotlin {
 ### kotlinx libraries
 
 If you use a multiplatform library and need to [depend on the shared code](#library-shared-for-all-source-sets), set the
-dependency only once in the shared source set. Use the library base artifact name, such as `kotlinx-coroutines-core`.
+dependency only once in the shared source set. Use the library base artifact name, such as `kotlinx-coroutines-core`:
 
 <tabs group="build-script">
 <tab title="Kotlin" group-key="kotlin">
@@ -125,9 +125,8 @@ kotlin {
 </tab>
 </tabs>
 
-If you use a kotlinx library and need a [platform-specific dependency](#library-used-in-specific-source-sets), you can
-use platform-specific variants of libraries with suffixes such as `-jvm` or `-js`, for
-example, `kotlinx-coroutines-core-jvm`.
+If you need a kotlinx library for a [platform-specific dependency](#library-used-in-specific-source-sets), you can
+still use library's base artifact name in the corresponding platform source set:
 
 <tabs group="build-script">
 <tab title="Kotlin" group-key="kotlin">
@@ -136,7 +135,7 @@ example, `kotlinx-coroutines-core-jvm`.
 kotlin {
     sourceSets {
         jvmMain.dependencies {
-            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:%coroutinesVersion%")
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
         }
     }
 }
@@ -150,7 +149,7 @@ kotlin {
     sourceSets {
         jvmMain {
             dependencies {
-                implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:%coroutinesVersion%'
+                implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%'
             }
         }
     }

--- a/docs/topics/scripting/custom-script-deps-tutorial.md
+++ b/docs/topics/scripting/custom-script-deps-tutorial.md
@@ -133,7 +133,7 @@ In this tutorial, this includes support for the `@Repository` and `@DependsOn` a
        implementation 'org.jetbrains.kotlin:kotlin-scripting-dependencies'
        implementation 'org.jetbrains.kotlin:kotlin-scripting-dependencies-maven'
        // coroutines dependency is required for this particular definition
-       implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:%coroutinesVersion%'
+       implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%'
 
    }
    ```


### PR DESCRIPTION
[KT-69458](https://youtrack.jetbrains.com/issue/KT-69458): This PR removes recommendations on using platform-specific variants of kotlinx libraries in platform source sets