### PR TITLE
Add CMP tutorial to KMP tab on Get started

### DIFF
--- a/docs/topics/getting-started.md
+++ b/docs/topics/getting-started.md
@@ -31,11 +31,10 @@ Here you'll learn how to develop a console application and create unit tests wit
    * ![StackOverflow](stackoverflow.svg){width=25}{type="joined"} StackOverflow: subscribe to the ["kotlin"](https://stackoverflow.com/questions/tagged/kotlin) tag.
 
 4. **Follow Kotlin** on:
-
+   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
    * ![Twitter](twitter.svg){width=18}{type="joined"} [Twitter](https://twitter.com/kotlin)
    * ![Bluesky](bsky.svg){width=18}{type="joined"} [Bluesky](https://bsky.app/profile/kotlinlang.org)
    * ![Reddit](reddit.svg){width=25}{type="joined"} [Reddit](https://www.reddit.com/r/Kotlin/)
-   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
 
 If you encounter any difficulties or problems, report an issue in our [issue tracker](https://youtrack.jetbrains.com/issues/KT).
 
@@ -47,8 +46,8 @@ Here you'll learn how to develop a backend application with Kotlin server-side.
 
 1. **Create your first backend application:**
 
-     * [Create a RESTful web service with Spring Boot](jvm-get-started-spring-boot.md).
-     * [Create HTTP APIs with Ktor](https://ktor.io/docs/creating-http-apis.html).
+     * [Create a RESTful web service with Spring Boot](jvm-get-started-spring-boot.md)
+     * [Create HTTP APIs with Ktor](https://ktor.io/docs/creating-http-apis.html)
 
 2. **[Learn how to mix Kotlin and Java code in your application](mixing-java-kotlin-intellij.md).**
 
@@ -59,10 +58,10 @@ Here you'll learn how to develop a backend application with Kotlin server-side.
 
 4. **Follow Kotlin** on:
 
+   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
    * ![Twitter](twitter.svg){width=18}{type="joined"} [Twitter](https://twitter.com/kotlin)
    * ![Bluesky](bsky.svg){width=18}{type="joined"} [Bluesky](https://bsky.app/profile/kotlinlang.org)
    * ![Reddit](reddit.svg){width=25}{type="joined"} [Reddit](https://www.reddit.com/r/Kotlin/)
-   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
 
 If you encounter any difficulties or problems, report an issue in our [issue tracker](https://youtrack.jetbrains.com/issues/KT).
 
@@ -76,9 +75,11 @@ Here you'll learn how to develop a cross-platform application using [Kotlin Mult
 
 2. **Create your first application for iOS and Android:**
 
-   * [Create a basic cross-platform application from scratch with the project wizard](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-create-first-app.html).
-   * [Make your existing Android application work on iOS](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-integrate-in-existing-app.html).
-   * [Create a cross-platform application using Ktor and SQLdelight](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-ktor-sqldelight.html).
+   * Create a cross-platform application from scratch and:
+     * [Share business logic while keeping the UI native](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-create-first-app.html)
+     * [Share business logic and UI](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-create-first-app.html)
+   * [Make your existing Android application work on iOS](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-integrate-in-existing-app.html)
+   * [Create a cross-platform application using Ktor and SQLdelight](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-ktor-sqldelight.html)
 
 3. **Explore [sample projects](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-samples.html)**.
 
@@ -89,10 +90,10 @@ Here you'll learn how to develop a cross-platform application using [Kotlin Mult
 
 5. **Follow Kotlin** on:
 
+   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
    * ![Twitter](twitter.svg){width=18}{type="joined"} [Twitter](https://twitter.com/kotlin)
    * ![Bluesky](bsky.svg){width=18}{type="joined"} [Bluesky](https://bsky.app/profile/kotlinlang.org)
    * ![Reddit](reddit.svg){width=25}{type="joined"} [Reddit](https://www.reddit.com/r/Kotlin/)
-   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
 
 If you encounter any difficulties or problems, report an issue to our [issue tracker](https://youtrack.jetbrains.com/issues/KT).
 
@@ -104,7 +105,7 @@ To start using Kotlin for Android development, read [Google's recommendation for
 
 Join the Android community on ![Slack](slack.svg){width=25}{type="joined"} Slack: [get an invite](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up) and join the [#android](https://kotlinlang.slack.com/archives/C0B8M7BUY) channel.
 
-Follow Kotlin on ![Twitter](twitter.svg){width=18}{type="joined"} [Twitter](https://twitter.com/kotlin), ![Bluesky](bsky.svg){width=18}{type="joined"} [Bluesky](https://bsky.app/profile/kotlinlang.org), ![Reddit](reddit.svg){width=25}{type="joined"} [Reddit](https://www.reddit.com/r/Kotlin/), and ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw), and don't miss any important ecosystem updates.
+Follow Kotlin on ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw), ![Twitter](twitter.svg){width=18}{type="joined"} [Twitter](https://twitter.com/kotlin), ![Bluesky](bsky.svg){width=18}{type="joined"} [Bluesky](https://bsky.app/profile/kotlinlang.org), and ![Reddit](reddit.svg){width=25}{type="joined"} [Reddit](https://www.reddit.com/r/Kotlin/), and don't miss any important ecosystem updates.
 
 </tab>
 
@@ -114,7 +115,7 @@ From building data pipelines to productionizing machine learning models, Kotlin 
 
 1. **Create and edit notebooks seamlessly within the IDE:**
 
-   * [Get started with Kotlin Notebook](get-started-with-kotlin-notebooks.md).
+   * [Get started with Kotlin Notebook](get-started-with-kotlin-notebooks.md)
 
 2. **Explore and experiment with your data:**
 
@@ -127,10 +128,10 @@ From building data pipelines to productionizing machine learning models, Kotlin 
    * ![Twitter](twitter.svg){width=18}{type="joined"} Twitter: follow [KotlinForData](http://twitter.com/KotlinForData).
 
 4. **Follow Kotlin** on:
+   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
    * ![Twitter](twitter.svg){width=18}{type="joined"} [Twitter](https://twitter.com/kotlin)
    * ![Bluesky](bsky.svg){width=18}{type="joined"} [Bluesky](https://bsky.app/profile/kotlinlang.org)
    * ![Reddit](reddit.svg){width=25}{type="joined"} [Reddit](https://www.reddit.com/r/Kotlin/)
-   * ![YouTube](youtube.svg){width=25}{type="joined"} [Youtube](https://www.youtube.com/channel/UCP7uiEZIqci43m22KDl0sNw)
 
 </tab>
 


### PR DESCRIPTION
This PR updates the cross-platform tab to include the CMP tutorial. It also rearranges the social media icons to put YouTube first. Approved by Pamela Hill.