### PR TITLE
Fix KT-85276: Update Gradle + JPMS example

### DIFF
--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -525,17 +525,11 @@ tasks.named("compileJava", JavaCompile::class.java) {
 
 ```groovy
 // Add the following three lines if you use a Gradle version less than 7.0
-java {
-    modularity.inferModulePath = true
-}
-
-tasks.named("compileJava", JavaCompile.class) {
-    options.compilerArgumentProviders.add(new CommandLineArgumentProvider() {
-        @Override
-        Iterable<String> asArguments() {
-            // Provide compiled Kotlin classes to javac – needed for Java/Kotlin mixed sources to work
-            return ["--patch-module", "YOUR_MODULE_NAME=${sourceSets["main"].output.asPath}"]
-        }
+tasks.named("compileJava", JavaCompile::class.java) {
+    // Use FileCollection to ensure compatibility with Gradle configuration cache
+    val mainOutput: FileCollection = sourceSets["main"].output
+    options.compilerArgumentProviders.add(CommandLineArgumentProvider {
+        listOf("--patch-module", "YOUR_MODULE_NAME=${mainOutput.asPath}")
     })
 }
 ```


### PR DESCRIPTION
Fixes KT-85276

Updated the Gradle + JPMS example to ensure compatibility with the Gradle configuration cache.

- Replaced direct sourceSets output usage with a FileCollection
- Removed outdated Gradle < 7.0 configuration