### PR TITLE
Fix for java-test-fixtures plugin in 2.1.21

### DIFF
--- a/docs/topics/multiplatform/multiplatform-compatibility-guide.md
+++ b/docs/topics/multiplatform/multiplatform-compatibility-guide.md
@@ -78,6 +78,10 @@ Starting with Gradle 8.7, the Application plugin will no longer work with the Ko
 If you want to use both the Kotlin Multiplatform Gradle plugin and other Gradle plugins for
 Java in your multiplatform project, see [Deprecated compatibility with Kotlin Multiplatform Gradle plugin and Java plugins](multiplatform-compatibility-guide.md#deprecated-compatibility-with-kotlin-multiplatform-gradle-plugin-and-gradle-java-plugins).
 
+If you use the [Java test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) Gradle plugin with Kotlin 2.1.20
+and a Gradle version higher than 8.7, the plugin doesn't work. Instead, upgrade to [Kotlin 2.1.21](releases.md#release-details)
+where this issue is resolved.
+
 If you run into any issues, report them in our [issue tracker](https://kotl.in/issue) or ask for help in our [public Slack channel](https://kotlinlang.slack.com/archives/C19FD9681).
 
 **When do the changes take effect?**

--- a/docs/topics/whatsnew/whatsnew2120.md
+++ b/docs/topics/whatsnew/whatsnew2120.md
@@ -561,9 +561,10 @@ alongside the plugin, due to an option being effectively set twice.
 
 ## Breaking changes and deprecations
 
-* To align Kotlin Multiplatform with upcoming changes in Gradle, we are phasing out the `withJava()` function.
-  [Java source sets are now created by default](multiplatform-compatibility-guide.md#java-source-sets-created-by-default).
 
+* To align Kotlin Multiplatform with upcoming changes in Gradle, we are phasing out the `withJava()` function.
+  [Java source sets are now created by default](multiplatform-compatibility-guide.md#java-source-sets-created-by-default). If you use the [Java test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) Gradle plugin,
+  upgrade directly to [Kotlin 2.1.21](releases.md#release-details) to avoid compatibility issues.
 * The JetBrains team is proceeding with the deprecation of the `kotlin-android-extensions` plugin. If you try to use it
   in your project, you'll now get a configuration error, and no plugin code will be executed.
 


### PR DESCRIPTION
This PR explains that developers should upgrade to 2.1.21 if they are KMP users that use the Java test fixtures Gradle plugin in their projects.