### PR TITLE
'Default arguments' -> 'Default parameters'

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -1128,7 +1128,7 @@ class Point(val x: Double, val y: Double) {
 ```
 
 If you have an object with multiple overloaded constructors that don't call different superclass constructors and
-can't be reduced to a single constructor with default argument values, prefer to replace the overloaded constructors with
+can't be reduced to a single constructor with optional parameters, prefer to replace the overloaded constructors with
 factory functions.
 
 ### Platform types

--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -1128,7 +1128,7 @@ class Point(val x: Double, val y: Double) {
 ```
 
 If you have an object with multiple overloaded constructors that don't call different superclass constructors and
-can't be reduced to a single constructor with optional parameters, prefer to replace the overloaded constructors with
+can't be reduced to a single constructor including parameters with default values, prefer to replace the overloaded constructors with
 factory functions.
 
 ### Platform types

--- a/docs/topics/collection-parts.md
+++ b/docs/topics/collection-parts.md
@@ -120,7 +120,7 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
 
-`windowed()` provides more flexibility with optional parameters:
+`windowed()` provides more flexibility regarding parameters with default values:
 
 * `step` defines a distance between first elements of two adjacent windows. By default the value is 1, so the result contains windows starting from all elements. If you increase the step to 2, you will receive only windows starting from odd elements: first, third, and so on.
 * `partialWindows` includes windows of smaller sizes that start from the elements at the end of the collection. For example, if you request windows of three elements, you can't build them for the last two elements. Enabling `partialWindows` in this case includes two more lists of sizes 2 and 1.

--- a/docs/topics/collection-transformations.md
+++ b/docs/topics/collection-transformations.md
@@ -244,8 +244,8 @@ strings: [`joinToString()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.
 `joinToString()` builds a single `String` from the collection elements based on the provided arguments.
 `joinTo()` does the same but appends the result to the given [`Appendable`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-appendable/index.html) object.
 
-When called with the default arguments, the functions return the result similar to calling `toString()` on the collection:
-a `String` of elements' string representations separated by commas with spaces. 
+When called with the parameters' default values, the functions return the result similar to calling `toString()` on the collection:
+a `String` of elements' string representations separated by commas with spaces.
 
 ```kotlin
 

--- a/docs/topics/compatibility-guides/compatibility-guide-22.md
+++ b/docs/topics/compatibility-guides/compatibility-guide-22.md
@@ -190,7 +190,7 @@ perspective (for example, from Java) is out of the scope of this document.
 >
 > - 2.2.0: report an error when accessing private types or members from non-private inline functions
 
-### Forbid non-local returns in default argument lambdas
+### Forbid non-local returns in lambdas used as parameter's default value
 
 > **Issue**: [KTLC-286](https://youtrack.jetbrains.com/issue/KTLC-286)
 >
@@ -198,12 +198,12 @@ perspective (for example, from Java) is out of the scope of this document.
 >
 > **Incompatible change type**: source
 >
-> **Short summary**: Non-local return statements are no longer allowed in lambdas used as default arguments.
-> This pattern previously compiled but led to runtime crashes. To migrate, rewrite the lambda to avoid non-local returns or move the logic outside the default argument.
+> **Short summary**: Non-local return statements are no longer allowed in lambdas used as parameter's default value.
+> This pattern previously compiled but led to runtime crashes. To migrate, rewrite the lambda to avoid non-local returns or move the logic outside the default value.
 >
 > **Deprecation cycle**:
 >
-> - 2.2.0: report an error for non-local returns in lambdas used as default argument values
+> - 2.2.0: report an error for non-local returns in lambdas used as parameter's default value
 
 ## Standard library
 

--- a/docs/topics/exceptions.md
+++ b/docs/topics/exceptions.md
@@ -459,11 +459,11 @@ creating a hierarchy of exceptions can help making the code clearer and more spe
 You can achieve this by using an [abstract class](classes.md#abstract-classes) or a
 [sealed class](sealed-classes.md#constructors) as a base for common exception features and creating specific 
 subclasses for detailed exception types.
-Additionally, custom exceptions with optional parameters offer flexibility, allowing initialization with varied messages,
+Additionally, custom exceptions including parameters with default values offer flexibility, allowing initialization with varied messages,
 which enables more granular error handling.
 
 Let's look at an example using the sealed class `AccountException` as the base for an exception hierarchy, 
-and class `APIKeyExpiredException`, a subclass, which showcases the use of optional parameters for improved exception detail:
+and class `APIKeyExpiredException`, a subclass, which showcases the use of parameters with default values for improved exception detail:
 
 ```kotlin
 //sampleStart

--- a/docs/topics/functions.md
+++ b/docs/topics/functions.md
@@ -53,7 +53,7 @@ fun read(
 ) { /*...*/ }
 ```
 
-Such parameters are sometimes referred as _optional parameters_.
+Such parameters are also referred to as _optional parameters_.
 
 A default value is set by appending `=` to the type.
 
@@ -82,7 +82,7 @@ fun foo(
 foo(baz = 1) // The default value bar = 0 is used
 ```
 
-If the last parameter after all optional parameters has a functional type,
+If the last parameter after all parameters with default values has a functional type,
 then you can pass the corresponding [lambda](lambdas.md#lambda-expression-syntax) argument either as a named argument or [outside the parentheses](lambdas.md#passing-trailing-lambdas):
 
 ```kotlin

--- a/docs/topics/functions.md
+++ b/docs/topics/functions.md
@@ -40,10 +40,10 @@ fun powerOf(
 ) { /*...*/ }
 ```
 
-### Default arguments
+### Parameters with default values
 
-Function parameters can have default values, which are used when you skip the corresponding argument. This reduces the number
-of overloads:
+Function parameters can have default values, which are used when you skip the corresponding argument.
+This reduces the number of overloads:
 
 ```kotlin
 fun read(
@@ -52,6 +52,8 @@ fun read(
     len: Int = b.size,
 ) { /*...*/ }
 ```
+
+Such parameters are sometimes referred as _optional parameters_.
 
 A default value is set by appending `=` to the type.
 
@@ -68,7 +70,7 @@ class B : A() {
 }
 ```
 
-If a default parameter precedes a parameter with no default value, the default value can only be used by calling
+If a parameter with default value precedes a parameter with no default value, the default value can only be used by calling
 the function with [named arguments](#named-arguments):
 
 ```kotlin
@@ -80,8 +82,8 @@ fun foo(
 foo(baz = 1) // The default value bar = 0 is used
 ```
 
-If the last argument after default parameters is a [lambda](lambdas.md#lambda-expression-syntax),
-you can pass it either as a named argument or [outside the parentheses](lambdas.md#passing-trailing-lambdas):
+If the last parameter after all optional parameters has a functional type,
+then you can pass the corresponding [lambda](lambdas.md#lambda-expression-syntax) argument either as a named argument or [outside the parentheses](lambdas.md#passing-trailing-lambdas):
 
 ```kotlin
 fun foo(

--- a/docs/topics/functions.md
+++ b/docs/topics/functions.md
@@ -249,7 +249,7 @@ for the call). Infix functions must meet the following requirements:
 * They must be member functions or [extension functions](extensions.md).
 * They must have a single parameter.
 * The parameter must not [accept variable number of arguments](#variable-number-of-arguments-varargs) and must have
-no [default value](#default-arguments).
+no [default value](#parameters-with-default-values).
 
 ```kotlin
 infix fun Int.shl(x: Int): Int { ... }

--- a/docs/topics/gsoc-2023.md
+++ b/docs/topics/gsoc-2023.md
@@ -138,7 +138,7 @@ but the support for code that uses composition instead of inheritance has yet to
 
 The main problem of working with code that heavily uses composition is parameter forwarding.
 In particular:
-* The IDE doesn't suggest completing parameter declarations that can be forwarded as arguments to other functions that currently use default arguments.
+* The IDE doesn't suggest completing parameter declarations that can be forwarded as arguments to other functions that currently use default parameter values.
 * The IDE doesn't rename the chain of forwarded parameters.
 * The IDE doesn't provide any quick-fixes that fill in all the required arguments with parameters that can be forwarded.
 

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -133,7 +133,7 @@ class Bar : Foo() {
 There are some limitations:
 
 - When a function of an external base class is overloaded by signature, you can't override it in a derived class.
-- You can't override a function with optional parameters.
+- You can't override a function including parameters with default values.
 - Non-external classes can't be extended by external classes.
 
 ### external interfaces

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -92,9 +92,9 @@ external class MyClass {
 }
 ```
 
-### Declare optional parameters
+### Declare parameters with default values
 
-If you are writing an external declaration for a JavaScript function which has an optional parameter, use `definedExternally`.
+If you are writing an external declaration for a JavaScript function which has a parameter with default values, use `definedExternally`.
 This delegates the generation of the default values to the JavaScript function itself:
 
 ```kotlin

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -94,7 +94,7 @@ external class MyClass {
 
 ### Declare parameters with default values
 
-If you are writing an external declaration for a JavaScript function which has a parameter with default values, use `definedExternally`.
+If you are writing an external declaration for a JavaScript function which has a parameter with a default value, use `definedExternally`.
 This delegates the generation of the default values to the JavaScript function itself:
 
 ```kotlin

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -133,7 +133,7 @@ class Bar : Foo() {
 There are some limitations:
 
 - When a function of an external base class is overloaded by signature, you can't override it in a derived class.
-- You can't override a function with default arguments.
+- You can't override a function with optional parameters.
 - Non-external classes can't be extended by external classes.
 
 ### external interfaces

--- a/docs/topics/jvm/comparison-to-java.md
+++ b/docs/topics/jvm/comparison-to-java.md
@@ -45,7 +45,7 @@ Kotlin fixes a series of issues that Java suffers from:
 * [Data classes](data-classes.md)
 * [Coroutines](coroutines-overview.md)
 * [Top-level functions](functions.md)
-* [Parameters with default values](/docs/topics/functions.md#parameters-with-default-values)
+* [Parameters with default values](functions.md#parameters-with-default-values)
 * [Named parameters](functions.md#named-arguments)
 * [Infix functions](functions.md#infix-notation)
 * [Expect and actual declarations](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-expect-actual.html)

--- a/docs/topics/jvm/comparison-to-java.md
+++ b/docs/topics/jvm/comparison-to-java.md
@@ -45,7 +45,7 @@ Kotlin fixes a series of issues that Java suffers from:
 * [Data classes](data-classes.md)
 * [Coroutines](coroutines-overview.md)
 * [Top-level functions](functions.md)
-* [Default arguments](functions.md#default-arguments)
+* [Parameters with default values](/docs/topics/functions.md#parameters-with-default-values)
 * [Named parameters](functions.md#named-arguments)
 * [Infix functions](functions.md#infix-notation)
 * [Expect and actual declarations](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-expect-actual.html)

--- a/docs/topics/jvm/java-to-kotlin-nullability-guide.md
+++ b/docs/topics/jvm/java-to-kotlin-nullability-guide.md
@@ -216,7 +216,7 @@ findOrder()?.customer?.let(::processCustomer)
 
 ## Default values instead of null
 
-Checking for `null` is often used in combination with [setting the default value](functions.md#default-arguments)
+Checking for `null` is often used in combination with [setting the default value](functions.md#parameters-with-default-values)
 in case the null check is successful.
 
 The Java code with a null check:

--- a/docs/topics/k2-compiler-migration-guide.md
+++ b/docs/topics/k2-compiler-migration-guide.md
@@ -1258,7 +1258,7 @@ for further reading. Changes listed with an asterisk (*) next to the Issue ID ar
 | [KT-49015](https://youtrack.jetbrains.com/issue/KT-49015)  | Qualified this: change behavior in case of potential label conflicts                                                                       |
 | [KT-56545](https://youtrack.jetbrains.com/issue/KT-56545)  | Fix incorrect functions mangling in JVM backend in case of accidental clashing overload in a Java subclass                                 |
 | [KT-62019](https://youtrack.jetbrains.com/issue/KT-62019)  | [LC issue] Prohibit suspend-marked anonymous function declarations in statement positions                                                  |
-| [KT-55111](https://youtrack.jetbrains.com/issue/KT-55111)  | OptIn: forbid constructor calls with default arguments under marker                                                                        |
+| [KT-55111](https://youtrack.jetbrains.com/issue/KT-55111)  | OptIn: forbid constructor calls with default arguments (parameters with default values) under marker                                                  |
 | [KT-61182](https://youtrack.jetbrains.com/issue/KT-61182)  | Unit conversion is accidentally allowed to be used for expressions on variables + invoke resolution                                        |
 | [KT-55199](https://youtrack.jetbrains.com/issue/KT-55199)  | Forbid promoting callable references with adaptations to KFunction                                                                         |
 | [KT-65776](https://youtrack.jetbrains.com/issue/KT-65776)  | [LC] K2 breaks \`false && ...\` and \`false &VerticalLine;&VerticalLine; ...\`                                                             |

--- a/docs/topics/keyword-reference.md
+++ b/docs/topics/keyword-reference.md
@@ -135,7 +135,7 @@ Kotlin supports the following operators and special symbols:
      - `*` is also used to [pass an array to a vararg parameter](functions.md#variable-number-of-arguments-varargs).
  * `=`
      - assignment operator.
-     - is used to specify [default values for parameters](functions.md#default-arguments).
+     - is used to specify [default values for parameters](functions.md#parameters-with-default-values).
  * `+=`, `-=`, `*=`, `/=`, `%=` - [augmented assignment operators](operator-overloading.md#augmented-assignments).
  * `++`, `--` - [increment and decrement operators](operator-overloading.md#increments-and-decrements).
  * `&&`, `||`, `!` - logical 'and', 'or', 'not' operators (for bitwise operations, use the corresponding [infix functions](numbers.md#operations-on-numbers) instead).

--- a/docs/topics/whatsnew/whatsnew14.md
+++ b/docs/topics/whatsnew/whatsnew14.md
@@ -165,14 +165,14 @@ val colors = listOf(
 
 Kotlin 1.4 supports more cases for using callable references:
 
-* References to functions with default argument values
+* References to functions with optional parameters
 * Function references in `Unit`-returning functions 
 * References that adapt based on the number of arguments in a function
 * Suspend conversion on callable references 
 
-#### References to functions with default argument values 
+#### References to functions with optional parameters
 
-Now you can use callable references to functions with default argument values. If the callable reference 
+Now you can use callable references to functions with optional parameters. If the callable reference
 to the function `foo` takes no arguments, the default value `0` is used.
 
 ```kotlin
@@ -186,7 +186,7 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.4"}
 
-Previously, you had to write additional overloads for the function `apply` to use the default argument values.
+Previously, you had to write an additional overload for either the `apply` or `foo` function.
 
 ```kotlin
 // some new overload

--- a/docs/topics/whatsnew/whatsnew14.md
+++ b/docs/topics/whatsnew/whatsnew14.md
@@ -165,14 +165,14 @@ val colors = listOf(
 
 Kotlin 1.4 supports more cases for using callable references:
 
-* References to functions with optional parameters
+* References to functions that include parameters with default values
 * Function references in `Unit`-returning functions 
 * References that adapt based on the number of arguments in a function
 * Suspend conversion on callable references 
 
-#### References to functions with optional parameters
+#### References to functions that include parameters with default values
 
-Now you can use callable references to functions with optional parameters. If the callable reference
+Now you can use callable references to functions including parameters with default values. If the callable reference
 to the function `foo` takes no arguments, the default value `0` is used.
 
 ```kotlin

--- a/docs/topics/whatsnew/whatsnew1720.md
+++ b/docs/topics/whatsnew/whatsnew1720.md
@@ -536,7 +536,7 @@ Kotlin/JS has received some enhancements that improve the developer experience a
 * Klib generation is faster in both incremental and clean builds, thanks to efficiency improvements for the loading of dependencies.
 * [Incremental compilation for development binaries](js-ir-compiler.md#incremental-compilation-for-development-binaries)
   has been reworked, resulting in major improvements in clean build scenarios, faster incremental builds, and stability fixes.
-* We've improved `.d.ts` generation for nested objects, sealed classes, and optional parameters in constructors.
+* We've improved `.d.ts` generation for nested objects, sealed classes, and parameters with default values in constructors.
 
 ## Gradle
 

--- a/docs/topics/whatsnew/whatsnew2120.md
+++ b/docs/topics/whatsnew/whatsnew2120.md
@@ -514,17 +514,17 @@ In 2.1.20, the Compose compiler relaxes some restrictions on `@Composable` funct
 In addition, the Compose compiler Gradle plugin is set to include source information by default, aligning the behavior
 on all platforms with Android.
 
-### Support for default arguments in open `@Composable` functions
+### Support for optional parameters in open `@Composable` functions
 
-The compiler previously restricted default arguments in open `@Composable` functions due to incorrect compiler output,
-which would result in crashes at runtime. The underlying issue is now resolved, and default arguments are fully supported
+The compiler previously restricted optional parameters in open `@Composable` functions due to incorrect compiler output,
+which would result in crashes at runtime. The underlying issue is now resolved, and optional parameters are fully supported
 when used with Kotlin 2.1.20 or newer.
 
-Compose compiler allowed default arguments in open functions before [version 1.5.8](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.5.8),
+Compose compiler allowed optional parameters in open functions before [version 1.5.8](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.5.8),
 so the support depends on project configuration:
 
 * If an open composable function is compiled with Kotlin version 2.1.20 or newer, the compiler generates correct wrappers
-  for default arguments. This includes wrappers compatible with pre-1.5.8 binaries, meaning that downstream libraries
+  for optional parameters. This includes wrappers compatible with pre-1.5.8 binaries, meaning that downstream libraries
   will also be able to use this open function.
 * If the open composable function is compiled with Kotlin older than 2.1.20, Compose uses a compatibility mode, which
   might result in runtime crashes. When using the compatibility mode, the compiler emits a warning to highlight potential

--- a/docs/topics/whatsnew/whatsnew2120.md
+++ b/docs/topics/whatsnew/whatsnew2120.md
@@ -514,17 +514,17 @@ In 2.1.20, the Compose compiler relaxes some restrictions on `@Composable` funct
 In addition, the Compose compiler Gradle plugin is set to include source information by default, aligning the behavior
 on all platforms with Android.
 
-### Support for optional parameters in open `@Composable` functions
+### Support for parameters with default values in open `@Composable` functions
 
-The compiler previously restricted optional parameters in open `@Composable` functions due to incorrect compiler output,
-which would result in crashes at runtime. The underlying issue is now resolved, and optional parameters are fully supported
+The compiler previously restricted parameters with default values in open `@Composable` functions due to incorrect compiler output,
+which would result in crashes at runtime. The underlying issue is now resolved, and parameters with default values are fully supported
 when used with Kotlin 2.1.20 or newer.
 
-Compose compiler allowed optional parameters in open functions before [version 1.5.8](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.5.8),
+Compose compiler allowed parameters with default values in open functions before [version 1.5.8](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.5.8),
 so the support depends on project configuration:
 
 * If an open composable function is compiled with Kotlin version 2.1.20 or newer, the compiler generates correct wrappers
-  for optional parameters. This includes wrappers compatible with pre-1.5.8 binaries, meaning that downstream libraries
+  for parameters with default values. This includes wrappers compatible with pre-1.5.8 binaries, meaning that downstream libraries
   will also be able to use this open function.
 * If the open composable function is compiled with Kotlin older than 2.1.20, Compose uses a compatibility mode, which
   might result in runtime crashes. When using the compatibility mode, the compiler emits a warning to highlight potential


### PR DESCRIPTION
Two fixes:
1. Parameters refer to the variables on the declaration site. Arguments are the expressions that "fill in" the parameters. That's why it's called "default parameters" not "default arguments". You can even see that further in the paragraph it's already referred as a "default parameter"
2. Lambda is not a parameter. It's an expression, and it's an argument that corresponds to a parameter with functional type.


---

I didn't touch anything in `docs/topics/whatsnew/*` because I don't consider them a part of the documentation but rather a piece of history that is written the way it's written.

Similarly, I didn't touch the following files:
- ./docs/topics/gsoc-2023.md
- ./docs/topics/k2-compiler-migration-guide.md

because they don't feel like a documentation to me. But let me know if you actually want me to update them

Further, I acknowledge that I'm changing the title of the section in `./docs/topics/functions.md` file which will break the existing URL links. I don't know what are the policy for doing that (if there are any). So please let me know if I just can't change it, or if there is a more "migration friendly" way to do that.

Feel free to amend the commits as you please or let me know if there are changes that you want me to make, thanks