### PR TITLE
feat: update the navigation for the What's new section

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -382,6 +382,20 @@
 			<toc-element toc-title="FAQ" topic="ksp-faq.md"/>
 		</toc-element>
 	</toc-element>
+	<toc-element toc-title="Kotlin evolution and roadmap">
+		<toc-element topic="roadmap.md"/>
+		<toc-element toc-title="Language features and proposals" topic="kotlin-language-features-and-proposals.md"/>
+		<toc-element toc-title="Language evolution principles" accepts-web-file-names="kotlin-evolution.html" topic="kotlin-evolution-principles.md"/>
+		<toc-element topic="components-stability.md"/>
+		<toc-element topic="compatibility-modes.md"/>
+		<toc-element hidden="true" topic="components-stability-pre-1.4.md"/>
+		<toc-element accepts-web-file-names="plugin-releases.html" topic="releases.md"/>
+	</toc-element>
+	<toc-element toc-title="Early access preview (EAP)">
+		<toc-element toc-title="Participate" topic="eap.md"/>
+		<toc-element toc-title="Install the Kotlin EAP Plugin" topic="install-eap-plugin.md"/>
+		<toc-element topic="configure-build-for-eap.md"/>
+	</toc-element>
 	<toc-element toc-title="Learning materials">
 		<toc-element toc-title="Overview" topic="learning-materials-overview.md"/>
 		<toc-element href="https://play.kotlinlang.org/byExample/overview" toc-title="Kotlin by example"/>

--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -399,16 +399,22 @@
 			<include from="api-guidelines.tree" origin="api-guidelines" element-id="api-guidelines"/>
 		</toc-element>
 	</toc-element>
+	<toc-element toc-title="Kotlin evolution and roadmap">
+		<toc-element topic="roadmap.md"/>
+		<toc-element toc-title="Language features and proposals" topic="kotlin-language-features-and-proposals.md"/>
+		<toc-element toc-title="Language evolution principles" accepts-web-file-names="kotlin-evolution.html" topic="kotlin-evolution-principles.md"/>
+		<toc-element topic="components-stability.md"/>
+		<toc-element topic="compatibility-modes.md"/>
+		<toc-element hidden="true" topic="components-stability-pre-1.4.md"/>
+		<toc-element accepts-web-file-names="plugin-releases.html" topic="releases.md"/>
+	</toc-element>
 	<toc-element toc-title="Early access preview (EAP)">
 		<toc-element toc-title="Participate" topic="eap.md"/>
 		<toc-element topic="configure-build-for-eap.md" accepts-web-file-names="install-eap-plugin.html"/>
 	</toc-element>
 	<toc-element toc-title="Other resources">
 		<toc-element topic="faq.md"/>
-		<toc-element toc-title="Kotlin compatibility guides">
-
-		</toc-element>
-		<toc-element toc-title="Earlier versions">
+		<toc-element toc-title="Earlier Kotlin versions">
 			<toc-element toc-title="Kotlin 1.7.x">
 				<toc-element toc-title="Kotlin 1.7.20" topic="whatsnew1720.md"/>
 				<toc-element toc-title="Kotlin 1.7.0" topic="whatsnew17.md"/>
@@ -438,7 +444,6 @@
 			</toc-element>
 			<toc-element toc-title="Kotlin 1.2" topic="whatsnew12.md"/>
 			<toc-element toc-title="Kotlin 1.1" topic="whatsnew11.md"/>
-		</toc-element>
 		</toc-element>
 		<toc-element toc-title="Kotlin Foundation">
 			<toc-element toc-title="Kotlin Foundation" href="https://kotlinfoundation.org/"/>

--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -23,35 +23,23 @@
 		<toc-element topic="competitive-programming.md"/>
 	</toc-element>
 	<toc-element toc-title="What's new in Kotlin">
