### PR TITLE
Add small clarification for language feature stability levels

### DIFF
--- a/docs/topics/kotlin-evolution-principles.md
+++ b/docs/topics/kotlin-evolution-principles.md
@@ -146,7 +146,7 @@ A Kotlin language feature can have one of the following statuses:
   We seek feedback on your experience with the feature, including how easily it integrates into your codebase,
   how it interacts with existing code, and any IDE support issues or suggestions.
   The feature's design may change significantly, or it could be completely revoked based on feedback. When a feature is
-  _in preview_, it has a [stability level](components-stability.md#stability-levels-explained).
+  _in preview_, it has either Experimental or Beta [stability levels](components-stability.md#stability-levels-explained).
 
 * **Stable**. The language feature is now a first-class citizen in the Kotlin language.
   We guarantee its backward compatibility and that we'll provide tooling support.


### PR DESCRIPTION
This PR clarifies that language features that have the "In preview" status can only have Experimental or Beta stability levels.