### PR TITLE
Remove dependencies at top level section

### DIFF
--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -760,8 +760,6 @@ kotlin {
 </tab>
 </tabs>
 
-Alternatively, you can [set dependencies at top level](#set-dependencies-at-top-level).
-
 ### Dependency types
 
 Choose the dependency type based on your requirements.
@@ -1170,33 +1168,6 @@ kotlin {
             }
         }
     }
-}
-```
-
-</tab>
-</tabs>
-
-### Set dependencies at top level
-
-Alternatively, you can specify the dependencies at top level, using the following pattern for the configuration names:
-`<sourceSetName><DependencyType>`. This can be helpful for some Gradle built-in dependencies, like `gradleApi()`, `localGroovy()`,
-or `gradleTestKit()`, which are not available in the source sets' dependency DSL.
-
-<tabs group="build-script">
-<tab title="Kotlin" group-key="kotlin">
-
-```kotlin
-dependencies {
-    "commonMainImplementation"("com.example:my-library:1.0")
-}
-```
-
-</tab>
-<tab title="Groovy" group-key="groovy">
-
-```groovy
-dependencies {
-    commonMainImplementation 'com.example:my-library:1.0'
 }
 ```
 


### PR DESCRIPTION
This PR removes the Gradle content about setting dependencies at top level.