-		<toc-element toc-title="Kotlin 2.1.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2120.md"/>
-		<toc-element toc-title="Kotlin 2.1.0" topic="whatsnew21.md"/>
-        <toc-element toc-title="Kotlin 2.1.20-RC3" topic="whatsnew-eap.md" hidden="true"/>
-        <toc-element toc-title="Kotlin 2.0.x">
-            <toc-element toc-title="Kotlin 2.0.20" topic="whatsnew2020.md"/>
-            <toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>
-        </toc-element>
-        <toc-element toc-title="Kotlin 1.9.x">
-            <toc-element toc-title="Kotlin 1.9.20" topic="whatsnew1920.md"/>
-            <toc-element toc-title="Kotlin 1.9.0" topic="whatsnew19.md"/>
-        </toc-element>
+<!--        <toc-element toc-title="Kotlin 2.1.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2120.md"/>-->
+<!--        <toc-element toc-title="Kotlin 2.1.0" topic="whatsnew21.md"/>-->
+		<toc-element toc-title="Kotlin 2.1.0-RC3" topic="whatsnew-eap.md"/>
+		<toc-element toc-title="Kotlin 2.0.x">
+			<toc-element toc-title="Kotlin 2.0.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2020.md"/>
+			<toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>
+			<toc-element topic="compatibility-guide-20.md"/>
+		</toc-element>
+		<toc-element toc-title="Kotlin 1.9.x">
+			<toc-element toc-title="Kotlin 1.9.20" topic="whatsnew1920.md"/>
+			<toc-element toc-title="Kotlin 1.9.0" topic="whatsnew19.md"/>
+			<toc-element topic="compatibility-guide-19.md"/>
+		</toc-element>
 		<toc-element toc-title="Kotlin 1.8.x">
 			<toc-element toc-title="Kotlin 1.8.20" topic="whatsnew1820.md"/>
 			<toc-element toc-title="Kotlin 1.8.0" topic="whatsnew18.md"/>
-		</toc-element>
-		<toc-element toc-title="Earlier versions">
-			<toc-element toc-title="Kotlin 1.7.20" topic="whatsnew1720.md"/>
-			<toc-element toc-title="Kotlin 1.7.0" topic="whatsnew17.md"/>
-			<toc-element toc-title="Kotlin 1.6.20" topic="whatsnew1620.md"/>
-			<toc-element toc-title="Kotlin 1.6.0" topic="whatsnew16.md"/>
-			<toc-element toc-title="Kotlin 1.5.30" topic="whatsnew1530.md"/>
-			<toc-element toc-title="Kotlin 1.5.20" topic="whatsnew1520.md"/>
-			<toc-element toc-title="Kotlin 1.5.0" topic="whatsnew15.md"/>
-			<toc-element toc-title="Kotlin 1.4.30" topic="whatsnew1430.md"/>
-			<toc-element toc-title="Kotlin 1.4.20" topic="whatsnew1420.md"/>
-			<toc-element toc-title="Kotlin 1.4.0" topic="whatsnew14.md"/>
-			<toc-element toc-title="Kotlin 1.3" topic="whatsnew13.md"/>
-			<toc-element toc-title="Kotlin 1.2" topic="whatsnew12.md"/>
-			<toc-element toc-title="Kotlin 1.1" topic="whatsnew11.md"/>
+			<toc-element topic="compatibility-guide-18.md"/>
 		</toc-element>
 	</toc-element>
 	<toc-element toc-title="Kotlin evolution and roadmap">
@@ -59,6 +47,7 @@
 		<toc-element toc-title="Language features and proposals" topic="kotlin-language-features-and-proposals.md"/>
 		<toc-element toc-title="Language evolution principles" accepts-web-file-names="kotlin-evolution.html" topic="kotlin-evolution-principles.md"/>
 		<toc-element topic="components-stability.md"/>
+		<toc-element topic="compatibility-modes.md"/>
 		<toc-element hidden="true" topic="components-stability-pre-1.4.md"/>
 		<toc-element accepts-web-file-names="plugin-releases.html" topic="releases.md"/>
 	</toc-element>
