### PR TITLE
Update `compilerOptions{}` block example

### DIFF
--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -117,7 +117,7 @@ show how to set this configuration up in both Kotlin and Groovy DSLs:
 ```kotlin
 tasks.named("compileKotlin", org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask::class.java) {
     compilerOptions {
-        apiVersion.set("1.8")
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
     }
 }
 ```
@@ -128,7 +128,7 @@ tasks.named("compileKotlin", org.jetbrains.kotlin.gradle.tasks.KotlinCompilation
 ```groovy
 tasks.named('compileKotlin', org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask.class) {
     compilerOptions {
-        apiVersion.set("1.8")
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
     }
 }
 ```


### PR DESCRIPTION
This PR updates an example with the `compilerOptions{}` block so that it runs correctly.