### PR TITLE
chore: updating compiler version example

### DIFF
--- a/docs/topics/compiler/compiler-reference.md
+++ b/docs/topics/compiler/compiler-reference.md
@@ -87,8 +87,8 @@ Core plugins and their options are listed in the [Core compiler plugins](compone
 ### -language-version _version_
 
 This option sets the supported syntax and semantics according to the specified language version. For example, using 
-Kotlin compiler version 2.2.0 with `-language-version=1.9` lets you use only the language features and standard library APIs from
-version 1.9 or earlier. This can help with a gradual migration to newer Kotlin versions.
+Kotlin compiler version 2.4.0 with `-language-version=2.2` lets you use only the language features and standard library APIs from
+version 2.2 or earlier. This can help with a gradual migration to newer Kotlin versions.
 
 ### -api-version _version_
 


### PR DESCRIPTION
This update is related to [KT-80590](https://youtrack.jetbrains.com/issue/KT-80590) and updates the example for a more recent Kotlin compiler