### PR TITLE
Update `withJava()` function content for 2.1.20

### DIFF
--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -48,23 +48,24 @@ plugins {
 When configuring your project, check the Kotlin Gradle plugin (KGP) compatibility with available Gradle versions. 
 In the following table, there are the minimum and maximum **fully supported** versions of Gradle and Android Gradle plugin (AGP):
 
-| KGP version   | Gradle min and max versions            | AGP min and max versions                            |
-|---------------|----------------------------------------|-----------------------------------------------------|
-| 2.1.0         | %minGradleVersion%–%maxGradleVersion%* | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
-| 2.0.20–2.0.21 | 6.8.3–8.8*                             | 7.1.3–8.5                                           |
-| 2.0.0         | 6.8.3–8.5                              | 7.1.3–8.3.1                                         |
-| 1.9.20–1.9.25 | 6.8.3–8.1.1                            | 4.2.2–8.1.0                                         |
-| 1.9.0–1.9.10  | 6.8.3–7.6.0                            | 4.2.2–7.4.0                                         |
-| 1.8.20–1.8.22 | 6.8.3–7.6.0                            | 4.1.3–7.4.0                                         |      
-| 1.8.0–1.8.11  | 6.8.3–7.3.3                            | 4.1.3–7.2.1                                         |   
-| 1.7.20–1.7.22 | 6.7.1–7.1.1                            | 3.6.4–7.0.4                                         |
-| 1.7.0–1.7.10  | 6.7.1–7.0.2                            | 3.4.3–7.0.2                                         |
-| 1.6.20–1.6.21 | 6.1.1–7.0.2                            | 3.4.3–7.0.2                                         |
+| KGP version   | Gradle min and max versions           | AGP min and max versions                            |
+|---------------|---------------------------------------|-----------------------------------------------------|
+| 2.1.20        | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 2.1.0–2.1.10  | 7.6.3–8.10*                           | 7.3.1–8.7.2                                         |
+| 2.0.20–2.0.21 | 6.8.3–8.8*                            | 7.1.3–8.5                                           |
+| 2.0.0         | 6.8.3–8.5                             | 7.1.3–8.3.1                                         |
+| 1.9.20–1.9.25 | 6.8.3–8.1.1                           | 4.2.2–8.1.0                                         |
+| 1.9.0–1.9.10  | 6.8.3–7.6.0                           | 4.2.2–7.4.0                                         |
+| 1.8.20–1.8.22 | 6.8.3–7.6.0                           | 4.1.3–7.4.0                                         |      
+| 1.8.0–1.8.11  | 6.8.3–7.3.3                           | 4.1.3–7.2.1                                         |   
+| 1.7.20–1.7.22 | 6.7.1–7.1.1                           | 3.6.4–7.0.4                                         |
+| 1.7.0–1.7.10  | 6.7.1–7.0.2                           | 3.4.3–7.0.2                                         |
+| 1.6.20–1.6.21 | 6.1.1–7.0.2                           | 3.4.3–7.0.2                                         |
 
-> *Kotlin 2.0.20–2.0.21 and Kotlin 2.1.0 are fully compatible with Gradle up to 8.6.
+> *Kotlin 2.0.20–2.0.21 and Kotlin 2.1.0–2.1.10 are fully compatible with Gradle up to 8.6.
 > Gradle versions 8.7–8.10 are also supported, with only one exception: If you use the Kotlin Multiplatform Gradle plugin,
-> you may see deprecation warnings in your multiplatform projects calling the [`withJava()` function in the JVM target](multiplatform-dsl-reference.md#jvm-targets).
-> For more information, see the issue in [YouTrack](https://youtrack.jetbrains.com/issue/KT-66542/Gradle-JVM-target-with-withJava-produces-a-deprecation-warning).
+> you may see deprecation warnings in your multiplatform projects calling the `withJava()` function in the JVM target.
+> For more information, see [Java source sets created by default](multiplatform-compatibility-guide.md#java-source-sets-created-by-default).
 >
 {style="warning"}
 

--- a/docs/topics/ksp/ksp-multiplatform.md
+++ b/docs/topics/ksp/ksp-multiplatform.md
@@ -14,18 +14,11 @@ plugins {
 }
 
 kotlin {
-    jvm {
-        withJava()
-    }
-    linuxX64() {
+    jvm()
+    linuxX64 {
         binaries {
             executable()
         }
-    }
-    sourceSets {
-        val commonMain by getting
-        val linuxX64Main by getting
-        val linuxX64Test by getting
     }
 }
 
@@ -34,7 +27,7 @@ dependencies {
     add("kspJvm", project(":test-processor"))
     add("kspJvmTest", project(":test-processor")) // Not doing anything because there's no test source set for JVM
     // There is no processing for the Linux x64 main source set, because kspLinuxX64 isn't specified
-    add("kspLinuxX64Test", project(":test-processor"))
+    // add("kspLinuxX64Test", project(":test-processor"))
 }
 ```
 

--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -18,19 +18,20 @@ the Kotlin version you have in your projects, for example:
 When configuring your project, check the compatibility of a particular version of the Kotlin Multiplatform Gradle plugin
 (same as the Kotlin version in your project) with Gradle, Xcode, and Android Gradle plugin versions:
 
-| Kotlin Multiplatform plugin version | Gradle                                 | Android Gradle plugin           | Xcode   |
-|-------------------------------------|----------------------------------------|---------------------------------|---------|
-| 2.1.0                               | %minGradleVersion%–%maxGradleVersion%* | 7.4.2–%maxAndroidGradleVersion% | %xcode% |
-| 2.0.21                              | 7.5-8.8*                               | 7.4.2–8.5                       | 16.0    |
-| 2.0.20                              | 7.5-8.8*                               | 7.4.2–8.5                       | 15.3    |
-| 2.0.0                               | 7.5-8.5                                | 7.4.2–8.3                       | 15.3    |
-| 1.9.20                              | 7.5-8.1.1                              | 7.4.2–8.2                       | 15.0    |
+| Kotlin Multiplatform plugin version | Gradle                                | Android Gradle plugin           | Xcode   |
+|-------------------------------------|---------------------------------------|---------------------------------|---------|
+| 2.1.20                              | %minGradleVersion%–%maxGradleVersion% | 7.4.2–%maxAndroidGradleVersion% | %xcode% |
+| 2.1.0–2.1.10                        | 7.6.3-8.10*                           | 7.4.2–8.7.2                     | 16.0    |
+| 2.0.21                              | 7.5-8.8*                              | 7.4.2–8.5                       | 16.0    |
+| 2.0.20                              | 7.5-8.8*                              | 7.4.2–8.5                       | 15.3    |
+| 2.0.0                               | 7.5-8.5                               | 7.4.2–8.3                       | 15.3    |
+| 1.9.20                              | 7.5-8.1.1                             | 7.4.2–8.2                       | 15.0    |
 
-> *Kotlin 2.0.20–2.0.21 and Kotlin 2.1.0 are fully compatible with Gradle up to 8.6.
-> Gradle 8.7 and 8.8 are also supported, but you may see deprecation warnings in your multiplatform projects
-> calling the [`withJava()` function in the JVM target](multiplatform-dsl-reference.md#jvm-targets). 
-> For more information, see the issue in [YouTrack](https://youtrack.jetbrains.com/issue/KT-66542/Gradle-JVM-target-with-withJava-produces-a-deprecation-warning).
-> 
+> *Kotlin 2.0.20–2.0.21 and Kotlin 2.1.0–2.1.10 are fully compatible with Gradle up to 8.6.
+> Gradle versions 8.7–8.10 are also supported, with only one exception: If you use the Kotlin Multiplatform Gradle plugin,
+> you may see deprecation warnings in your multiplatform projects calling the `withJava()` function in the JVM target.
+> For more information, see [Java source sets created by default](#java-source-sets-created-by-default).
+>
 {style="warning"}
 
 ## Kotlin 2.0.0 and later

--- a/docs/topics/multiplatform/multiplatform-configure-compilations.md
+++ b/docs/topics/multiplatform/multiplatform-configure-compilations.md
@@ -207,24 +207,14 @@ JVM versions in your final artifact, or you have already set up source sets in G
 
 ## Use Java sources in JVM compilations
 
-When creating a project with the [project wizard](https://kmp.jetbrains.com/), Java sources are included in the compilations of
+When creating a project with the [project wizard](https://kmp.jetbrains.com/), Java sources are created by default and included in the compilations of
 the JVM target.
-
-In the build script, the following section applies the Gradle `java` plugin and configures the target to cooperate with it:
-
-```kotlin
-kotlin {
-    jvm {
-        withJava()
-    }
-}
-```
 
 The Java source files are placed in the child directories of the Kotlin source roots. For example, the paths are:
 
 ![Java source files](java-source-paths.png){width=200}
 
-The common source sets cannot include Java sources.
+The common source sets can't include Java sources.
 
 Due to current limitations, the Kotlin plugin replaces some tasks configured by the Java plugin:
 

--- a/docs/topics/multiplatform/multiplatform-dsl-reference.md
+++ b/docs/topics/multiplatform/multiplatform-dsl-reference.md
@@ -135,27 +135,6 @@ In any target block, you can use the following declarations:
 | `components`        | Components used to set up Gradle publications.                                                                                                                                             |
 | `compilerOptions`   | [Compiler options](#compiler-options) used for the target. This declaration overrides any `compilerOptions {}` configured at [top level](multiplatform-dsl-reference.md#top-level-blocks). |
 
-### JVM targets
-
-In addition to [common target configuration](#common-target-configuration), `jvm` targets have a specific function:
-
-| **Name**     | **Description**                                           | 
-|--------------|-----------------------------------------------------------|
-| `withJava()` | Includes Java sources into the JVM target's compilations. |
-
-Use this function for projects that contain both Java and Kotlin source files. Note that the default source directories for Java sources
-don't follow the Java plugin's defaults. Instead, they are derived from the Kotlin source sets. For example, if the JVM target
-has the default name `jvm`, the paths are `src/jvmMain/java` (for production Java sources) and `src/jvmTest/java` for test Java sources.
-Learn more about [Java sources in JVM compilations](multiplatform-configure-compilations.md#use-java-sources-in-jvm-compilations).
-
-```kotlin
-kotlin {
-    jvm {
-        withJava()
-    } 
-}
-```
-
 ### Web targets
 
 The `js {}` block describes the configuration of Kotlin/JS targets, and the `wasmJs {}` block describes the configuration of

--- a/docs/topics/whatsnew2020.md
+++ b/docs/topics/whatsnew2020.md
@@ -518,8 +518,7 @@ This feature is available for the `Set`, `Map`, and `List` Kotlin collection typ
 
 Kotlin 2.0.20 is fully compatible with Gradle 6.8.3 through 8.6. Gradle 8.7 and 8.8 are also supported, with only one 
 exception: If you use the Kotlin Multiplatform Gradle plugin, you may see deprecation warnings in your multiplatform projects
-calling the [`withJava()` function in the JVM target](multiplatform-dsl-reference.md#jvm-targets). We plan to fix
-this issue as soon as possible.
+calling the `withJava()` function in the JVM target. We plan to fix this issue as soon as possible.
 
 For more information, see the issue in [YouTrack](https://youtrack.jetbrains.com/issue/KT-66542/Gradle-JVM-target-with-withJava-produces-a-deprecation-warning).
 

--- a/docs/topics/whatsnew21.md
+++ b/docs/topics/whatsnew21.md
@@ -1181,7 +1181,7 @@ Learn more about [ES2015 (ECMAScript 2015, ES6) in the official documentation](h
 Kotlin 2.1.0 is fully compatible with Gradle 7.6.3 through 8.6.
 Gradle versions 8.7 to 8.10 are also supported, with only one exception.
 If you use the Kotlin Multiplatform Gradle plugin,
-you may see deprecation warnings in your multiplatform projects calling the [`withJava()` function in the JVM target](multiplatform-dsl-reference.md#jvm-targets).
+you may see deprecation warnings in your multiplatform projects calling the `withJava()` function in the JVM target.
 We plan to fix this issue as soon as possible.
 
 For more information,


### PR DESCRIPTION
This PR updates content around the `withJava()` function that reflects the state of Kotlin 2.1.20.