### PR TITLE
update: add a warning for casting in java-to-kotlin-nullability-guide.md

### DIFF
--- a/docs/topics/jvm/java-to-kotlin-nullability-guide.md
+++ b/docs/topics/jvm/java-to-kotlin-nullability-guide.md
@@ -337,6 +337,13 @@ you would do the check anyway, but no additional boxing is performed this way.
 >
 {style="note"}
 
+> In Java, the unsafe type cast `(String) y` corresponds to `y as String?` in Kotlin, not `y as String`.
+This is because `y as String?` only throws `ClassCastException` when the `y` is not of type `String`,
+whereas `y as String` additionally throws `NullPointerException` (NPE) when `y` is `null`.
+This distinction might lead to accidental NPE swallowing if using try-catch blocks designed to handle `ClassCastException`.
+>
+{style="warning"}
+
 ## What's next?
 
 * Browse other [Kotlin idioms](idioms.md).


### PR DESCRIPTION
Based on some of my recent findings, many Java developers new to Kotlin often confuse `obj as T` with `obj as T?`, especially when interacting with Java code. Accidentally writing `obj as T` instead of `obj as T?` may lead to unexpected NPEs. For this reason, I've added a warning block in this documentation.

You can see some example commits here:
[androidx-8e967e](https://github.com/androidx/androidx/commit/d0368b8bd00b91987340eaea3856a87c248e967e#diff-82fee78f32a586f9babd3fc0b7a548a1cb2977b9fecdf015b878a9c10cca2ee6L50)
[androidAPS-36b99e](https://github.com/nightscout/AndroidAPS/commit/22cad1a761b1955a628355d9006ceca34036b99e)
[androidAPS-49f0f1](https://github.com/nightscout/AndroidAPS/commit/407a7700a5714bcd2f521480179e14694049f0f1)
[androidAPS-f95b34](https://github.com/nightscout/AndroidAPS/commit/4c9052b29a166cb946fcc138afaa92458ff95b34)
[facebook-android-sdk-fd5a42](https://github.com/facebook/facebook-android-sdk/commit/8d4a2e19cbe9f75bb37eed76d7abd7c785fd5a42)

These fix commits demonstrate how easily people might mistakenly use `obj as T` instead of `obj as T?` during migration, which is precisely why I opened this PR.
