### PR TITLE
Remove mentions of IntelliJ IDEA editions

### DIFF
--- a/docs/topics/js/js-debugging.md
+++ b/docs/topics/js/js-debugging.md
@@ -36,7 +36,7 @@ when the script is loaded for the first time.
 
 ## Debug in the IDE
 
-[IntelliJ IDEA Ultimate](https://www.jetbrains.com/idea/) provides a powerful set of tools for debugging code during development.
+[IntelliJ IDEA](https://www.jetbrains.com/idea/) with an Ultimate subscription provides a powerful set of tools for debugging code during development.
 
 For debugging Kotlin/JS in IntelliJ IDEA, you'll need a **JavaScript Debug** configuration. To add such a debug configuration:
 

--- a/docs/topics/js/js-get-started.md
+++ b/docs/topics/js/js-get-started.md
@@ -15,8 +15,7 @@ To create your app, choose the tool that best fits your workflow:
 
 ## Create your application in IntelliJ IDEA 
 
-To create your Kotlin/JS web application, you can use either the
-Community or Ultimate edition of [IntelliJ IDEA](https://www.jetbrains.com/idea/download/).
+To create your Kotlin/JS web application, you can use [IntelliJ IDEA](https://www.jetbrains.com/idea/download/).
 
 ### Set up the environment
 
@@ -84,7 +83,7 @@ After you run the application for the first time, IntelliJ IDEA creates its corr
 
 ![Gradle run configuration](js-run-config.png){width=500}
 
-> In IntelliJ IDEA Ultimate,
+> In IntelliJ IDEA with an Ultimate subscription,
 > you can use the [JS Debugger](https://www.jetbrains.com/help/idea/configuring-javascript-debugger.html)
 > to debug code directly from the IDE.
 > 

--- a/docs/topics/jvm/jvm-create-project-with-spring-boot.md
+++ b/docs/topics/jvm/jvm-create-project-with-spring-boot.md
@@ -15,16 +15,16 @@ The first part of the tutorial shows how to create a Spring Boot project with Gr
 
 ## Before you start
 
-Download and install the latest version of [IntelliJ IDEA Ultimate Edition](https://www.jetbrains.com/idea/download/).
+Download and install the latest version of [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) and use an Ultimate subscription.
 
-> If you use IntelliJ IDEA Community Edition or another IDE, you can generate a Spring Boot project using
+> If you use IntelliJ IDEA without an Ultimate subscription or you use another IDE, you can generate a Spring Boot project using
 > a [web-based project generator](https://start.spring.io/#!language=kotlin&type=gradle-project-kotlin).
 > 
 {style="tip"}
 
 ## Create a Spring Boot project
 
-Create a new Spring Boot project with Kotlin by using the Project Wizard in IntelliJ IDEA Ultimate Edition:
+Create a new Spring Boot project with Kotlin by using the Project Wizard in IntelliJ IDEA:
 
 1. In IntelliJ IDEA, select **File** | **New** | **Project**. 
 2. In the panel on the left, select **Spring Boot** in the **Generators** section.

--- a/docs/topics/jvm/jvm-test-using-junit.md
+++ b/docs/topics/jvm/jvm-test-using-junit.md
@@ -13,9 +13,8 @@ In this tutorial, you'll learn how to:
 
 > Before you start, make sure you have:
 >
-> * [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) (Community or Ultimate edition) that has a bundled Kotlin plugin
-> or [VS Code](https://code.visualstudio.com/Download) with the installed [Kotlin extension](https://github.com/Kotlin/kotlin-lsp/tree/main?tab=readme-ov-file#vs-code-quick-start).
-> * Java 17 or later
+> * [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) or [VS Code](https://code.visualstudio.com/Download) with the installed [Kotlin extension](https://github.com/Kotlin/kotlin-lsp/tree/main?tab=readme-ov-file#vs-code-quick-start).
+> * Java 17 or later.
 >
 {style="note"}
 

--- a/docs/topics/jvm/server-overview.md
+++ b/docs/topics/jvm/server-overview.md
@@ -19,7 +19,7 @@ included in IntelliJ IDEA:
 
 Kotlin is fully compatible with all Java-based frameworks, so you can use your familiar technology stack while
 benefiting from Kotlin syntax. In addition to great IDE support, Kotlin offers framework-specific tooling,
-such as support for Spring and Ktor in IntelliJ IDEA Ultimate.
+such as support for Spring and Ktor in IntelliJ IDEA with an Ultimate subscription.
 
 ### Spring
 

--- a/docs/topics/native/native-get-started.md
+++ b/docs/topics/native/native-get-started.md
@@ -23,8 +23,7 @@ in this tutorial, you'll be targeting the same platform you're compiling on.
 
 ## In IDE
 
-In this section, you'll learn how to use IntelliJ IDEA to create a Kotlin/Native application. You can use both
-the Community Edition and the Ultimate Edition.
+In this section, you'll learn how to use IntelliJ IDEA to create a Kotlin/Native application.
 
 ### Create the project
 
@@ -70,7 +69,7 @@ After the first run, the IDE creates the corresponding run configuration at the 
 
 ![Gradle run configuration](native-run-config.png){width=500}
 
-> IntelliJ IDEA Ultimate users can install
+> IntelliJ IDEA users with an Ultimate subscription can install
 > the [Native Debugging Support](https://plugins.jetbrains.com/plugin/12775-native-debugging-support)
 > plugin that allows debugging compiled native executables and also automatically creates run configurations for
 > imported Kotlin/Native projects.

--- a/docs/topics/spring-ai-guide.md
+++ b/docs/topics/spring-ai-guide.md
@@ -14,9 +14,9 @@ You will use the following tools during this tutorial:
 
 ## Before you start
 
-1. Download and install the latest version of [IntelliJ IDEA Ultimate Edition](https://www.jetbrains.com/idea/download/).
+1. Download and install the latest version of [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) and use an Ultimate subscription.
 
-    > If you use IntelliJ IDEA Community Edition or another IDE, you can generate a Spring Boot project using
+    > If you use IntelliJ IDEA without an Ultimate subscription or you use another IDE, you can generate a Spring Boot project using
     > a [web-based project generator](https://start.spring.io/#!language=kotlin&type=gradle-project-kotlin).
     >
     {style="tip"}
@@ -31,11 +31,11 @@ You will use the following tools during this tutorial:
 
 ## Create the project
 
-> You can use [Spring Boot web-based project generator](https://start.spring.io/) as an alternative to generate your project.
+> You can use the [Spring Boot web-based project generator](https://start.spring.io/) as an alternative to generate your project.
 >
 {style="note"}
 
-Create a new Spring Boot project in IntelliJ IDEA Ultimate Edition:
+Create a new Spring Boot project in IntelliJ IDEA with an Ultimate subscription:
 
 1. In IntelliJ IDEA, select **File** | **New** | **Project**.
 2. In the panel on the left, select **New Project** | **Spring Boot**.

--- a/docs/topics/whatsnew/whatsnew1530.md
+++ b/docs/topics/whatsnew/whatsnew1530.md
@@ -561,7 +561,7 @@ Previously, we published the migration guide for the JS IR backend to help you m
 
 Kotlin 1.5.30 brings JavaScript source map generation for the Kotlin/JS IR backend. This will improve the Kotlin/JS debugging experience when the IR backend is enabled, with full debugging support that includes breakpoints, stepping, and readable stack traces with proper source references.
 
-Learn how to [debug Kotlin/JS in the browser or IntelliJ IDEA Ultimate](js-debugging.md).
+Learn how to [debug Kotlin/JS in the browser or IntelliJ IDEA](js-debugging.md).
 
 ## Gradle
 


### PR DESCRIPTION
This PR updates the docs so that we no longer mention editions of IntelliJ IDEA but the Ultimate subscription instead.