### PR TITLE
Remove K2 mode Beta notice

### DIFF
--- a/docs/topics/k2-compiler-migration-guide.md
+++ b/docs/topics/k2-compiler-migration-guide.md
@@ -21,11 +21,6 @@ The new architecture and enriched data structure enables the K2 compiler to prov
   frontend to analyze your Kotlin code, bringing stability and performance improvements. For more information,
   see [Support in IDEs](#support-in-ides).
 
-  > The K2 mode is in Beta. We are working on stability and code analysis improvements, but not all IDE features are supported
-  > yet.
-  >
-  {style="warning"}
-
 This guide:
 
 * Explains the benefits of the new K2 compiler.


### PR DESCRIPTION
This PR removes one last warning about K2 mode being in Beta, leftover from #4593. 