### PR TITLE
ktl-2482 chore: update webhelp version to clear css cache

### DIFF
--- a/.teamcity/builds/kotlinlang/buidTypes/BuildReferenceDocs.kt
+++ b/.teamcity/builds/kotlinlang/buidTypes/BuildReferenceDocs.kt
@@ -25,7 +25,7 @@ object BuildReferenceDocs : BuildType({
   """.trimIndent()
 
   params {
-    param("WEBHELP_FRONTEND_VERSION", "6.11.0-footer")
+    param("WEBHELP_FRONTEND_VERSION", "6.22.0-fix-mermaid")
     param("WH_DOCS_PATH_REGEX", "docs")
     param("WH_PROJECT_NAME", "kotlin-reference")
   }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-2482/Mermaid-diagrams-in-Docs-are-broken