### PR TITLE
Add informative note for the JVM binary DSL regarding `runJvm`

### DIFF
--- a/docs/topics/whatsnew/whatsnew2120.md
+++ b/docs/topics/whatsnew/whatsnew2120.md
@@ -117,6 +117,13 @@ kotlin {
 In this example, Gradle's [Distribution](https://docs.gradle.org/current/userguide/distribution_plugin.html#distribution_plugin)
 plugin is applied on the first `executable {}` block.
 
+> After configuring your JVM binary information, be sure to use the `runJvm` task and *not* the legacy `jvmRun` task.
+>
+> You may also wish to see [KT-75240](https://youtrack.jetbrains.com/issue/KT-75240) which requests that the behavoir of the two
+> tasks are better aligned.
+>
+{style="note"}
+
 If you run into any issues, report them in our [issue tracker](https://kotl.in/issue) or let us know in our [public Slack channel](https://kotlinlang.slack.com/archives/C19FD9681).
 
 ## Kotlin/Native


### PR DESCRIPTION
Recently, I updated a very old KMP project of mine over to latest Kotlin versions (2.2.10 at the time of writing this message) and was informed that the application plugin was no longer compatible, and that I should migrate over to the new JVM binary DSL via https://kotl.in/jvm-binaries-dsl

Confusingly, after doing that, I kept getting an error:
```
Execution failed for task ':myproject:jvmRun'.
> No main class specified and classpath is not an executable jar.
```
It turns out `jvmRun` (which is what I've used for years) is now obsolete, and I thought it would be nicer if the docs made sure to call that out (especially as these docs are linked to directly from the warning issued by the Kotlin Multiplatform Gradle plugin). Especially, this isn't intuitive, as otherwise, all other tasks associated with KMP targets are prefixed by their platform (e.g. nativeBuild, jsBrowserDevelopmentRun, etc.)