### PR TITLE
Add note that worksheets aren't supported in K2 mode

### DIFF
--- a/docs/topics/run-code-snippets.md
+++ b/docs/topics/run-code-snippets.md
@@ -24,6 +24,10 @@ IntelliJ IDEA and Android Studio support Kotlin [scratch files and worksheets](h
   To create a Kotlin worksheet in a project directory, right-click the directory in the project tree and select
   **New** | **Kotlin Class/File** | **Kotlin Worksheet**.
 
+    > Kotlin worksheets aren't supported in [K2 mode](k2-compiler-migration-guide.md#support-in-ides).
+    >
+    {style="note"}
+
 Syntax highlighting, auto-completion, and other
 IntelliJ IDEA code editing features are supported in scratches and worksheets. There's no need to declare the `main()` function 
 – all the code you write is executed as if it were in the body of `main()`.

--- a/docs/topics/run-code-snippets.md
+++ b/docs/topics/run-code-snippets.md
@@ -24,7 +24,7 @@ IntelliJ IDEA and Android Studio support Kotlin [scratch files and worksheets](h
   To create a Kotlin worksheet in a project directory, right-click the directory in the project tree and select
   **New** | **Kotlin Class/File** | **Kotlin Worksheet**.
 
-    > Kotlin worksheets aren't supported in [K2 mode](https://blog.jetbrains.com/idea/2024/11/k2-mode-becomes-stable/) yet. We're working on providing an alternative with similar functionality.
+    > Kotlin worksheets aren't supported in [K2 mode](https://blog.jetbrains.com/idea/2024/11/k2-mode-becomes-stable/). We're working on providing an alternative with similar functionality.
     >
     {style="warning"}
 

--- a/docs/topics/run-code-snippets.md
+++ b/docs/topics/run-code-snippets.md
@@ -24,7 +24,7 @@ IntelliJ IDEA and Android Studio support Kotlin [scratch files and worksheets](h
   To create a Kotlin worksheet in a project directory, right-click the directory in the project tree and select
   **New** | **Kotlin Class/File** | **Kotlin Worksheet**.
 
-    > Kotlin worksheets aren't supported in [K2 mode](https://blog.jetbrains.com/idea/2024/11/k2-mode-becomes-stable/) yet. We're working on adding this functionality.
+    > Kotlin worksheets aren't supported in [K2 mode](https://blog.jetbrains.com/idea/2024/11/k2-mode-becomes-stable/) yet. We're working on providing an alternative with similar functionality.
     >
     {style="warning"}
 

--- a/docs/topics/run-code-snippets.md
+++ b/docs/topics/run-code-snippets.md
@@ -26,7 +26,7 @@ IntelliJ IDEA and Android Studio support Kotlin [scratch files and worksheets](h
 
     > Kotlin worksheets aren't supported in [K2 mode](https://blog.jetbrains.com/idea/2024/11/k2-mode-becomes-stable/) yet. We're working on adding this functionality.
     >
-    {style="note"}
+    {style="warning"}
 
 Syntax highlighting, auto-completion, and other
 IntelliJ IDEA code editing features are supported in scratches and worksheets. There's no need to declare the `main()` function 

--- a/docs/topics/run-code-snippets.md
+++ b/docs/topics/run-code-snippets.md
@@ -24,7 +24,7 @@ IntelliJ IDEA and Android Studio support Kotlin [scratch files and worksheets](h
   To create a Kotlin worksheet in a project directory, right-click the directory in the project tree and select
   **New** | **Kotlin Class/File** | **Kotlin Worksheet**.
 
-    > Kotlin worksheets aren't supported in [K2 mode](k2-compiler-migration-guide.md#support-in-ides).
+    > Kotlin worksheets aren't supported in [K2 mode](https://blog.jetbrains.com/idea/2024/11/k2-mode-becomes-stable/) yet. We're working on adding this functionality.
     >
     {style="note"}
 


### PR DESCRIPTION
Short update to include a note explaining that Kotlin worksheets aren't supported in K2 mode. 
Related issue: [KT-74667](https://youtrack.jetbrains.com/issue/KT-74667)