### PR TITLE
Correct minAndroidGradleVersion for Kotlin v2.1.20

### DIFF
--- a/docs/v.list
+++ b/docs/v.list
@@ -37,7 +37,7 @@
     <var name="minGradleVersion" value="7.6.3" type="string"/>
     <var name="maxGradleVersion" value="8.11" type="string"/>
 
-    <var name="minAndroidGradleVersion" value="7.4.2" type="string"/>
+    <var name="minAndroidGradleVersion" value="7.3.1" type="string"/>
     <var name="maxAndroidGradleVersion" value="8.7.2" type="string"/>
 
     <var name="gradleVersion" value="8.10" type="string"/>


### PR DESCRIPTION
The minimum version is still 7.3.1 in v2.1.20:

https://github.com/JetBrains/kotlin/blob/v2.1.20/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/diagnostics/AgpCompatibilityCheck.kt#L16