### PR TITLE
Replace ./gradlew with gradle in native-get-started.md

### DIFF
--- a/docs/topics/native/native-get-started.md
+++ b/docs/topics/native/native-get-started.md
@@ -277,7 +277,7 @@ as specified in the build file.
 1. From the root project directory, run the build command:
 
    ```bash
-   ./gradlew nativeBinaries
+   gradle nativeBinaries
    ```
 
    This command creates the `build/bin/native` directory with two directories inside: `debugExecutable` and


### PR DESCRIPTION
gradlew is not there. after install proper gradle, should invoke gradle directly.