### PR TITLE
Fix broken DataFrame documentation link

### DIFF
--- a/docs/topics/data-analysis/data-analysis-connect-to-db.md
+++ b/docs/topics/data-analysis/data-analysis-connect-to-db.md
@@ -2,7 +2,7 @@
 
 [Kotlin Notebook](kotlin-notebook-overview.md) offers capabilities for connecting to and retrieving data from various types of SQL databases, such as 
 MariaDB, PostgreSQL, MySQL, and SQLite. 
-Utilizing the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html), Kotlin Notebook can establish 
+Utilizing the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html), Kotlin Notebook can establish 
 connections to databases, execute SQL queries, and import the results for further operations.
 
 For a detailed example, see the [Notebook in the KotlinDataFrame SQL Examples GitHub repository](https://github.com/zaleslaw/KotlinDataFrame-SQL-Examples/blob/master/notebooks/imdb.ipynb).
@@ -22,7 +22,7 @@ Create a new Kotlin Notebook:
 
 ## Connect to database
 
-You can connect to and interact with an SQL database using specific functions from the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html). 
+You can connect to and interact with an SQL database using specific functions from the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html). 
 You can use `DatabaseConfiguration` to establish a connection to your database and `getSchemaForAllSqlTables()` to retrieve 
 the schema of all tables within it.
 
@@ -148,7 +148,7 @@ rows from the year 2000 onwards using the [`filter`](https://kotlin.github.io/da
 ## Analyze data in Kotlin Notebook
 
 After [establishing a connection to an SQL database](#connect-to-database), you can use Kotlin Notebook for in-depth data analysis 
-utilizing the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html). This includes functions for 
+utilizing the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html). This includes functions for 
 grouping, sorting, and aggregating data, helping you to uncover and understand patterns within your data.
 
 Let's dive into an example that involves analyzing actor data from a movie database, focusing on the most frequently 

--- a/docs/topics/data-analysis/data-analysis-notebooks-output-formats.md
+++ b/docs/topics/data-analysis/data-analysis-notebooks-output-formats.md
@@ -193,7 +193,7 @@ You can render mathematical formulas and equations using the LaTeX format, a typ
 
 With Kotlin Notebook, you can visualize structured data with data frames:
 
