### PR TITLE
Use `compilerOptions` DSL in Kotlin Multiplatform opt-in example

### DIFF
--- a/docs/topics/opt-in-requirements.md
+++ b/docs/topics/opt-in-requirements.md
@@ -222,9 +222,9 @@ If your Gradle module is a multiplatform module, use the `optIn` method:
 <tab title="Kotlin" group-key="kotlin">
 
 ```kotlin
-sourceSets {
-    all {
-        languageSettings.optIn("org.mylibrary.OptInAnnotation")
+kotlin {
+    compilerOptions {
+        optIn.add("org.mylibrary.OptInAnnotation")
     }
 }
 ```
@@ -233,11 +233,9 @@ sourceSets {
 <tab title="Groovy" group-key="groovy">
 
 ```groovy
-sourceSets {
-    all {
-        languageSettings {
-            optIn('org.mylibrary.OptInAnnotation')
-        }
+kotlin {
+    compilerOptions {
+        optIn.add('org.mylibrary.OptInAnnotation')
     }
 }
 ```


### PR DESCRIPTION
The code snippet demonstrating how to opt in to using an API in a Kotlin Multiplatform module currently uses the `languageSettings` DSL. However, [its KDoc](https://kotlinlang.org/api/kotlin-gradle-plugin/kotlin-gradle-plugin-api/org.jetbrains.kotlin.gradle.plugin/-language-settings-builder/) includes the following note:

> Note: The `LanguageSettingsBuilder` interface will be deprecated in the future. Instead, it is better to use the existing `compilerOptions` DSL.

The `compilerOptions` DSL was [introduced in Kotlin 2.0.0](https://kotlinlang.org/docs/whatsnew20.html#new-gradle-dsl-for-compiler-options-in-multiplatform-projects) and has been [stable since Kotlin 2.1.0](https://kotlinlang.org/docs/whatsnew21.html#new-gradle-dsl-for-compiler-options-in-multiplatform-projects-promoted-to-stable).

This PR updates the snippet to use `compilerOptions`, aligning it with the current recommended approach and avoiding the use of a soon-to-be-deprecated API.