@@ -417,17 +406,39 @@
 	<toc-element toc-title="Other resources">
 		<toc-element topic="faq.md"/>
 		<toc-element toc-title="Kotlin compatibility guides">
-			<toc-element topic="compatibility-guide-21.md"/>
-			<toc-element topic="compatibility-guide-20.md"/>
-			<toc-element topic="compatibility-guide-19.md"/>
-			<toc-element topic="compatibility-guide-18.md"/>
-			<toc-element topic="compatibility-guide-1720.md"/>
-			<toc-element topic="compatibility-guide-17.md"/>
-			<toc-element topic="compatibility-guide-16.md"/>
-			<toc-element topic="compatibility-guide-15.md"/>
-			<toc-element topic="compatibility-guide-14.md"/>
-			<toc-element topic="compatibility-guide-13.md"/>
-			<toc-element topic="compatibility-modes.md"/>
+
+		</toc-element>
+		<toc-element toc-title="Earlier versions">
+			<toc-element toc-title="Kotlin 1.7.x">
+				<toc-element toc-title="Kotlin 1.7.20" topic="whatsnew1720.md"/>
+				<toc-element toc-title="Kotlin 1.7.0" topic="whatsnew17.md"/>
+				<toc-element topic="compatibility-guide-1720.md"/>
+				<toc-element topic="compatibility-guide-17.md"/>
+			</toc-element>
+			<toc-element toc-title="Kotlin 1.6.x">
+				<toc-element toc-title="Kotlin 1.6.20" topic="whatsnew1620.md"/>
+				<toc-element toc-title="Kotlin 1.6.0" topic="whatsnew16.md"/>
+				<toc-element topic="compatibility-guide-16.md"/>
+			</toc-element>
+			<toc-element toc-title="Kotlin 1.5.x">
+				<toc-element toc-title="Kotlin 1.5.30" topic="whatsnew1530.md"/>
+				<toc-element toc-title="Kotlin 1.5.20" topic="whatsnew1520.md"/>
+				<toc-element toc-title="Kotlin 1.5.0" topic="whatsnew15.md"/>
+				<toc-element topic="compatibility-guide-15.md"/>
+			</toc-element>
+			<toc-element toc-title="Kotlin 1.4.x">
+				<toc-element toc-title="Kotlin 1.4.30" topic="whatsnew1430.md"/>
+				<toc-element toc-title="Kotlin 1.4.20" topic="whatsnew1420.md"/>
+				<toc-element toc-title="Kotlin 1.4.0" topic="whatsnew14.md"/>
+				<toc-element topic="compatibility-guide-14.md"/>
+			</toc-element>
+			<toc-element toc-title="Kotlin 1.3.x">
+				<toc-element toc-title="Kotlin 1.3" topic="whatsnew13.md"/>
+				<toc-element topic="compatibility-guide-13.md"/>
+			</toc-element>
+			<toc-element toc-title="Kotlin 1.2" topic="whatsnew12.md"/>
+			<toc-element toc-title="Kotlin 1.1" topic="whatsnew11.md"/>
+		</toc-element>
 		</toc-element>
 		<toc-element toc-title="Kotlin Foundation">
 			<toc-element toc-title="Kotlin Foundation" href="https://kotlinfoundation.org/"/>

--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -23,11 +23,11 @@
 		<toc-element topic="competitive-programming.md"/>
 	</toc-element>
 	<toc-element toc-title="What's new in Kotlin">
-<!--        <toc-element toc-title="Kotlin 2.1.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2120.md"/>-->
-<!--        <toc-element toc-title="Kotlin 2.1.0" topic="whatsnew21.md"/>-->
-		<toc-element toc-title="Kotlin 2.1.0-RC3" topic="whatsnew-eap.md"/>
+        <toc-element toc-title="Kotlin 2.1.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2120.md"/>
+        <toc-element toc-title="Kotlin 2.1.0" topic="whatsnew21.md"/>
+		<toc-element toc-title="Kotlin 2.1.0-RC3" topic="whatsnew-eap.md" hidden="true"/>
 		<toc-element toc-title="Kotlin 2.0.x">
