### PR TITLE
feat: Kotlin 2.4.0-RC2 release

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -22,7 +22,7 @@
         <toc-element hidden="true" topic="kotlin-tour-intermediate-libraries-and-apis.md"/>
     </toc-element>
     <toc-element toc-title="What's new in Kotlin">
-        <toc-element toc-title="Kotlin 2.4.0-RC" topic="whatsnew-eap.md"/>
+        <toc-element toc-title="Kotlin 2.4.0-RC2" topic="whatsnew-eap.md"/>
         <toc-element toc-title="Kotlin 2.3.20" accepts-web-file-names="whatsnew.html" topic="whatsnew2320.md"/>
         <toc-element toc-title="Kotlin 2.3.0" topic="whatsnew23.md"/>
         <toc-element toc-title="Compatibility guide" topic="compatibility-guide-23.md"/>

--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -63,13 +63,13 @@ _No preview versions are currently available._
         <th>Build highlights</th>
     </tr>
     <tr>
-        <td><strong>2.4.0-RC</strong>
-            <p>Released: <strong>May 13, 2026</strong></p>
-            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-RC" target="_blank">Release on GitHub</a></p>
+        <td><strong>2.4.0-RC2</strong>
+            <p>Released: <strong>May 27, 2026</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-RC2" target="_blank">Release on GitHub</a></p>
         </td>
         <td>
             <p>A language release with major changes in the language and tooling updates.</p>
-            <p>For more details, refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-RC">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.4.0-RC</a>.</p>
+            <p>For more details, refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0-RC2">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.4.0-RC2</a>.</p>
         </td>
     </tr>
 </table>

--- a/docs/v.list
+++ b/docs/v.list
@@ -14,8 +14,8 @@
     <var name="apiVersion" value="2.3"/>
 
     <!-- Kotlin EAP -->
-    <var name="kotlinEapVersion" value="2.4.0-RC"/>
-    <var name="kotlinEapReleaseDate" value="May 13, 2026"/>
+    <var name="kotlinEapVersion" value="2.4.0-RC2"/>
+    <var name="kotlinEapReleaseDate" value="May 27, 2026"/>
 
     <!-- Libraries and Frameworks -->
     <var name="coroutinesVersion" value="1.10.2"/>


### PR DESCRIPTION
This PR adds information about the Kotlin 2.4.0-RC2 release.