### PR TITLE
update: adding information about new context-sensitive resolution 

### DIFF
--- a/docs/topics/control-flow.md
+++ b/docs/topics/control-flow.md
@@ -183,6 +183,13 @@ val numericValue = when (getRandomBit()) {
 }
 ```
 
+> To simplify your `when` expressions and reduce repetition, you can try out the Experimental context-sensitive resolution feature.
+> This feature allows you to omit the type name when using enum entries or sealed class members in `when` expressions if the expected type is known.
+> 
+> For more information, see [Preview of context-sensitive resolution](whatsnew2220.md#preview-of-context-sensitive-resolution).
+> 
+{style="tip"}
+
 If your `when` expression **doesn't** have a subject, you **must** have an `else` branch or the compiler throws an error.
 The `else` branch is evaluated when none of the other branch conditions are satisfied:
 

--- a/docs/topics/enum-classes.md
+++ b/docs/topics/enum-classes.md
@@ -119,6 +119,13 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="rgb-enums-properties-kotlin"}
 
+> To reduce repetition when working with enum entries, you can try out the Experimental context-sensitive resolution feature.
+> This feature allows you to omit the enum class name when the expected type is known, such as in `when` expressions or when assigning to a typed variable.
+>
+> For more information, see [Preview of context-sensitive resolution](whatsnew2220.md#preview-of-context-sensitive-resolution).
+>
+{style="tip"}
+
 You can access the constants in an enum class in a generic way using
 the [`enumValues<T>()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/enum-values.html) and [`enumValueOf<T>()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/enum-value-of.html) functions. 
 In Kotlin 2.0.0, the [`enumEntries<T>()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.enums/enum-entries.html) function is introduced as a replacement for the [`enumValues<T>()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/enum-values.html)

--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -200,6 +200,13 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.5"}
 
+> To reduce repetition in `when` expressions, you can try out the Experimental context-sensitive resolution feature.
+> This feature allows you to omit the type name when matching sealed class members if the expected type is known.
+>
+> For more information, see [Preview of context-sensitive resolution](whatsnew2220.md#preview-of-context-sensitive-resolution).
+> 
+{style="tip"}
+
 When using sealed classes with `when` expressions, you can also add guard conditions to include additional checks in a single branch.
 For more information, see [Guard conditions in when expressions](control-flow.md#guard-conditions-in-when-expressions).
 


### PR DESCRIPTION
This PR adds new information to docs about contex-tsensitive resolution.

Related ticket in YouTrack is [here](https://youtrack.jetbrains.com/issue/KT-76830).