### PR TITLE
update: Add section about constructor parameters and properties in classes

### DIFF
--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -93,6 +93,20 @@ class Person(
 
 Much like regular properties, properties declared in the primary constructor can be mutable (`var`) or read-only (`val`).
 
+When you declare a parameter without a `val` or `var` in the primary constructor, it is simply a constructor parameter, and **not a property in the class**. The parameter is only accessible within the constructor's scope.  
+
+```kotlin
+// The following will not compile 
+class RectangleWithParameters(width: Int, height: Int) {
+    fun area() = width * height
+}
+
+// The following will compile
+class RectangleWithProperties(val width: Int, val height: Int) {
+    fun area() = width * height
+}
+```
+
 If the constructor has annotations or visibility modifiers, the `constructor` keyword is required and the modifiers go before it:
 
 ```kotlin

--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -93,17 +93,21 @@ class Person(
 
 Much like regular properties, properties declared in the primary constructor can be mutable (`var`) or read-only (`val`).
 
-When you declare a parameter without a `val` or `var` in the primary constructor, it is simply a constructor parameter, and **not a property in the class**. The parameter is only accessible within the constructor's scope.  
+Plain constructor parameters (that are not properties) are accessible in:
+* The class header.
+* Initialized properties within the class body.
+* Initializer blocks.
+
+For example:
 
 ```kotlin
-// The following will not compile 
+// width and height are plain constructor parameters
 class RectangleWithParameters(width: Int, height: Int) {
-    fun area() = width * height
-}
+    val perimeter = 2 * width + 2 * height
 
-// The following will compile
-class RectangleWithProperties(val width: Int, val height: Int) {
-    fun area() = width * height
+    init {
+        println("Rectangle created with width = $width and height = $height")
+    }
 }
 ```
 


### PR DESCRIPTION
# High Level Overview

[KT-77990](https://youtrack.jetbrains.com/issue/KT-77990)

When I was going through the documentation, I had a bit of confusion around "When would we include `val` or `var`  vs when we shouldn't?" I could not really find it anywhere in the docs, hence I am proposing to include a section explaining the difference between parameters and properties in the constructor. 

While it may seem obvious, I hope this clarification can help!

I debated between making this it's own tiny section - but figured it flowed naturally from the current description of properties. 

First time contributing to these docs, so happy for any feedback/correction/discussion. 
