### PR TITLE
Update the order of releases in the TOC

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -34,9 +34,9 @@
 	</toc-element>
 	<toc-element toc-title="What's new in Kotlin">
 		<toc-element toc-title="Kotlin 2.2.0" accepts-web-file-names="whatsnew.html" topic="whatsnew22.md"/>
-		<toc-element toc-title="Kotlin 2.1.20" topic="whatsnew2120.md"/>
 		<toc-element toc-title="Kotlin 2.2.20-Beta1" topic="whatsnew-eap.md"/>
 		<toc-element toc-title="Earlier versions">
+			<toc-element toc-title="Kotlin 2.1.20" topic="whatsnew2120.md"/>
 			<toc-element toc-title="Kotlin 2.1.0" topic="whatsnew21.md"/>
 			<toc-element toc-title="Kotlin 2.0.20" topic="whatsnew2020.md"/>
 			<toc-element toc-title="Kotlin 2.0.0" topic="whatsnew20.md"/>


### PR DESCRIPTION
This PR puts the 2.1.20 release inside earlier versions of the TOC.