### PR TITLE
feat: add section for read write annotations kotlin metadata

### DIFF
--- a/docs/topics/metadata-jvm.md
+++ b/docs/topics/metadata-jvm.md
@@ -182,7 +182,7 @@ fun main() {
 You can store annotations in Kotlin metadata and access them using the `kotlin-metadata-jvm` library.
 This removes the need to match annotations by signature, making access more reliable for overloaded declarations.
 
-To make annotations available in the metadata for your compiled files, add the following compiler option:
+To make annotations available in the metadata of your compiled files, add the following compiler option:
 
 ```kotlin
 -Xannotations-in-metadata
@@ -199,7 +199,7 @@ kotlin {
 }
 ```
 
-With this option enabled, the Kotlin compiler writes annotations into metadata alongside the JVM bytecode,
+When you enable this option, the Kotlin compiler writes annotations into metadata alongside the JVM bytecode,
 making them accessible to the `kotlin-metadata-jvm` library.
 
 The library provides the following APIs for accessing annotations:


### PR DESCRIPTION
This update adds a section to the Kotlin Metadata JVM page about the a new experimental feature for reading and writing annotations in Kotlin metadata

Related ticket: [KT-31857](https://youtrack.jetbrains.com/issue/KT-31857) Provide easy way to retrieve annotations for kotlinx-metadata