### PR TITLE
feat: stabilization of features and add explicit context arguments

### DIFF
--- a/docs/topics/annotations.md
+++ b/docs/topics/annotations.md
@@ -184,7 +184,7 @@ The full list of supported use-site targets is:
   * `property` (annotations with this target are not visible to Java)
   * `get` (property getter)
   * `set` (property setter)
-  * `all` (an experimental meta-target for properties, see [below](#all-meta-target) for its purpose and usage)
+  * `all` (a meta-target for properties, see the [`all` meta-target](#all-meta-target) section for more information)
   * `receiver` (receiver parameter of an extension function or property)
 
     To annotate the receiver parameter of an extension function, use the following syntax:
@@ -274,8 +274,6 @@ Whenever you'd like to use the old behavior, you can:
 
 ### `all` meta-target
 
-<primary-label ref="experimental-opt-in"/>
-
 The `all` target makes it easier to apply the same annotation not only to the parameter and the property or field, but also to the corresponding getter and setter.
 
 Specifically, the annotation marked with `all` is propagated, if applicable:
@@ -323,25 +321,6 @@ The `all` target comes with some limitations:
     val x: Int = 5
     ```
 * It cannot be used with [delegated properties](delegated-properties.md).
-
-#### How to enable
-
-To enable the `all` meta-target in your project, use the following compiler option in the command line:
-
-```Bash
--Xannotation-target-all
-```
-
-Or add it to the `compilerOptions {}` block of your Gradle build file:
-
-```kotlin
-// build.gradle.kts
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.add("-Xannotation-target-all")
-    }
-}
-```
 
 ## Java annotations
 

--- a/docs/topics/compiler/compiler-reference.md
+++ b/docs/topics/compiler/compiler-reference.md
@@ -145,16 +145,6 @@ Activates the Kotlin REPL.
 kotlinc -Xrepl
 ```
 
-### -Xannotation-target-all
-
-<primary-label ref="experimental-general"/>
-
-Enables the experimental [`all` use-site target for annotations](annotations.md#all-meta-target):
-
-```bash
-kotlinc -Xannotation-target-all
-```
-
 ### -Xannotation-default-target=param-property
 
 <primary-label ref="experimental-general"/>

--- a/docs/topics/context-parameters.md
+++ b/docs/topics/context-parameters.md
@@ -1,7 +1,5 @@
 [//]: # (title: Context parameters)
 
-<primary-label ref="experimental-general"/>
-
 > Context parameters replace an older experimental feature called [context receivers](whatsnew1620.md#prototype-of-context-receivers-for-kotlin-jvm).
 > You can find their main differences in the [design document for context parameters](https://github.com/Kotlin/KEEP/blob/master/proposals/context-parameters.md#summary-of-changes-from-the-previous-proposal).
 > To migrate from context receivers to context
@@ -37,7 +35,26 @@ context(users: UserService)
 val firstUser: String
     // Uses findUserById from the context    
     get() = users.findUserById(1)
+
+fun main() {
+    val users = object : UserService {
+        override fun log(message: String) {
+            println(message)
+        }
+
+        override fun findUserById(id: Int): String {
+            return "User $id"
+        }
+    }
+
+    context(users) {
+        outputMessage("Looking up the first user")
+        println(firstUser)
+        // User 1
+    }
+}
 ```
+{kotlin-runnable="true" kotlin-min-compiler-version="2.4"}
 
 You can use `_` as a context parameter name. In this case, the parameter's value is available for resolution but is not accessible by name inside the block:
 
@@ -50,7 +67,7 @@ fun logWelcome() {
 }
 ```
 
-#### Context parameters resolution
+## Context parameters resolution
 
 Kotlin resolves context parameters at the call site by searching for matching context values in the current scope. Kotlin matches them by their type.
 If multiple compatible values exist at the same scope level, the compiler reports an ambiguity:
@@ -86,7 +103,76 @@ fun main() {
 }
 ```
 
-#### Restrictions
+### Pass context arguments explicitly
+<primary-label ref="experimental-opt-in"/>
+
+When overloads differ only by context parameters, a call can become ambiguous if multiple matching context values are available.
+You can resolve this ambiguity by passing an explicit context argument at the call site.
+
+Here's an example:
+
+```kotlin
+class EmailSender
+class SmsSender
+
+context(emailSender: EmailSender)
+fun sendNotification() {
+    println("Sent email notification")
+}
+
+context(smsSender: SmsSender)
+fun sendNotification() {
+    println("Sent SMS notification")
+}
+
+context(defaultEmailSender: EmailSender, defaultSmsSender: SmsSender)
+fun notifyUser() {
+    // Selects the overload with the EmailSender context parameter
+    sendNotification(emailSender = defaultEmailSender)
+
+    // Selects the overload with the SmsSender context parameter
+    sendNotification(smsSender = defaultSmsSender)
+}
+```
+
+You can also use explicit context arguments instead of the `context()` function to reduce nesting and make some calls easier to read. If you need to use the same context arguments in multiple calls, use the `context()` function instead.
+
+This feature is [Experimental](components-stability.md#stability-levels-explained). To opt in, add the following compiler option to your build file:
+
+<tabs group="build-system">
+<tab title="Gradle" group-key="gradle">
+
+```kotlin
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xexplicit-context-arguments")
+    }
+}
+```
+
+</tab>
+<tab title="Maven" group-key="maven">
+
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-plugin</artifactId>
+            <configuration>
+                <args>
+                    <arg>-Xexplicit-context-arguments</arg>
+                </args>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+</tab>
+</tabs>
+
+## Restrictions
 
 Context parameters are in continuous improvement, and some of the current restrictions include:
 
@@ -96,29 +182,3 @@ Context parameters are in continuous improvement, and some of the current restri
 
 Despite these restrictions, context parameters simplify managing dependencies through simplified dependency injection,
 improved DSL design, and scoped operations.
-
-#### How to enable context parameters
-
-To enable context parameters in your project, use the following compiler option in the command line:
-
-```Bash
--Xcontext-parameters
-```
-
-Or add it to the `compilerOptions {}` block of your Gradle build file:
-
-```kotlin
-// build.gradle.kts
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-parameters")
-    }
-}
-```
-
-> Specifying both `-Xcontext-receivers` and `-Xcontext-parameters` compiler options simultaneously leads to an error.
->
-{style="warning"}
-
-This feature is planned to be [stabilized](components-stability.md#stability-levels-explained) and improved in future Kotlin releases.
-We would appreciate your feedback in our issue tracker [YouTrack](https://youtrack.jetbrains.com/issue/KT-10468/Context-Parameters-expanding-extension-receivers-to-work-with-scopes).

--- a/docs/topics/context-parameters.md
+++ b/docs/topics/context-parameters.md
@@ -107,9 +107,8 @@ fun main() {
 <primary-label ref="experimental-opt-in"/>
 
 When overloads differ only by context parameters, a call can become ambiguous if multiple matching context values are available.
-You can resolve this ambiguity by passing an explicit context argument at the call site.
 
-Here's an example:
+To resolve the ambiguity, pass an explicit context argument at the call site:
 
 ```kotlin
 class EmailSender
@@ -135,7 +134,10 @@ fun notifyUser() {
 }
 ```
 
-You can also use explicit context arguments instead of the `context()` function to reduce nesting and make some calls easier to read. If you need to use the same context arguments in multiple calls, use the `context()` function instead.
+You can also use explicit context arguments to reduce nesting in some function calls:
+
+* For a single call, use explicit context arguments to make the call easier to read.
+* If multiple calls use the same context arguments, use the `context()` function.
 
 This feature is [Experimental](components-stability.md#stability-levels-explained). To opt in, add the following compiler option to your build file:
 

--- a/docs/topics/jvm/jvm-records.md
+++ b/docs/topics/jvm/jvm-records.md
@@ -72,19 +72,6 @@ To specify it explicitly, use the `jvmTarget` compiler option in [Gradle](gradle
 In Java, [annotations](annotations.md) on a record component are automatically propagated to the backing field, getter, setter, and constructor parameter.
 You can replicate this behavior in Kotlin by using the [`all`](annotations.md#all-meta-target) use-site target.
 
-> To use the `all` use-site target, you must opt in. Either use the `-Xannotation-target-all` compiler option or add
-> the following to your `build.gradle.kts` file:
->
-> ```kotlin
-> kotlin {
->     compilerOptions {
->         freeCompilerArgs.add("-Xannotation-target-all")
->     }
-> }
-> ```
->
-{style="warning"}
-
 For example:
 
 ```kotlin


### PR DESCRIPTION
This PR adds information about explicit context arguments to context parameters.
Related issue: [KT-84188](https://youtrack.jetbrains.com/issue/KT-84188)

It also updates the relevant pages of the Stabilization of `all` meta-target and context parameters.