### PR TITLE
Update kotlin-tour-intermediate-null-safety.md

### DIFF
--- a/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
@@ -204,7 +204,7 @@ fun main() {
     val temperatures = listOf(15, 18, 21, 21, 19, 17, 16)
 
     // Check if there was exactly one day with 30 degrees
-    val singleHotDay = temperatures.singleOrNull()
+    val singleHotDay = temperatures.singleOrNull {it == 30}
     println("Single hot day with 30 degrees: ${singleHotDay ?: "None"}")
     // Single hot day with 30 degrees: None
 


### PR DESCRIPTION
Docs: Fix predicate missing in singleOrNull example

The code example in the "Null values and collections" section intended to find a single day with a temperature of 30. However, the call to `temperatures.singleOrNull()` was missing the required predicate.

This resulted in the code checking if the list itself had a single element, rather than checking for an element with a specific value.

The predicate `{ it == 30 }` has been added to align the code's behavior with the accompanying comment and the example's intent.