### PR TITLE
async docs: CB & promises - sp fix and clarifications 

### DIFF
--- a/docs/topics/async-programming.md
+++ b/docs/topics/async-programming.md
@@ -61,15 +61,15 @@ fun preparePostAsync(callback: (Token) -> Unit) {
 This in principle feels like a much more elegant solution, but once again has several issues:
 
 * Difficulty of nested callbacks. Usually a function that is used as a callback, often ends up needing its own callback. This leads to a series of nested callbacks which
-lead to incomprehensible code. The pattern is often referred to as the titled christmas tree (braces represent branches of the tree).
+lead to incomprehensible code. The pattern is often referred to as callback hell, or the [pyramid of doom](https://en.wikipedia.org/wiki/Pyramid_of_doom_(programming)) due to the triangular shape that indentations from these deeply nested callbacks create.
 * Error handling is complicated. The nesting model makes error handling and propagation of these somewhat more complicated. 
 
 Callbacks are quite common in event-loop architectures such as JavaScript, but even there, generally people have moved away to using other approaches such as promises or reactive extensions.
 
 ## Futures, promises, and others
 
-The idea behind futures or promises (there are also other terms these can be referred to depending on language/platform), is that when we make a call, we're promised 
-that at some point it will return with an object called a Promise, which can then be operated on.
+The idea behind futures or promises (other terms may be used depending on the language or platform), is that when we 
+make a call, we're _promised_ that at some point the call will return a `Promise` object, which we can then operate on.
 
 ```kotlin
 fun postItem(item: Item) {


### PR DESCRIPTION


- in the Callbacks section, there's a typo here: `**titled** christmas tree`. I was going to fix to `tilted` and then decided to update that to `pyramid of doom` since that seemed more well-known. 

- in the Promises/Futures section, the existing wording is unclear re: when the promise is returned: `we're promised that at some point it will return with an object called a Promise`. So I clarified that with a few more words, aiming to keep existing simplicity without overcomplicating.