### PR TITLE
Remove references to Kotlin by example

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -70,7 +70,6 @@
 	<toc-element toc-title="Basics">
 		<toc-element topic="basic-syntax.md"/>
 		<toc-element topic="idioms.md"/>
-		<toc-element href="https://play.kotlinlang.org/byExample/overview" toc-title="Kotlin by example"/>
 		<toc-element topic="coding-conventions.md"/>
 	</toc-element>
 	<toc-element toc-title="Concepts">
@@ -361,7 +360,7 @@
 	</toc-element>
 	<toc-element toc-title="Learning materials">
 		<toc-element toc-title="Overview" topic="learning-materials-overview.md"/>
-		<toc-element href="https://play.kotlinlang.org/byExample/overview" toc-title="Kotlin by example"/>
+		<toc-element href="kotlin-tour-welcome.md" toc-title="Kotlin tour"/>
 		<toc-element topic="koans.md"/>
 		<toc-element href="https://hyperskill.org/tracks?category=4&amp;utm_source=jbkotlin_hs&amp;utm_medium=referral&amp;utm_campaign=kotlinlang-docs&amp;utm_content=button_1&amp;utm_term=22.03.23" toc-title="Kotlin Core track"/>
 		<toc-element topic="kotlin-hands-on.md"/>

--- a/docs/topics/jvm/jvm-get-started.md
+++ b/docs/topics/jvm/jvm-get-started.md
@@ -108,6 +108,6 @@ Congratulations! You have just run your first Kotlin application.
 
 Once you've created this application, you can start to dive deeper into Kotlin syntax:
 
-* Add sample code from [Kotlin examples](https://play.kotlinlang.org/byExample/overview) 
+* Take the [Kotlin tour](kotlin-tour-welcome.md) 
 * Install the [JetBrains Academy plugin](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy) for IDEA and complete 
   exercises from the [Kotlin Koans course](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/learner-start-guide.html?section=Kotlin%20Koans)

--- a/docs/topics/learning-materials-overview.md
+++ b/docs/topics/learning-materials-overview.md
@@ -2,12 +2,12 @@
 
 You can use the following materials and resources for learning Kotlin:
 * [Basic syntax](basic-syntax.md) – get a quick overview of the Kotlin syntax.
+* [Kotlin tour](kotlin-tour-welcome.md) – learn the fundamentals of the Kotlin programming language.
 * [Idioms](idioms.md) – learn how to write idiomatic Kotlin code for popular cases.
   * [Java to Kotlin migration guide: Strings](java-to-kotlin-idioms-strings.md) – learn how to perform typical tasks with strings in Java and Kotlin.
   * [Java to Kotlin migration guide: Collections](java-to-kotlin-collections-guide.md) — learn how to perform typical tasks with collections in Java and Kotlin.
   * [Java to Kotlin migration guide: Nullability](java-to-kotlin-nullability-guide.md) — learn how to handle nullability in Java and Kotlin.
 * [Kotlin Koans](koans.md) – complete exercises to learn the Kotlin syntax. Each exercise is created as a failing unit test and your job is to make it pass. Recommended for developers with Java experience.
-* [Kotlin by example](https://play.kotlinlang.org/byExample/overview) – review a set of small and simple annotated examples for the Kotlin syntax.
 * [Kotlin Core track](https://hyperskill.org/tracks?category=4&utm_source=jbkotlin_hs&utm_medium=referral&utm_campaign=kotlinlang-docs&utm_content=button_1&utm_term=22.03.23) by JetBrains Academy – learn all the Kotlin essentials while creating working applications step by step.
 * [Kotlin books](books.md) – find books we've reviewed and recommend for learning Kotlin.
 * [Kotlin tips](kotlin-tips.md) – watch short videos where the Kotlin team shows you how to use Kotlin in a more efficient and idiomatic way, so you can have more fun when writing code.


### PR DESCRIPTION
This PR removes references to Kotlin by example and replaces them with the Kotlin tour.