### PR TITLE
Update supported versions for Kotlin 2.4.0

### DIFF
--- a/docs/topics/gradle/gradle-compiler-options.md
+++ b/docs/topics/gradle/gradle-compiler-options.md
@@ -603,8 +603,8 @@ Here is a complete list of options for the Gradle compiler:
 | `suppressWarnings`    | Don't generate warnings                                                                                                                                                  |                                                         | false         |
 | `verbose`             | Enable verbose logging output. Works only when the [Gradle debug log level enabled](https://docs.gradle.org/current/userguide/logging.html)                              |                                                         | false         |
 | `freeCompilerArgs`    | A list of additional compiler arguments. You can use experimental `-X` arguments here too. See an [example](#example-of-additional-arguments-usage-via-freecompilerargs) |                                                         | []            |
-| `apiVersion`          | Restrict the use of declarations to those from the specified version of bundled libraries                                                                                | "1.9", "2.0", "2.1", "2.2", "2.3", "2.4" (EXPERIMENTAL) |               |
-| `languageVersion`     | Provide source compatibility with the specified version of Kotlin                                                                                                        | "1.9", "2.0", "2.1", "2.2", "2.3", "2.4" (EXPERIMENTAL) |               |
+| `apiVersion`          | Restrict the use of declarations to those from the specified version of bundled libraries                                                                                | "2.0", "2.1", "2.2", "2.3", "2.4", "2.5" (EXPERIMENTAL) |               |
+| `languageVersion`     | Provide source compatibility with the specified version of Kotlin                                                                                                        | "2.0", "2.1", "2.2", "2.3", "2.4", "2.5" (EXPERIMENTAL)  |               |
 
 > We are going to deprecate the attribute `freeCompilerArgs` in future releases. If you miss some option in the Kotlin Gradle DSL,
 > please, [file an issue](https://youtrack.jetbrains.com/newissue?project=kt).

--- a/docs/topics/gradle/gradle-configure-project.md
+++ b/docs/topics/gradle/gradle-configure-project.md
@@ -50,7 +50,8 @@ In the following table, there are the minimum and maximum **fully supported** ve
 
 | KGP version   | Gradle min and max versions           | AGP min and max versions                            |
 |---------------|---------------------------------------|-----------------------------------------------------|
-| 2.3.20–2.3.21 | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 2.4.0         | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% |
+| 2.3.20–2.3.21 | 7.6.3–9.3.0                           | 8.2.2–9.0.0                                         |
 | 2.3.10        | 7.6.3–9.0.0                           | 8.2.2–9.0.0                                         |
 | 2.3.0         | 7.6.3–9.0.0                           | 8.2.2–8.13.0                                        |
 | 2.2.20–2.2.21 | 7.6.3–8.14                            | 7.3.1–8.11.1                                        |

--- a/docs/v.list
+++ b/docs/v.list
@@ -5,51 +5,51 @@
 <vars>
 
     <!-- Kotlin -->
-    <var name="kotlinVersion" value="2.3.21"/>
+    <var name="kotlinVersion" value="2.4.0"/>
     <var name="kotlinReleaseDate" value="April 23, 2026"/>
-    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.3.21"/>
+    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0"/>
     <var name="kotlinLatestWhatsnew" value="whatsnew2320.md"/>
 
-    <var name="languageVersion" value="2.3"/>
-    <var name="apiVersion" value="2.3"/>
+    <var name="languageVersion" value="2.4"/>
+    <var name="apiVersion" value="2.4"/>
 
     <!-- Kotlin EAP -->
     <var name="kotlinEapVersion" value="2.4.0-RC"/>
     <var name="kotlinEapReleaseDate" value="May 13, 2026"/>
 
     <!-- Libraries and Frameworks -->
-    <var name="coroutinesVersion" value="1.10.2"/>
-    <var name="coroutinesEapVersion" value="1.10.2"/>
+    <var name="coroutinesVersion" value="1.11.0"/>
+    <var name="coroutinesEapVersion" value="1.11.0"/>
 
-    <var name="serializationVersion" value="1.10.0"/>
+    <var name="serializationVersion" value="1.11.0"/>
 
     <var name="dateTimeVersion" value="0.8.0"/>
 
     <var name="lincheckVersion" value="3.4"/>
 
-    <var name="ktorVersion" value="3.4.1"/>
+    <var name="ktorVersion" value="3.5.0"/>
 
-    <var name="lombokVersion" value="9.2.0"/>
+    <var name="lombokVersion" value="9.5.0"/>
 
-    <var name="sqlDelightVersion" value="2.2.1"/>
+    <var name="sqlDelightVersion" value="2.3.2"/>
 
     <!-- Gradle, KGP, AGP -->
     <var name="minGradleVersion" value="7.6.3" type="string"/>
-    <var name="maxGradleVersion" value="9.3.0" type="string"/>
+    <var name="maxGradleVersion" value="9.5.0" type="string"/>
 
-    <var name="minAndroidGradleVersion" value="8.2.2" type="string"/>
-    <var name="maxAndroidGradleVersion" value="9.0.0" type="string"/>
+    <var name="minAndroidGradleVersion" value="8.5.2" type="string"/>
+    <var name="maxAndroidGradleVersion" value="9.1.0" type="string"/>
 
-    <var name="gradleVersion" value="9.3.0" type="string"/>
-    <var name="gradleLanguageVersion" value="KOTLIN_2_3" type="string"/>
-    <var name="gradleApiVersion" value="KOTLIN_2_3" type="string"/>
+    <var name="gradleVersion" value="9.5.0" type="string"/>
+    <var name="gradleLanguageVersion" value="KOTLIN_2_4" type="string"/>
+    <var name="gradleApiVersion" value="KOTLIN_2_4" type="string"/>
 
     <!-- Maven -->
     <var name="mavenPluginVersion" value="3.15.0" type="string"/>
     <var name="mavenExtensionsVersion" value="3.10.1" type="string"/>
 
     <!-- KSP -->
-    <var name="kspVersion" value="2.3.7"/>
+    <var name="kspVersion" value="2.3.8"/>
 
     <!-- Spring -->
     <var name="springBootSupportedKotlinVersion" value="2.2.21"/>


### PR DESCRIPTION
This PR updates supported versions for Kotlin 2.4.0 except for Maven, which will be covered in a separate PR.