### PR TITLE
feat: Kotlin 2.4.0-RC release

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -22,7 +22,7 @@
         <toc-element hidden="true" topic="kotlin-tour-intermediate-libraries-and-apis.md"/>
     </toc-element>
     <toc-element toc-title="What's new in Kotlin">
-        <toc-element toc-title="Kotlin 2.4.0-Beta2" topic="whatsnew-eap.md"/>
+        <toc-element toc-title="Kotlin 2.4.0-RC" topic="whatsnew-eap.md"/>
         <toc-element toc-title="Kotlin 2.3.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2320.md"/>
         <toc-element toc-title="Kotlin 2.3.0" topic="whatsnew23.md"/>
         <toc-element toc-title="Compatibility guide" topic="compatibility-guide-23.md"/>

--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -63,13 +63,13 @@ _No preview versions are currently available._
         <th>Build highlights</th>
     </tr>
     <tr>
-        <td><strong>2.4.0-Beta2</strong>
-            <p>Released: <strong>April 22, 2026</strong></p>
-            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-Beta2" target="_blank">Release on GitHub</a></p>
+        <td><strong>2.4.0-RC</strong>
+            <p>Released: <strong>May 13, 2026</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-RC" target="_blank">Release on GitHub</a></p>
         </td>
         <td>
             <p>A language release with major changes in the language and tooling updates.</p>
-            <p>For more details, refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-Beta2">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.4.0-Beta2</a>.</p>
+            <p>For more details, refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-RC">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.4.0-RC</a>.</p>
         </td>
     </tr>
 </table>

--- a/docs/topics/whatsnew/whatsnew-eap.md
+++ b/docs/topics/whatsnew/whatsnew-eap.md
@@ -23,7 +23,7 @@ The Kotlin %kotlinEapVersion% release is out! Here are some details of this EAP 
 * **Kotlin/Native:** [Support for Swift packages as dependencies, updates on Swift export, and default CMS GC](#kotlin-native)
 * **Kotlin/Wasm:** [Incremental compilation enabled by default and support for WebAssembly Component Model](#kotlin-wasm)
 * **Kotlin/JS**: [Support for value class export and ES2015 features in JS code inlining](#kotlin-js)
-* **Gradle:** [Compatibility with Gradle 9.4.1](#gradle)
+* **Gradle:** [Compatibility with Gradle 9.5.0](#gradle)
 * **Maven:** [Automatic alignment between Java and JVM target versions](#maven)
 * **Kotlin compiler:** [More consistent inline function behavior during `.klib` compilation](#consistent-intra-module-function-inlining-during-klib-compilation)
 
@@ -296,7 +296,7 @@ This feature is [Experimental](components-stability.md#stability-levels-explaine
 ```kotlin
 kotlin {
     compilerOptions {
-        freeCompilerArgs.add("-XXLanguage:+IntrinsicConstEvaluation")
+        freeCompilerArgs.add("-XIntrinsic-const-evaluation")
     }
 }
 ```
@@ -312,7 +312,7 @@ kotlin {
             <artifactId>kotlin-maven-plugin</artifactId>
             <configuration>
                 <args>
-                    <arg>-XXLanguage:+IntrinsicConstEvaluation</arg>
+                    <arg>-XIntrinsic-const-evaluation</arg>
                 </args>
             </configuration>
         </plugin>
@@ -630,7 +630,7 @@ For more information on inlining inline JavaScript code, see [our documentation]
 
 ## Gradle
 
-Kotlin %kotlinEapVersion% is fully compatible with Gradle 7.6.3 through 9.4.1. You can also use Gradle versions up to 
+Kotlin %kotlinEapVersion% is fully compatible with Gradle 7.6.3 through 9.5.0. You can also use Gradle versions up to 
 the latest Gradle release. However, be aware that doing so may result in deprecation warnings, and some new Gradle features might not work.
 
 ## Maven

--- a/docs/v.list
+++ b/docs/v.list
@@ -14,8 +14,8 @@
     <var name="apiVersion" value="2.3"/>
 
     <!-- Kotlin EAP -->
-    <var name="kotlinEapVersion" value="2.4.0-Beta2"/>
-    <var name="kotlinEapReleaseDate" value="April 22, 2026"/>
+    <var name="kotlinEapVersion" value="2.4.0-RC"/>
+    <var name="kotlinEapReleaseDate" value="May 13, 2026"/>
 
     <!-- Libraries and Frameworks -->
     <var name="coroutinesVersion" value="1.10.2"/>


### PR DESCRIPTION
This PR adds information about the Kotlin 2.4.0-RC release.