### PR TITLE
Make What's new in Kotlin 2.4.0-Beta2 standard library samples runnable

### DIFF
--- a/docs/labels.list
+++ b/docs/labels.list
@@ -18,7 +18,7 @@
     <secondary-label id="wasm" name="Kotlin/Wasm" color="purple"></secondary-label>
     <secondary-label id="js" name="Kotlin/JS" color="yellow"></secondary-label>
     <secondary-label id="language" name="Language" color="marine"></secondary-label>
-    <secondary-label id="standard-library" name="Standard library" color="tangerine"></secondary-label>
+    <secondary-label id="standard-library" name="Standard library" color="blue"></secondary-label>
     <secondary-label id="compiler" name="Compiler" color="black"></secondary-label>
     <secondary-label id="compose-compiler" name="Compose compiler" color="blue"></secondary-label>
 </labels>

--- a/docs/topics/whatsnew/whatsnew-eap.md
+++ b/docs/topics/whatsnew/whatsnew-eap.md
@@ -380,6 +380,7 @@ fun main() {
     // false
 }
 ```
+{kotlin-runnable="true" kotlin-min-compiler-version="2.4.0-Beta2" id="kotlin-2-4-0-check-sorted-order"}
 
 We would appreciate your feedback in [YouTrack](https://youtrack.jetbrains.com/issue/KT-78499).
 
@@ -395,6 +396,7 @@ Here's an example:
 
 ```kotlin
 fun main() {
+    //sampleStart
     val unsignedLong = Long.MAX_VALUE.toULong() + 1uL
     val unsignedInt = UInt.MAX_VALUE
 
@@ -403,8 +405,10 @@ fun main() {
 
     println(unsignedInt.toBigInteger())
     // 4294967295
+   //sampleEnd
 }
 ```
+{kotlin-runnable="true" kotlin-min-compiler-version="2.4.0-Beta2" id="kotlin-2-4-0-convert-unsigned-int"}
 
 We would appreciate your feedback in [YouTrack](https://youtrack.jetbrains.com/issue/KT-73111).
 


### PR DESCRIPTION
This PR updates the What's new for Kotlin 2.4.0-Beta2 to make the standard library samples runnable.