### PR TITLE
chore: fix broken link in ksp-quickstart.md

### DIFF
--- a/docs/topics/ksp/ksp-quickstart.md
+++ b/docs/topics/ksp/ksp-quickstart.md
@@ -454,5 +454,5 @@ Your project's final file structure should look like this:
 ## What's next?
 
 * Explore the full code for this example in [the KSP repository](https://github.com/google/ksp/tree/main/examples/hello-world).
-* Find more complex, real-world examples in [the KSP repository](https://github.com/google/ksp/blob/main/examples/playground/test-processor/src/main/kotlin/BuilderProcessor.kt).
+* Find more complex, real-world examples in [the KSP repository](https://github.com/google/ksp/tree/main/examples).
 * Browse the list of [KSP supported libraries](ksp-overview.md#supported-libraries).


### PR DESCRIPTION
Updated a link that broke when things were reorganized in Google's KSP repository.