### PR TITLE
Fixed incorrect description in delegation practice exercise

### DIFF
--- a/docs/topics/tour/kotlin-tour-intermediate-classes-interfaces.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-classes-interfaces.md
@@ -610,7 +610,7 @@ fun main() {
 You have a simple messaging app that has some basic functionality, but you want to add some functionality for 
 _smart_ messages without significantly duplicating your code.
 
-In the code below, define a class called `SmartMessenger` that inherits from the `BasicMessenger` class but delegates 
+In the code below, define a class called `SmartMessenger` that inherits from the `Messenger` interface but delegates 
 the implementation to an instance of the `BasicMessenger` class. 
 
 In the `SmartMessenger` class, override the `sendMessage()` function to send smart messages. The function must accept


### PR DESCRIPTION
Updated the exercise documentation on delegation to correctly refer to the `Messenger` interface instead of the `SmartMessenger` class.

Trying to implement the exercise as is will give the following compilation error and lead to user confusion:
```
Delegation is supported only for interfaces.
This type is final, so it cannot be extended.
This type has a constructor, so it must be initialized here.
```