### PR TITLE
Update kotlin-metadata-jvm API Reference task for DGPv2

### DIFF
--- a/.teamcity/references/builds/kotlinx/metadataJvm/KotlinxMetadataJvmBuildApiReference.kt
+++ b/.teamcity/references/builds/kotlinx/metadataJvm/KotlinxMetadataJvmBuildApiReference.kt
@@ -28,7 +28,7 @@ object KotlinxMetadataJvmBuildApiReference : BuildApiPages(
                 scriptContent = """
                     #!/bin/bash
                      set -e -u
-                    ./gradlew :kotlin-metadata-jvm:dokkaHtml -PdeployVersion=${KOTLIN_RELEASE_LABEL} --no-daemon --no-configuration-cache
+                    ./gradlew :kotlin-metadata-jvm:dokkaGenerate -PdeployVersion=${KOTLIN_RELEASE_LABEL}
                 """.trimIndent()
             }
         }


### PR DESCRIPTION
Kotlin `master` has already been migrated to DGPv2, so to deploy the API, future references for kotlin-metadata-jvm will need to use the new task name.
Changes are done in https://github.com/JetBrains/kotlin/commit/defc6c8905ba6ad77fb8055fbf6b7c33fcf2e20f, and so affect Kotlin 2.4.0+.