### PR TITLE
Update pseudocode in intermediate tour - Properties chapter

### DIFF
--- a/docs/topics/tour/kotlin-tour-intermediate-properties.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-properties.md
@@ -38,7 +38,7 @@ default implementations:
 
 ```kotlin
 class Contact(val id: Int, var email: String) {
-    val category: String = ""
+    var category: String = ""
 }
 ```
 
@@ -46,7 +46,7 @@ Under the hood, this is equivalent to this pseudocode:
 
 ```kotlin
 class Contact(val id: Int, var email: String) {
-    val category: String = ""
+    var category: String = ""
         get() = field
         set(value) {
             field = value


### PR DESCRIPTION
Update the pseudocode to say `var` instead of `val`.