-			<toc-element toc-title="Kotlin 2.0.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2020.md"/>
+			<toc-element toc-title="Kotlin 2.0.20" topic="whatsnew2020.md"/>
 			<toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>
 			<toc-element topic="compatibility-guide-20.md"/>
 		</toc-element>
@@ -36,20 +36,6 @@
 			<toc-element toc-title="Kotlin 1.9.0" topic="whatsnew19.md"/>
 			<toc-element topic="compatibility-guide-19.md"/>
 		</toc-element>
-		<toc-element toc-title="Kotlin 1.8.x">
-			<toc-element toc-title="Kotlin 1.8.20" topic="whatsnew1820.md"/>
-			<toc-element toc-title="Kotlin 1.8.0" topic="whatsnew18.md"/>
-			<toc-element topic="compatibility-guide-18.md"/>
-		</toc-element>
-	</toc-element>
-	<toc-element toc-title="Kotlin evolution and roadmap">
-		<toc-element topic="roadmap.md"/>
-		<toc-element toc-title="Language features and proposals" topic="kotlin-language-features-and-proposals.md"/>
-		<toc-element toc-title="Language evolution principles" accepts-web-file-names="kotlin-evolution.html" topic="kotlin-evolution-principles.md"/>
-		<toc-element topic="components-stability.md"/>
-		<toc-element topic="compatibility-modes.md"/>
-		<toc-element hidden="true" topic="components-stability-pre-1.4.md"/>
-		<toc-element accepts-web-file-names="plugin-releases.html" topic="releases.md"/>
 	</toc-element>
 	<toc-element toc-title="Language guide">
 	    <toc-element toc-title="Basic syntax">
@@ -393,8 +379,7 @@
 	</toc-element>
 	<toc-element toc-title="Early access preview (EAP)">
 		<toc-element toc-title="Participate" topic="eap.md"/>
-		<toc-element toc-title="Install the Kotlin EAP Plugin" topic="install-eap-plugin.md"/>
-		<toc-element topic="configure-build-for-eap.md"/>
+		<toc-element topic="configure-build-for-eap.md" accepts-web-file-names="install-eap-plugin.html"/>
 	</toc-element>
 	<toc-element toc-title="Learning materials">
 		<toc-element toc-title="Overview" topic="learning-materials-overview.md"/>
@@ -413,22 +398,14 @@
 			<include from="api-guidelines.tree" origin="api-guidelines" element-id="api-guidelines"/>
 		</toc-element>
 	</toc-element>
-	<toc-element toc-title="Kotlin evolution and roadmap">
-		<toc-element topic="roadmap.md"/>
-		<toc-element toc-title="Language features and proposals" topic="kotlin-language-features-and-proposals.md"/>
-		<toc-element toc-title="Language evolution principles" accepts-web-file-names="kotlin-evolution.html" topic="kotlin-evolution-principles.md"/>
-		<toc-element topic="components-stability.md"/>
-		<toc-element topic="compatibility-modes.md"/>
-		<toc-element hidden="true" topic="components-stability-pre-1.4.md"/>
-		<toc-element accepts-web-file-names="plugin-releases.html" topic="releases.md"/>
-	</toc-element>
-	<toc-element toc-title="Early access preview (EAP)">
-		<toc-element toc-title="Participate" topic="eap.md"/>
-		<toc-element topic="configure-build-for-eap.md" accepts-web-file-names="install-eap-plugin.html"/>
-	</toc-element>
 	<toc-element toc-title="Other resources">
 		<toc-element topic="faq.md"/>
 		<toc-element toc-title="Earlier Kotlin versions">
+			<toc-element toc-title="Kotlin 1.8.x">
+				<toc-element toc-title="Kotlin 1.8.20" topic="whatsnew1820.md"/>
+				<toc-element toc-title="Kotlin 1.8.0" topic="whatsnew18.md"/>
+				<toc-element topic="compatibility-guide-18.md"/>
+			</toc-element>
 			<toc-element toc-title="Kotlin 1.7.x">
 				<toc-element toc-title="Kotlin 1.7.20" topic="whatsnew1720.md"/>
 				<toc-element toc-title="Kotlin 1.7.0" topic="whatsnew17.md"/>