-1. Add the [Kotlin DataFrame](https://kotlin.github.io/dataframe/gettingstarted.html) library to your notebook:
+1. Add the [Kotlin DataFrame](https://kotlin.github.io/dataframe/quickstart.html) library to your notebook:
 
    ```none
    %use dataframe

--- a/docs/topics/data-analysis/data-analysis-visualization.md
+++ b/docs/topics/data-analysis/data-analysis-visualization.md
@@ -4,7 +4,7 @@ Kotlin offers an all-in-one-place solution for powerful and flexible data visual
 before diving into complex models.
 
 This tutorial demonstrates how to create different chart types in IntelliJ IDEA using [Kotlin Notebook](kotlin-notebook-overview.md) with
-the [Kandy](https://kotlin.github.io/kandy/welcome.html) and [Kotlin DataFrame](https://kotlin.github.io/dataframe/gettingstarted.html) libraries.
+the [Kandy](https://kotlin.github.io/kandy/welcome.html) and [Kotlin DataFrame](https://kotlin.github.io/dataframe/quickstart.html) libraries.
 
 ## Before you start
 

--- a/docs/topics/data-analysis/data-analysis-work-with-api.md
+++ b/docs/topics/data-analysis/data-analysis-work-with-api.md
@@ -4,7 +4,7 @@
 It simplifies data extraction and analysis tasks by offering an iterative environment where every step can be visualized 
 for clarity. This makes it particularly useful when exploring APIs you are not familiar with.
 
-When used in conjunction with the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html), Kotlin Notebook not only enables you to connect to and fetch 
+When used in conjunction with the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html), Kotlin Notebook not only enables you to connect to and fetch 
 JSON data from APIs but also assists in reshaping this data for comprehensive analysis and visualization.
 
 > For Kotlin Notebook examples, see [DataFrame examples on GitHub](https://github.com/Kotlin/dataframe/blob/master/examples/notebooks/youtube/Youtube.ipynb).
@@ -108,7 +108,7 @@ The result is stored in the `df` variable:
 
 ## Clean and refine data
 
-Cleaning and refining data are crucial steps in preparing your dataset for analysis. The [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html) 
+Cleaning and refining data are crucial steps in preparing your dataset for analysis. The [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html) 
 offers powerful functionalities for these tasks. Methods like [`move`](https://kotlin.github.io/dataframe/move.html), 
 [`concat`](https://kotlin.github.io/dataframe/concatdf.html), [`select`](https://kotlin.github.io/dataframe/select.html), 
 [`parse`](https://kotlin.github.io/dataframe/parse.html), and [`join`](https://kotlin.github.io/dataframe/join.html) 
@@ -158,7 +158,7 @@ Each step is designed to refine the data, making it more suitable for [in-depth 
 ## Analyze data in Kotlin Notebook
 
 After you've successfully [fetched](#fetch-data-from-an-api) and [cleaned and refined your data](#clean-and-refine-data) 
-using functions from the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html), the next step 
+using functions from the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html), the next step 
 is to analyze this prepared dataset to extract meaningful insights.
 
 Methods such as [`groupBy`](https://kotlin.github.io/dataframe/groupby.html) for categorizing data, 
@@ -210,7 +210,7 @@ The results of the analysis:
 
 ![Analysis results](kotlin-analysis.png){width=700}
 
-For more advanced techniques, see the [Kotlin DataFrame documentation](https://kotlin.github.io/dataframe/gettingstarted.html).
+For more advanced techniques, see the [Kotlin DataFrame documentation](https://kotlin.github.io/dataframe/quickstart.html).
 
 ## What's next
 

--- a/docs/topics/data-analysis/data-analysis-work-with-data-sources.md
+++ b/docs/topics/data-analysis/data-analysis-work-with-data-sources.md
@@ -1,6 +1,6 @@
 [//]: # (title: Retrieve data from files)
 
-[Kotlin Notebook](kotlin-notebook-overview.md), coupled with the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html), enables 
+[Kotlin Notebook](kotlin-notebook-overview.md), coupled with the [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html), enables 
 you to work with both non-structured and structured data. This combination offers the flexibility to transform non-structured data, 
 such as data found in TXT files, into structured datasets. 
 

--- a/docs/topics/data-analysis/kotlin-notebook-add-dependencies.md
+++ b/docs/topics/data-analysis/kotlin-notebook-add-dependencies.md
@@ -31,7 +31,7 @@ You can also use the autocompletion feature in Kotlin Notebook to quickly access
 ## Add Kotlin DataFrame and Kandy libraries to your Kotlin Notebook
 
 Let's add two popular Kotlin library dependencies to your Kotlin Notebook:
-* The [Kotlin DataFrame library](https://kotlin.github.io/dataframe/gettingstarted.html) gives you the power to manipulate data in your Kotlin projects. 
+* The [Kotlin DataFrame library](https://kotlin.github.io/dataframe/quickstart.html) gives you the power to manipulate data in your Kotlin projects. 
 You can use it to retrieve data from [APIs](data-analysis-work-with-api.md), [SQL databases](data-analysis-connect-to-db.md), and [various file formats](data-analysis-work-with-data-sources.md), such as CSV or JSON.
 * The [Kandy library](https://kotlin.github.io/kandy/welcome.html) provides a powerful and flexible DSL for [creating charts](data-analysis-visualization.md).
 

--- a/docs/topics/data-analysis/lets-plot.md
+++ b/docs/topics/data-analysis/lets-plot.md
@@ -10,7 +10,7 @@ Additionally, LPK has seamless integration with [IntelliJ](https://www.jetbrains
 ![Lets-Plot](lets-plot-overview.png){width=700}
 
 This tutorial demonstrates how to create different plot types with
-the LPK and [Kotlin DataFrame](https://kotlin.github.io/dataframe/gettingstarted.html) libraries using Kotlin Notebook in IntelliJ IDEA.
+the LPK and [Kotlin DataFrame](https://kotlin.github.io/dataframe/quickstart.html) libraries using Kotlin Notebook in IntelliJ IDEA.
 
 ## Before you start
 


### PR DESCRIPTION
## Description
Fixed a broken link in the Kotlin website that was returning a 404 error.

## Changes
- Updated DataFrame documentation link from `/gettingstarted.html` to `/quickstart.html`
- Link now correctly points to the available documentation page (to be confirmed)


## Additional Context
The original link `https://kotlin.github.io/dataframe/gettingstarted.html` was returning a 404 error. The replacement link `https://kotlin.github.io/dataframe/quickstart.html` provides similar getting started content for DataFrame users.