### PR TITLE
Fix a typo in documentation page

### DIFF
--- a/docs/topics/idioms.md
+++ b/docs/topics/idioms.md
@@ -202,7 +202,7 @@ val filesSize = files?.size ?: run {
 println(filesSize)
 ```
 
-## Execute a expression if null
+## Execute an expression if null
 
 ```kotlin
 val values = ...


### PR DESCRIPTION
Thanks for maintaining this documentation. I noticed a small typo and thought a minor PR would be the best way to help.