### PR TITLE
Update kotlin-tour-null-safety.md

### DIFF
--- a/docs/topics/tour/kotlin-tour-null-safety.md
+++ b/docs/topics/tour/kotlin-tour-null-safety.md
@@ -59,7 +59,7 @@ fun main() {
         return notNull.length
     }
 
-    println(strLength(neverNull)) // 18
+    println(strLength("neverNull")) // 9
     println(strLength(nullable))  // Throws a compiler error
 }
 ```


### PR DESCRIPTION
Updated the example snippet for Nullable types
Here notNull is a string type, so argument passed must be a string and length is 9.