### PR TITLE
Kotlin/JS: Fix typo in docs related to running Kotlin/JS project in NodeJS environment

### DIFF
--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -278,7 +278,7 @@ to serve your JavaScript artifacts.
 If you want to customize the configuration used by `webpack-dev-server`, for example, adjust the port the server runs on,
 use the [webpack configuration file](#webpack-bundling).
 
-For running Kotlin/JS projects targeting Node.js, use the `jsBrowserDevelopmentRun` task that is an alias for the `nodeRun` task.
+For running Kotlin/JS projects targeting Node.js, use the `jsNodeDevelopmentRun` task that is an alias for the `nodeRun` task.
 
 To run a project, execute the standard lifecycle `jsBrowserDevelopmentRun` task, or the alias to which it corresponds:
 

--- a/docs/topics/js/running-kotlin-js.md
+++ b/docs/topics/js/running-kotlin-js.md
@@ -14,14 +14,14 @@ Depending on the target platform, some platform-specific extra setup might be re
 
 ## Run the Node.js target
 
-When targeting Node.js with Kotlin/JS, you can simply execute the `jsBrowserDevelopmentRun` Gradle task. This can be done for example via the
+When targeting Node.js with Kotlin/JS, you can simply execute the `run` Gradle task. This can be done for example via the
 command line, using the Gradle wrapper:
 
 ```bash
-./gradlew jsBrowserDevelopmentRun
+./gradlew run
 ```
 
-If you're using IntelliJ IDEA, you can find the `jsBrowserDevelopmentRun` action in the Gradle tool window:
+If you're using IntelliJ IDEA, you can find the `run` action in the Gradle tool window:
 
 ![Gradle Run task in IntelliJ IDEA](run-gradle-task.png){width=700}
 

--- a/docs/topics/js/running-kotlin-js.md
+++ b/docs/topics/js/running-kotlin-js.md
@@ -14,14 +14,14 @@ Depending on the target platform, some platform-specific extra setup might be re
 
 ## Run the Node.js target
 
-When targeting Node.js with Kotlin/JS, you can simply execute the `run` Gradle task. This can be done for example via the
+When targeting Node.js with Kotlin/JS, you can simply execute the `jsNodeDevelopmentRun` Gradle task. This can be done for example via the
 command line, using the Gradle wrapper:
 
 ```bash
-./gradlew run
+./gradlew jsNodeDevelopmentRun
 ```
 
-If you're using IntelliJ IDEA, you can find the `run` action in the Gradle tool window:
+If you're using IntelliJ IDEA, you can find the `jsNodeDevelopmentRun` action in the Gradle tool window:
 
 ![Gradle Run task in IntelliJ IDEA](run-gradle-task.png){width=700}
 


### PR DESCRIPTION
Hi folks, I suppose `:jsBrowserDevelopmentRun` is not the correct Gradle task name to be used with the NodeJS build target. From the context of the section, I made an assumption that calling `:run` is the right thing to do :)   