### PR TITLE
Update K2 compiler migration guide for 2.4.0

### DIFF
--- a/docs/topics/compiler/k2-compiler-migration-guide.md
+++ b/docs/topics/compiler/k2-compiler-migration-guide.md
@@ -561,12 +561,14 @@ The Kotlin Playground supports Kotlin 2.0.0 and later releases. [Check it out!](
 
 ## How to roll back to the previous compiler
 
-To use the previous compiler in Kotlin 2.0.0 and later releases, either:
+To use the previous compiler in Kotlin 2.0.0–2.3.21, either:
 
 * In your `build.gradle.kts` file, [set your language version](gradle-compiler-options.md#example-of-setting-languageversion) to `1.9`.
 
   OR
 * Use the following compiler option: `-language-version 1.9`.
+
+From Kotlin 2.4.0 onward, you can't roll back to the previous compiler.
 
 ## Changes
 


### PR DESCRIPTION
This PR updates the roll back to K1 compiler advice after the release of Kotlin 2.4.0.