### PR TITLE
fix: foundation logo positioning

### DIFF
--- a/blocks/main/foundation-preview/foundation-preview.module.css
+++ b/blocks/main/foundation-preview/foundation-preview.module.css
@@ -93,7 +93,7 @@
     .companies {
         flex-wrap: wrap;
         gap: 8px;
-        max-width: 684px;
+        max-width: 745px;
     }
 
     .companyLogo {
@@ -103,6 +103,12 @@
 
     .buttonWrap {
         align-self: flex-end;
+    }
+}
+
+@media (--ktl-ds) and (--ktl-tl-min) {
+    .companies {
+        max-width: 585px;
     }
 }
 


### PR DESCRIPTION
This is how it looks
<img width="1489" alt="Screenshot 2025-02-24 at 11 34 53" src="https://github.com/user-attachments/assets/143070de-18fa-4265-a20e-e51c1b7be5d5" />
<img width="1132" alt="Screenshot 2025-02-24 at 11 35 03" src="https://github.com/user-attachments/assets/723277c1-c781-49e0-a0d7-c81cb48c281c" />
<img width="742" alt="Screenshot 2025-02-24 at 11 35 23" src="https://github.com/user-attachments/assets/a0827283-c75b-40ef-877e-fb54cca05b69" />
<img width="360" alt="Screenshot 2025-02-24 at 11 35 38" src="https://github.com/user-attachments/assets/c79720b1-762b-4f5f-ae2c-4abd1542c7f1" />