--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -26,16 +26,7 @@
         <toc-element toc-title="Kotlin 2.1.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2120.md"/>
         <toc-element toc-title="Kotlin 2.1.0" topic="whatsnew21.md"/>
 		<toc-element toc-title="Kotlin 2.1.0-RC3" topic="whatsnew-eap.md" hidden="true"/>
-		<toc-element toc-title="Kotlin 2.0.x">
-			<toc-element toc-title="Kotlin 2.0.20" topic="whatsnew2020.md"/>
-			<toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>
-			<toc-element topic="compatibility-guide-20.md"/>
-		</toc-element>
-		<toc-element toc-title="Kotlin 1.9.x">
-			<toc-element toc-title="Kotlin 1.9.20" topic="whatsnew1920.md"/>
-			<toc-element toc-title="Kotlin 1.9.0" topic="whatsnew19.md"/>
-			<toc-element topic="compatibility-guide-19.md"/>
-		</toc-element>
+		<toc-element topic="compatibility-guide-21.md"/>
 	</toc-element>
 	<toc-element toc-title="Language guide">
 	    <toc-element toc-title="Basic syntax">
@@ -401,6 +392,16 @@
 	<toc-element toc-title="Other resources">
 		<toc-element topic="faq.md"/>
 		<toc-element toc-title="Earlier Kotlin versions">
+			<toc-element toc-title="Kotlin 2.0.x">
+				<toc-element toc-title="Kotlin 2.0.20" topic="whatsnew2020.md"/>
+				<toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>
+				<toc-element topic="compatibility-guide-20.md"/>
+			</toc-element>
+			<toc-element toc-title="Kotlin 1.9.x">
+				<toc-element toc-title="Kotlin 1.9.20" topic="whatsnew1920.md"/>
+				<toc-element toc-title="Kotlin 1.9.0" topic="whatsnew19.md"/>
+				<toc-element topic="compatibility-guide-19.md"/>
+			</toc-element>
 			<toc-element toc-title="Kotlin 1.8.x">
 				<toc-element toc-title="Kotlin 1.8.20" topic="whatsnew1820.md"/>
 				<toc-element toc-title="Kotlin 1.8.0" topic="whatsnew18.md"/>

--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -25,14 +25,20 @@
 	<toc-element toc-title="What's new in Kotlin">
 		<toc-element toc-title="Kotlin 2.1.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2120.md"/>
 		<toc-element toc-title="Kotlin 2.1.0" topic="whatsnew21.md"/>
-		<toc-element toc-title="Kotlin 2.1.20-RC3" topic="whatsnew-eap.md" hidden="true"/>
-		<toc-element toc-title="Earlier versions">
-			<toc-element toc-title="Kotlin 2.0.20" topic="whatsnew2020.md"/>
-			<toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>
-			<toc-element toc-title="Kotlin 1.9.20" topic="whatsnew1920.md"/>
-			<toc-element toc-title="Kotlin 1.9.0" topic="whatsnew19.md"/>
+        <toc-element toc-title="Kotlin 2.1.20-RC3" topic="whatsnew-eap.md" hidden="true"/>
+        <toc-element toc-title="Kotlin 2.0.x">
+            <toc-element toc-title="Kotlin 2.0.20" topic="whatsnew2020.md"/>
+            <toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>
+        </toc-element>
+        <toc-element toc-title="Kotlin 1.9.x">
+            <toc-element toc-title="Kotlin 1.9.20" topic="whatsnew1920.md"/>
+            <toc-element toc-title="Kotlin 1.9.0" topic="whatsnew19.md"/>
+        </toc-element>
+		<toc-element toc-title="Kotlin 1.8.x">
 			<toc-element toc-title="Kotlin 1.8.20" topic="whatsnew1820.md"/>
 			<toc-element toc-title="Kotlin 1.8.0" topic="whatsnew18.md"/>
