### PR TITLE
Moving the KT-71275 from Removed section to the Done section

### DIFF
--- a/docs/topics/roadmap.md
+++ b/docs/topics/roadmap.md
@@ -161,6 +161,19 @@ We've **added** the following items to the roadmap:
 * 🆕 Exposed: [Release 1.0.0](https://youtrack.jetbrains.com/issue/EXPOSED-444)
 * 🆕 Exposed: [Add R2DBC Support](https://youtrack.jetbrains.com/issue/EXPOSED-74)
 
+<!--
+### Removed items
+
+We've **removed** the following items from the roadmap:
+
+* ❌ Compiler: [Improve the quality of compiler diagnostics](https://youtrack.jetbrains.com/issue/KT-71275)
+
+> Some items were removed from the roadmap but not dropped completely. In some cases, we've merged previous roadmap items
+> with the current ones.
+>
+{style="note"}
+-->
+
 ### Items in progress
 
 All other previously identified roadmap items are in progress. You can check their [YouTrack tickets](https://youtrack.jetbrains.com/issues?q=project:%20KT,%20KTIJ%20tag:%20%7BRoadmap%20Item%7D%20%23Unresolved%20)

--- a/docs/topics/roadmap.md
+++ b/docs/topics/roadmap.md
@@ -133,6 +133,7 @@ Visit the [roadmap board in our issue tracker YouTrack](https://youtrack.jetbrai
 We've **completed** the following items from the previous roadmap:
 
 * ✅ Compiler: [Support debugging inline functions on Android](https://youtrack.jetbrains.com/issue/KT-60276)
+* ✅ Compiler: [Improve the quality of compiler diagnostics](https://youtrack.jetbrains.com/issue/KT-71275)
 * ✅ Multiplatform: [Support Xcode 16 in Kotlin](https://youtrack.jetbrains.com/issue/KT-71287)
 * ✅ Multiplatform: [Publish publicly available API reference for Kotlin Gradle Plugin](https://youtrack.jetbrains.com/issue/KT-71288)
 * ✅ Tooling: [Provide out-of-the-box debugging experience for Kotlin/Wasm targets](https://youtrack.jetbrains.com/issue/KT-71276)
@@ -159,17 +160,6 @@ We've **added** the following items to the roadmap:
 * 🆕 Ktor: [HTTP/3 Support](https://youtrack.jetbrains.com/issue/KTOR-7938)
 * 🆕 Exposed: [Release 1.0.0](https://youtrack.jetbrains.com/issue/EXPOSED-444)
 * 🆕 Exposed: [Add R2DBC Support](https://youtrack.jetbrains.com/issue/EXPOSED-74)
-
-### Removed items
-
-We've **removed** the following items from the roadmap:
-
-* ❌ Compiler: [Improve the quality of compiler diagnostics](https://youtrack.jetbrains.com/issue/KT-71275)
-
-> Some items were removed from the roadmap but not dropped completely. In some cases, we've merged previous roadmap items
-> with the current ones.
->
-{style="note"}
 
 ### Items in progress
 


### PR DESCRIPTION
According to the Compiler folks it makes sense to mark it as done. 