### PR TITLE
fix: update kotlin-tour-intermediate-scope-functions.md

### DIFF
--- a/docs/topics/tour/kotlin-tour-intermediate-scope-functions.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-scope-functions.md
@@ -407,9 +407,9 @@ of how these functions work in order to use them in your code.
 | Function | Access to `x` via | Return value  | Use case                                                                                     |
 |----------|-------------------|---------------|----------------------------------------------------------------------------------------------|
 | `let`    | `it`              | Lambda result | Perform null checks in your code and later perform further actions with the returned object. |
-| `apply`  | `this`            | `x`           | Initialize objects at the time of creation.                                                  |
+| `apply`  | `this`            | `this`        | Initialize objects at the time of creation.                                                  |
 | `run`    | `this`            | Lambda result | Initialize objects at the time of creation **AND** compute a result.                         |
-| `also`   | `it`              | `x`           | Complete additional actions before returning the object.                                     |
+| `also`   | `it`              | `this`        | Complete additional actions before returning the object.                                     |
 | `with`   | `this`            | Lambda result | Call multiple functions on an object.                                                        |
 
 For more information about scope functions, see [Scope functions](scope-functions.md).


### PR DESCRIPTION
According to the comments in the code, update the return values of the `apply` function and the `also` function to `this`.

- `apply` Function
> Calls the specified function [block] with `this` value as its receiver and returns `this` value.

- `also` Function
> Calls the specified function [block] with `this` value as its argument and returns `this` value.

ref. [libraries/stdlib/src/kotlin/util/Standard.kt](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/src/kotlin/util/Standard.kt)

> ```kotlin
> /**
>  * Calls the specified function [block] with `this` value as its receiver and returns `this` value.
>  *
>  * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#apply).
>  */
> @kotlin.internal.InlineOnly
> @IgnorableReturnValue
> public inline fun <T> T.apply(block: T.() -> Unit): T {
>     contract {
>         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
>     }
>     block()
>     return this
> }
> 
> /**
>  * Calls the specified function [block] with `this` value as its argument and returns `this` value.
>  *
>  * For detailed usage information see the documentation for [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html#also).
>  */
> @kotlin.internal.InlineOnly
> @SinceKotlin("1.1")
> @IgnorableReturnValue
> public inline fun <T> T.also(block: (T) -> Unit): T {
>     contract {
>         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
>     }
>     block(this)
>     return this
> }
> ```