+		</toc-element>
+		<toc-element toc-title="Earlier versions">
 			<toc-element toc-title="Kotlin 1.7.20" topic="whatsnew1720.md"/>
 			<toc-element toc-title="Kotlin 1.7.0" topic="whatsnew17.md"/>
 			<toc-element toc-title="Kotlin 1.6.20" topic="whatsnew1620.md"/>

--- a/docs/labels.list
+++ b/docs/labels.list
@@ -9,6 +9,4 @@
     <primary-label id="beta" name="Beta" short-name="β" href="components-stability.html#stability-levels-explained" color="tangerine">The feature is in Beta. It is almost stable, but migration steps may be required in the future. We'll do our best to minimize any changes you have to make.</primary-label>
     <primary-label id="advanced" name="Advanced" short-name="☆" color="purple"></primary-label>
     <primary-label id="eap" name="EAP" short-name="EAP" color="red">This functionality is available only in the latest EAP version.</primary-label>
-
-    <secondary-label id="eap" name="EAP" color="red">This functionality is available only in the latest EAP version.</secondary-label>
 </labels>

--- a/docs/topics/compatibility-guides/compatibility-guide-13.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-13.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 1.3)
+[//]: # (title: Compatibility guide for Kotlin 1.3.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental
 principles in Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed,

--- a/docs/topics/compatibility-guides/compatibility-guide-14.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-14.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 1.4)
+[//]: # (title: Compatibility guide for Kotlin 1.4.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental
 principles in Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed,

--- a/docs/topics/compatibility-guides/compatibility-guide-15.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-15.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 1.5)
+[//]: # (title: Compatibility guide for Kotlin 1.5.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental
 principles in Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed,

--- a/docs/topics/compatibility-guides/compatibility-guide-16.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-16.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 1.6)
+[//]: # (title: Compatibility guide for Kotlin 1.6.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental principles in
 Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed, and the

--- a/docs/topics/compatibility-guides/compatibility-guide-17.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-17.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 1.7)
+[//]: # (title: Compatibility guide for Kotlin 1.7.0)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental principles in
 Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed, and the

--- a/docs/topics/compatibility-guides/compatibility-guide-18.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-18.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 1.8)
+[//]: # (title: Compatibility guide for Kotlin 1.8.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental principles in
 Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed, and the

--- a/docs/topics/compatibility-guides/compatibility-guide-19.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-19.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 1.9)
+[//]: # (title: Compatibility guide for Kotlin 1.9.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental principles in
 Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed, and the

--- a/docs/topics/compatibility-guides/compatibility-guide-20.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-20.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 2.0)
+[//]: # (title: Compatibility guide for Kotlin 2.0.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental principles in
 Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed, and the

--- a/docs/topics/compatibility-guides/compatibility-guide-21.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-21.md
@@ -1,4 +1,4 @@
-[//]: # (title: Compatibility guide for Kotlin 2.1)
+[//]: # (title: Compatibility guide for Kotlin 2.1.x)
 
 _[Keeping the Language Modern](kotlin-evolution-principles.md)_ and _[Comfortable Updates](kotlin-evolution-principles.md)_ are among the fundamental principles in
 Kotlin Language Design. The former says that constructs which obstruct language evolution should be removed, and the

--- a/docs/topics/whatsnew/whatsnew-eap.md
+++ b/docs/topics/whatsnew/whatsnew-eap.md
@@ -1,5 +1,7 @@
 [//]: # (title: What's new in Kotlin %kotlinEapVersion%)
 
+<primary-label ref="eap"/>
+
 _[Released: %kotlinEapReleaseDate%](eap.md#build-details)_
 
 > This document doesn't cover all of the features of the Early Access Preview (EAP) release,


### PR DESCRIPTION
update the What's new navigation section:
* better file structure
* old Kotlin versions placed in the Other resources section
* placed compat guides near the corresponding Kotlin What's new pages
