### PR TITLE
Fix incorrect usage of singleOrNull() in null safety example

### DIFF
--- a/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
@@ -204,7 +204,7 @@ fun main() {
     val temperatures = listOf(15, 18, 21, 21, 19, 17, 16)
 
     // Check if there was exactly one day with 30 degrees
-    val singleHotDay = temperatures.singleOrNull()
+    val singleHotDay = temperatures.singleOrNull { it == 30 }
     println("Single hot day with 30 degrees: ${singleHotDay ?: "None"}")
     // Single hot day with 30 degrees: None
 


### PR DESCRIPTION
This PR fixes a logic error in the Kotlin Intermediate Tour's null safety example.

The original code used `singleOrNull()` without a predicate, which incorrectly checked whether the list had only one temperature value.

Replaced it with `singleOrNull { it == 30 }` to correctly check if the temperature 30 occurred exactly once, as described in the comment.

This makes the code behavior match its intention and provides a clearer learning example.