### PR TITLE
update: Kotlin 2.2.10-RC eap release details

### DIFF
--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -61,4 +61,14 @@ In this channel, you can also get notifications about new EAP builds.
             <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.2.20-Beta1">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.2.20-Beta1</a>.</p>
         </td>
     </tr>
+    <tr>
+        <td><strong>2.2.10-RC</strong>
+            <p>Released: <strong>July 17, 2025</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.2.10-RC" target="_blank">Release on GitHub</a></p>
+        </td>
+        <td>
+            <p>A bug fix release for Kotlin 2.2.0.</p>
+            <p>For more details, please refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.2.10-RC">changelog</a>.</p>
+        </td>
+    </tr>
 </table>


### PR DESCRIPTION
PR to update documentation with Kotlin 2.2.10-RC release details. 