### PR TITLE
Fixed singleOrNull example code snippet that was missing predicate

### DIFF
--- a/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
@@ -204,7 +204,7 @@ fun main() {
     val temperatures = listOf(15, 18, 21, 21, 19, 17, 16)
 
     // Check if there was exactly one day with 30 degrees
-    val singleHotDay = temperatures.singleOrNull()
+    val singleHotDay = temperatures.singleOrNull() { it == 30 }
     println("Single hot day with 30 degrees: ${singleHotDay ?: "None"}")
     // Single hot day with 30 degrees: None
 


### PR DESCRIPTION
Updated the singleOrNull code snippet example to include missing predicate that checks for target value of 30.