### PR TITLE
Revert "chore: add estimated reading time to Kotlin tour"

### DIFF
--- a/docs/topics/tour/kotlin-tour-basic-types.md
+++ b/docs/topics/tour/kotlin-tour-basic-types.md
@@ -12,10 +12,6 @@
         <img src="icon-7-todo.svg" width="20" alt="Final step" /> <a href="kotlin-tour-null-safety.md">Null safety</a></p>
 </tldr>
 
-> 3 min read
->
-{style="tip"}
-
 Every variable and data structure in Kotlin has a type. Types are important because they tell the compiler what you are allowed to 
 do with that variable or data structure. In other words, what functions and properties it has.
 

--- a/docs/topics/tour/kotlin-tour-classes.md
+++ b/docs/topics/tour/kotlin-tour-classes.md
@@ -12,10 +12,6 @@
         <img src="icon-7-todo.svg" width="20" alt="Final step" /> <a href="kotlin-tour-null-safety.md">Null safety</a></p>
 </tldr>
 
-> 8 min read
->
-{style="tip"}
-
 Kotlin supports object-oriented programming with classes and objects. Objects are useful for storing data in your program.
 Classes allow you to declare a set of characteristics for an object. When you create objects from a class, you can save
 time and effort because you don't have to declare these characteristics every time.

--- a/docs/topics/tour/kotlin-tour-collections.md
+++ b/docs/topics/tour/kotlin-tour-collections.md
@@ -12,10 +12,6 @@
         <img src="icon-7-todo.svg" width="20" alt="Final step" /> <a href="kotlin-tour-null-safety.md">Null safety</a></p>
 </tldr>
 
-> 10 min read
->
-{style="tip"}
-
 When programming, it is useful to be able to group data into structures for later processing. Kotlin provides collections
 for exactly this purpose.
 

--- a/docs/topics/tour/kotlin-tour-control-flow.md
+++ b/docs/topics/tour/kotlin-tour-control-flow.md
@@ -12,10 +12,6 @@
         <img src="icon-7-todo.svg" width="20" alt="Final step" /> <a href="kotlin-tour-null-safety.md">Null safety</a></p>
 </tldr>
 
-> 10 min read
->
-{style="tip"}
-
 Like other programming languages, Kotlin is capable of making decisions based on whether a piece of code is evaluated to
 be true. Such pieces of code are called **conditional expressions**. Kotlin is also able to create and iterate
 through loops.

--- a/docs/topics/tour/kotlin-tour-functions.md
+++ b/docs/topics/tour/kotlin-tour-functions.md
@@ -12,10 +12,6 @@
         <img src="icon-7-todo.svg" width="20" alt="Final step" /> <a href="kotlin-tour-null-safety.md">Null safety</a></p>
 </tldr>
 
-> 14 min read
->
-{style="tip"}
-
 You can declare your own functions in Kotlin using the `fun` keyword.
 
 ```kotlin

--- a/docs/topics/tour/kotlin-tour-hello-world.md
+++ b/docs/topics/tour/kotlin-tour-hello-world.md
@@ -12,10 +12,6 @@
         <img src="icon-7-todo.svg" width="20" alt="Final step" /> <a href="kotlin-tour-null-safety.md">Null safety</a></p>
 </tldr>
 
-> 3 min read
-> 
-{style="tip"}
-
 Here is a simple program that prints "Hello, world!":
 
 ```kotlin

--- a/docs/topics/tour/kotlin-tour-intermediate-classes-interfaces.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-classes-interfaces.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 17 min read
->
-{style="tip"}
-
 In the beginner tour, you learned how to use classes and data classes to store data and maintain a collection of characteristics
 that can be shared in your code. Eventually, you will want to create a hierarchy to efficiently share code within your 
 projects. This chapter explains the options Kotlin provides for sharing code and how they can make your code safer and easier to maintain.

--- a/docs/topics/tour/kotlin-tour-intermediate-extension-functions.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-extension-functions.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 4 min read
->
-{style="tip"}
-
 In this chapter, you'll explore special Kotlin functions that make your code more concise and readable. Learn how they
 can help you use efficient design patterns to take your projects to the next level.
 

--- a/docs/topics/tour/kotlin-tour-intermediate-lambdas-receiver.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-lambdas-receiver.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 7 min read
->
-{style="tip"}
-
 In this chapter, you'll learn how to use receivers with another type of function, lambda expressions, and how they
 can help you create a domain-specific language.
 

--- a/docs/topics/tour/kotlin-tour-intermediate-libraries-and-apis.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-libraries-and-apis.md
@@ -14,10 +14,6 @@
         <img src="icon-9.svg" width="20" alt="Ninth step" /> <strong>Libraries and APIs</strong><br /></p>
 </tldr>
 
-> 8 min read
->
-{style="tip"}
-
 To get the most out of Kotlin, use existing libraries and APIs so you can spend more time coding and less time 
 reinventing the wheel.
 

--- a/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-null-safety.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 15 min read
->
-{style="tip"}
-
 In the beginner tour, you learned how to handle `null` values in your code. This chapter covers common use cases for null
 safety features and how to make the most of them.
 

--- a/docs/topics/tour/kotlin-tour-intermediate-objects.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-objects.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 8 min read
->
-{style="tip"}
-
 In this chapter, you'll expand your understanding of classes by exploring object declarations. This knowledge will help 
 you efficiently manage behavior across your projects.
 

--- a/docs/topics/tour/kotlin-tour-intermediate-open-special-classes.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-open-special-classes.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 13 min read
->
-{style="tip"}
-
 In this chapter, you'll learn about open classes, how they work with interfaces, and other special
 types of classes available in Kotlin.
 

--- a/docs/topics/tour/kotlin-tour-intermediate-properties.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-properties.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 17 min read
->
-{style="tip"}
-
 In the beginner tour, you learned how properties are used to declare characteristics of class instances and how to access
 them. This chapter digs deeper into how properties work in Kotlin and explores other ways that you can use them in your code.
 

--- a/docs/topics/tour/kotlin-tour-intermediate-scope-functions.md
+++ b/docs/topics/tour/kotlin-tour-intermediate-scope-functions.md
@@ -14,10 +14,6 @@
         <img src="icon-9-todo.svg" width="20" alt="Ninth step" /> <a href="kotlin-tour-intermediate-libraries-and-apis.md">Libraries and APIs</a></p>
 </tldr>
 
-> 13 min read
->
-{style="tip"}
-
 In this chapter, you'll build on your understanding of extension functions to learn how to use scope functions to 
 write more idiomatic code.
 

--- a/docs/topics/tour/kotlin-tour-null-safety.md
+++ b/docs/topics/tour/kotlin-tour-null-safety.md
@@ -12,10 +12,6 @@
         <img src="icon-7.svg" width="20" alt="Final step" /> <strong>Null safety</strong><br /></p>
 </tldr>
 
-> 6 min read
->
-{style="tip"}
-
 In Kotlin, it's possible to have a `null` value. Kotlin uses `null` values when something is missing or not yet set.
 You've already seen an example of Kotlin returning a `null` value in the [Collections](kotlin-tour-collections.md#kotlin-tour-map-no-key)
 chapter when you tried to access a key-value pair with a key that doesn't exist in the map. Although it's useful to use


### PR DESCRIPTION
This reverts commit 3a10155634030f13ea61e037e320f47c7ce4246a.
This PR removes the reading estimates from the Kotlin tour since they seemed to provide no benefit.