### PR TITLE
Update `field` keyword for Keywords and operators page

### DIFF
--- a/docs/topics/keyword-reference.md
+++ b/docs/topics/keyword-reference.md
@@ -66,7 +66,9 @@ as identifiers in other contexts:
  * `constructor` declares a [primary or secondary constructor](classes.md#constructors-and-initializer-blocks).
  * `delegate` is used as an [annotation use-site target](annotations.md#annotation-use-site-targets).
  * `dynamic` references a [dynamic type](dynamic-type.md) in Kotlin/JS code.
- * `field` is used as an [annotation use-site target](annotations.md#annotation-use-site-targets).
+ * `field`
+     - declares an [explicit backing field](properties.md#explicit-backing-fields).
+     - is used as an [annotation use-site target](annotations.md#annotation-use-site-targets).
  * `file` is used as an [annotation use-site target](annotations.md#annotation-use-site-targets).
  * `finally` begins a block that [is always executed when a try block exits](exceptions.md).
  * `get`


### PR DESCRIPTION
This PR updates the `field` keyword in the Keywords and operators page since explicit backing fields becomes stable in Kotlin 2.4.0.