### PR TITLE
Update when expression example

### DIFF
--- a/docs/topics/control-flow.md
+++ b/docs/topics/control-flow.md
@@ -187,7 +187,7 @@ If your `when` expression **doesn't** have a subject, you **must** have an `else
 The `else` branch is evaluated when none of the other branch conditions are satisfied:
 
 ```kotlin
-when {
+val message = when {
     a > b -> "a is greater than b"
     a < b -> "a is less than b"
     else -> "a is equal to b"


### PR DESCRIPTION
Text above code example explains that a when expression must be exhaustive and if it isn't a compilation error will occur. However, the code example is a when statement in which else branch can be removed without a compilation error.