### PR TITLE
Fix version of Dokka

### DIFF
--- a/docs/v.list
+++ b/docs/v.list
@@ -59,7 +59,7 @@
     <var name="jctoolsVersion" value="3.3.0" type="string"/>
 
     <var name="dokkaVersion"
-         value="2.0.20"
+         value="2.0.0"
          type="string"/>
 
     <var name="xcode" value="16.0" type="string"/>


### PR DESCRIPTION
Latest Dokka version is 2.0.0 :)

While Dokka has it's own `v.list` with `dokkaVersion=2.0.0` ([here](https://github.com/Kotlin/dokka/blob/1554f6efafc0ad099be7fe1d5c55dc9692408327/docs/v.list#L7)), looks like the version specified here is used on kotlinlang.org