### PR TITLE
Add 2025.3 EAP build notes for some language features

### DIFF
--- a/docs/topics/whatsnew/whatsnew22.md
+++ b/docs/topics/whatsnew/whatsnew22.md
@@ -566,6 +566,10 @@ fun main() {
 ### Improved Java interop with inline value classes
 <primary-label ref="experimental-general"/>
 
+> Support for code analysis, code completion, and highlighting of this feature in IntelliJ IDEA is currently available only in [2025.3 EAP builds](https://www.jetbrains.com/idea/nextversion/).
+>
+{style = "note"}
+
 Kotlin 2.2.0 introduces a new experimental annotation: [`@JvmExposeBoxed`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.jvm/-jvm-expose-boxed/). This annotation makes it easier to consume [inline value classes](inline-classes.md) from Java.
 
 By default, Kotlin compiles inline value classes to use **unboxed representations**, which are more performant but often 

--- a/docs/topics/whatsnew/whatsnew2220.md
+++ b/docs/topics/whatsnew/whatsnew2220.md
@@ -152,6 +152,10 @@ We would appreciate your feedback in our issue tracker, [YouTrack](https://youtr
 ### Data-flow-based exhaustiveness checks for `when` expressions
 <primary-label ref="experimental-opt-in"/>
 
+> Support for code analysis, code completion, and highlighting of this feature in IntelliJ IDEA is currently available only in [2025.3 EAP builds](https://www.jetbrains.com/idea/nextversion/).
+>
+{style = "note"}
+
 Kotlin 2.2.20 introduces **data-flow-based** exhaustiveness checks for `when` expressions.
 Previously, the compiler's checks were limited to the `when` expression itself,
 often forcing you to add a redundant `else` branch.
@@ -190,6 +194,10 @@ kotlin {
 
 ### Support for reified types in `catch` clauses
 <primary-label ref="experimental-opt-in"/>
+
+> Support for code analysis, code completion, and highlighting of this feature in IntelliJ IDEA is currently available only in [2025.3 EAP builds](https://www.jetbrains.com/idea/nextversion/).
+> 
+{style = "note"}
 
 In Kotlin 2.2.20, the compiler now allows using [reified generic type parameters](inline-functions.md#reified-type-parameters) in `catch` clauses of `inline` functions.
 
@@ -231,6 +239,10 @@ The Kotlin team is grateful to external contributor [Iven Krall](https://github.
 
 ### Improved Kotlin contracts
 <primary-label ref="experimental-opt-in"/>
+
+> Support for code analysis, code completion, and highlighting of this feature in IntelliJ IDEA is currently available only in [2025.3 EAP builds](https://www.jetbrains.com/idea/nextversion/).
+>
+{style = "note"}
 
 Kotlin 2.2.20 introduces several improvements to [Kotlin contracts](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.contracts/contract.html), including:
 


### PR DESCRIPTION
This PR adds notes about language features that need EAP builds of IntelliJ IDEA to get the syntax highlighting support.