### PR TITLE
feat: block parameter names

### DIFF
--- a/docs/topics/native/native-objc-interop.md
+++ b/docs/topics/native/native-objc-interop.md
@@ -543,9 +543,9 @@ foo {
 
 #### Explicit parameter names in Objective-C block types
 
-You can add explicit parameter names to Kotlin's function types for exported Objective-C headers. Xcode's autocompletion
-suggests calling such functions with no parameter names in the Objective-C block, and the generated block triggers Clang
-warnings.
+You can add explicit parameter names to Kotlin's function types for exported Objective-C headers. Without them,
+Xcode's autocompletion suggests calling Objective-C functions with no parameter names in the Objective-C block,
+and the generated block triggers Clang warnings.
 
 To enable explicit parameter names, add the following [binary option](native-binary-options.md) to your `gradle.properties` file:
 


### PR DESCRIPTION
This PR updates Obj-C/Swift interop page for the 2.2.20 release, following [KT-77488](https://youtrack.jetbrains.com/issue/KT-77488) [ObjCExport] Add explicit ObjCBlock parameter name in objc export