### PR TITLE
Remove sketchy link from FAQ page

### DIFF
--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -144,7 +144,6 @@ You can learn all the Kotlin essentials while creating working applications with
 A few other courses you can take:
 * [Pluralsight Course: Getting Started with Kotlin](https://www.pluralsight.com/courses/kotlin-getting-started) by Kevin Jones
 * [O'Reilly Course: Introduction to Kotlin Programming](https://www.oreilly.com/library/view/introduction-to-kotlin/9781491964125/) by Hadi Hariri
-* [Udemy Course: 10 Kotlin Tutorials for Beginners](https://petersommerhoff.com/dev/kotlin/kotlin-beginner-tutorial/) by Peter Sommerhoff
 
 You can also check out the other tutorials and content on our [YouTube channel](https://www.youtube.com/c/Kotlin).
 


### PR DESCRIPTION
Removed Udemy course "10 Kotlin Tutorials for Beginners" by Peter Sommerhoff from the FAQ section, as it redirects to a sketchy website now