### PR TITLE
Add Kotlin daemon links

### DIFF
--- a/docs/topics/build-tools-api.md
+++ b/docs/topics/build-tools-api.md
@@ -100,7 +100,7 @@ kotlin.compiler.execution.strategy=in-process
 
 ## Integration with Maven
 
-The BTA enables the [`kotlin-maven-plugin`](maven.md) to support the Kotlin daemon, which is the default
+The BTA enables the [`kotlin-maven-plugin`](maven.md) to support the [Kotlin daemon](kotlin-daemon.md), which is the default
 [compiler execution strategy](maven.md#configure-kotlin-compiler-execution-strategy). The `kotlin-maven-plugin` uses BTA by default,
 so there's no need to configure anything.
 

--- a/docs/topics/gradle/gradle-compilation-and-caches.md
+++ b/docs/topics/gradle/gradle-compilation-and-caches.md
@@ -70,7 +70,7 @@ starts using it.
 
 ## The Kotlin daemon and how to use it with Gradle
 
-The Kotlin daemon:
+The [Kotlin daemon](kotlin-daemon.md):
 * Runs with the Gradle daemon to compile the project.
 * Runs separately from the Gradle daemon when you compile the project with an IntelliJ IDEA built-in build system.
 

--- a/docs/topics/maven.md
+++ b/docs/topics/maven.md
@@ -221,7 +221,7 @@ The _Kotlin compiler execution strategy_ defines where the Kotlin compiler runs.
 | Kotlin daemon (default) | Inside its own daemon process         |
 | In process              | Inside the Maven process              |
 
-By default, the Kotlin daemon is used. You can switch to the "in process" strategy by setting the following
+By default, the [Kotlin daemon](kotlin-daemon.md) is used. You can switch to the "in process" strategy by setting the following
 property in your `pom.xml` file:
 
 ```xml


### PR DESCRIPTION
This PR adds links from the build tools docs to the page on Kotlin daemon.