### PR TITLE
fix: Correct terminology from "statement" to "expression"

### DIFF
--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -202,7 +202,7 @@ val filesSize = files?.size ?: run {
 println(filesSize)
 ```
 
-## Execute a statement if null
+## Execute a expression if null
 
 ```kotlin
 val values = ...


### PR DESCRIPTION
Changed "Execute a statement if null" to "Execute an expression if null", since `throw` in Kotlin is an expression rather than a standalone statement.