### PR TITLE
Update the id of the Ranges chapter to avoid the conflict (WRS-7029)

### DIFF
--- a/docs/topics/ranges.md
+++ b/docs/topics/ranges.md
@@ -2,7 +2,7 @@
 
 Ranges and progressions define sequences of values in Kotlin, supporting range operators, iteration, custom step values, and arithmetic progressions.
 
-## Ranges
+## Ranges {id="range"}
 
 Kotlin lets you easily create ranges of values using the [`.rangeTo()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.ranges/range-to.html)
 and [`.rangeUntil()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.ranges/range-until.html) functions from the 


### PR DESCRIPTION
**Root cause:**
The main title automatically receives the `id="ranges"` based on the file name `ranges.md`. This creates a conflict when the `## Ranges` sub-header which also assigns the same id for chapter.

To avoid this conflict, explicitly assign a different ID to the sub-header that does not match the main title’s auto-generated ID.