### PR TITLE
Add missing Kotlin 2.4.0 documentation

### DIFF
--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -27,7 +27,7 @@ JavaScript code inlining has full support for [ES2015 features](js-project-setup
 * Spread and rest operators
 * Template strings
 
-Because the parameter of `js` is parsed at compile time and translated to JavaScript code "as-is", it is required to be
+Because the parameter of `js` is parsed at compile time and translated to JavaScript code "as-is", it must be
 a string constant. So, the following code is incorrect:
 
 ```kotlin
@@ -48,11 +48,11 @@ fun runSumExample() {
 }
 ```
 
-> Invoking `js()` returns a result of type [`dynamic`](dynamic-type.md), which provides no type safety at compile time.
+> Invoking `js()` returns a result of [`dynamic`](dynamic-type.md) type, which doesn't provide type safety at compile time.
 >
 {style="note"}
 
-## external modifier
+## `external` modifier
 
 To tell Kotlin that a certain declaration is written in pure JavaScript, you should mark it with the `external` modifier.
 When the compiler sees such a declaration, it assumes that the implementation for the corresponding class, function or

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -20,25 +20,26 @@ fun jsTypeOf(o: Any): String {
 
 JavaScript code inlining has full support for [ES2015 features](js-project-setup.md#support-for-es2015-features), including:
 
-* Lambdas ([arrow functions](whatsnew21.md#support-for-generating-es2015-arrow-functions))
-* ES classes
-* Template strings
-* Spread and rest operators
 * `const` and `let` variable declarations
+* ES classes
 * Generators
+* Lambdas ([arrow functions](whatsnew21.md#support-for-generating-es2015-arrow-functions))
+* Spread and rest operators
+* Template strings
 
 Because the parameter of `js` is parsed at compile time and translated to JavaScript code "as-is", it is required to be
 a string constant. So, the following code is incorrect:
 
 ```kotlin
 fun jsTypeOf(o: Any): String {
-    return js(getTypeof() + " o") // error reported here
+    return js(getTypeof() + " o") // Error: Argument must be a string constant
+    // The compiler cannot evaluate string concatenations
 }
 
 fun getTypeof() = "typeof"
 ```
 
-Instead, for example for the rest operator, use:
+Instead, for example to inline the rest operator, use a string constant:
 
 ```kotlin
 fun runSumExample() {

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -41,17 +41,10 @@ fun getTypeof() = "typeof"
 Instead, for example for the spread operator, use:
 
 ```kotlin
-fun spreadExample(): dynamic = js("""
-    const add = (a, b, c) => a + b + c;
-
-    const nums = [1, 2, 3];
-    const sum = add(...nums);
-
-    const a = [1, 2, 3];
-    const b = [...a, 4, 5, 6];
-
-    return { sum, b: b };
-""")
+fun runSpreadExample() {
+    val sum = js("(...nums) => nums.reduce((a, b) => a + b, 0)")
+    println(sum(1, 2, 3, 4))
+}
 ```
 
 > Invoking `js()` returns a result of type [`dynamic`](dynamic-type.md), which provides no type safety at compile time.

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -10,14 +10,22 @@ the surrounding tooling.
 
 ## Inline JavaScript
 
-You can inline JavaScript code into your Kotlin code using the [`js()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.js/js.html) function.
-For example:
+You can inline JavaScript code into your Kotlin code using the [`js()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.js/js.html) function:
 
 ```kotlin
 fun jsTypeOf(o: Any): String {
     return js("typeof o")
 }
 ```
+
+JavaScript code inlining has full support for [ES2015 features](js-project-setup.md#support-for-es2015-features), including:
+
+* Lambdas ([arrow functions](whatsnew21.md#support-for-generating-es2015-arrow-functions))
+* ES classes
+* Template strings
+* Spread operators
+* `const` and `let` variable declarations
+* Generators
 
 Because the parameter of `js` is parsed at compile time and translated to JavaScript code "as-is", it is required to be
 a string constant. So, the following code is incorrect:
@@ -30,12 +38,25 @@ fun jsTypeOf(o: Any): String {
 fun getTypeof() = "typeof"
 ```
 
-> As the JavaScript code is parsed by the Kotlin compiler, not all ECMAScript features might be supported.
-> In this case, you can encounter compilation errors.
-> 
-{style="note"}
+Instead, for example for the spread operator, use:
 
-Note that invoking `js()` returns a result of type [`dynamic`](dynamic-type.md), which provides no type safety at compile time.
+```kotlin
+fun spreadExample(): dynamic = js("""
+    const add = (a, b, c) => a + b + c;
+
+    const nums = [1, 2, 3];
+    const sum = add(...nums);
+
+    const a = [1, 2, 3];
+    const b = [...a, 4, 5, 6];
+
+    return { sum, b: b };
+""")
+```
+
+> Invoking `js()` returns a result of type [`dynamic`](dynamic-type.md), which provides no type safety at compile time.
+>
+{style="note"}
 
 ## external modifier
 

--- a/docs/topics/js/js-interop.md
+++ b/docs/topics/js/js-interop.md
@@ -23,7 +23,7 @@ JavaScript code inlining has full support for [ES2015 features](js-project-setup
 * Lambdas ([arrow functions](whatsnew21.md#support-for-generating-es2015-arrow-functions))
 * ES classes
 * Template strings
-* Spread operators
+* Spread and rest operators
 * `const` and `let` variable declarations
 * Generators
 
@@ -38,10 +38,10 @@ fun jsTypeOf(o: Any): String {
 fun getTypeof() = "typeof"
 ```
 
-Instead, for example for the spread operator, use:
+Instead, for example for the rest operator, use:
 
 ```kotlin
-fun runSpreadExample() {
+fun runSumExample() {
     val sum = js("(...nums) => nums.reduce((a, b) => a + b, 0)")
     println(sum(1, 2, 3, 4))
 }

--- a/docs/topics/js/js-project-setup.md
+++ b/docs/topics/js/js-project-setup.md
@@ -89,13 +89,13 @@ Node.js, there is also an option to use an existing Node.js installation. Learn 
 
 ## Support for ES2015 features
 
-Kotlin provides an [Experimental](components-stability.md#stability-levels-explained) support for the following ES2015
-features:
+Kotlin provides support for ES2015 features, including:
 
 * Modules that simplify your codebase and improve maintainability.
 * Classes that allow incorporating OOP principles, resulting in cleaner and more intuitive code.
 * Generators for compiling [suspend functions](https://kotlinlang.org/docs/composing-suspending-functions.html) that improve the final bundle size
   and help with debugging.
+* [JavaScript code inlining](js-interop.md#inline-javascript).
 
 You can enable all the supported ES2015 features at once by adding the `es2015` compilation target to your
 `build.gradle(.kts)` file:

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -176,9 +176,9 @@ For Kotlin Multiplatform projects, the general rules are:
 * Using `external` interface declarations in common code on the `expect` side is prohibited. Instead, use regular 
   interfaces annotated with `@JsNoRuntime`.
 
-Exporting Kotlin interfaces with `@JsNoRuntime` has some restrictions. The annotation is not allowed with:
+Exporting Kotlin interfaces with `@JsNoRuntime` has some restrictions. The annotation isn't allowed with:
 
-* `external` interfaces as they already behave as if they have `@JsNoRuntime` by default. Adding it will result in a compiler warning.
+* `external` interfaces as they already behave as if they have `@JsNoRuntime` by default. Adding it results in a compiler warning.
 * `is` and `as` type checks.
 * Class references that use the [`::class` syntax](js-reflection.md).
 * Interfaces that are passed as reified type argument.

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -131,7 +131,7 @@ the JavaScript target, and allows you to also export Kotlin declarations that ar
 
 ### `@JsNoRuntime` annotation
 
-You can more export Kotlin interfaces to JavaScript/TypeScript from common code with the `@JsNoRuntime` annotation.
+You can export Kotlin interfaces to JavaScript/TypeScript from common code with the `@JsNoRuntime` annotation.
 It allows for direct mapping to regular TypeScript interfaces.
 
 To export a Kotlin interface from your Kotlin Multiplatform project:

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -172,8 +172,8 @@ To export a Kotlin interface, for example from a Kotlin Multiplatform project:
 For Kotlin Multiplatform projects, the general rules are:
 
 * Both `expect` and `actual` interface declarations must be annotated with `@JsNoRuntime`. The only exception is
-  `external` implementations in platform-specific code on the `actual` side.
-* Using `external` interface declarations in common code on the `expect` side is not recommended. Instead, use regular 
+  `external` implementations in platform-specific code on the `actual` side that require no annotation.
+* Using `external` interface declarations in common code on the `expect` side is prohibited. Instead, use regular 
   interfaces annotated with `@JsNoRuntime`.
 
 Exporting Kotlin interfaces with `@JsNoRuntime` has some restrictions. The annotation is not allowed with:

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -132,12 +132,12 @@ interface Identity {
 
 Currently, the `@JsExport` annotation is the only way to make your functions visible from Kotlin.
 
-`@JsExport` is also available:
+The `@JsExport` annotation is also available:
 
 * In common code in multiplatform projects. It only has an effect when compiling for the JavaScript target and allows you
   to also export Kotlin declarations that are not platform-specific.
 * Together with the [`@JsName` annotation](#jsname-annotation) to specify the names for the generated and exported functions.
-  This helps to resolve ambiguities in exports (like overloads for functions with the same name),
+  This helps to resolve ambiguities in exports (like overloads for functions with the same name).
 * At the file level using `@file:JsExport`.
 
 #### Support for value class export

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -66,7 +66,7 @@ import { foo } from 'myModule';
 alert(foo());
 ```
 
-### @JsName annotation
+### `@JsName` annotation
 
 In some cases (for example, to support overloads), the Kotlin compiler mangles the names of generated functions and attributes
 in JavaScript code. To control the generated names, you can use the `@JsName` annotation:
@@ -110,24 +110,68 @@ The following example produces a compile-time error:
 external fun newC()
 ```
 
-### @JsExport annotation
+### `@JsExport` annotation
+<primary-label ref="experimental-general"/>
 
-> This feature is [Experimental](components-stability.md#stability-levels-explained).
-> Its design may change in future versions.
->
-{style="warning"} 
+By applying the `@JsExport` annotation to a top-level declaration (like a class, interface, or function), you can make
+Kotlin declarations available from JavaScript or TypeScript. The annotation exports all nested declarations with the
+name given in Kotlin.
 
-By applying the `@JsExport` annotation to a top-level declaration (like a class or function), you make the Kotlin
-declaration available from JavaScript. The annotation exports all nested declarations with the name given in Kotlin.
-It can also be applied on file-level using `@file:JsExport`.
+For example, here's how you can export a Kotlin interface with a nested class and a named companion object:
 
-To resolve ambiguities in exports (like overloads for functions with the same name), you can use the `@JsExport`
-annotation together with `@JsName` to specify the names for the generated and exported functions.
+```kotlin
+@JsExport
+interface Identity {
+     class Metadata(val tag: String)
+
+    companion object Registry {
+        val defaultTag = "GUEST"
+    }
+}
+```
 
 Currently, the `@JsExport` annotation is the only way to make your functions visible from Kotlin.
 
-For multiplatform projects, `@JsExport` is available in common code as well. It only has an effect when compiling for
-the JavaScript target, and allows you to also export Kotlin declarations that are not platform specific.
+`@JsExport` is also available:
+
+* In common code in multiplatform projects. It only has an effect when compiling for the JavaScript target and allows you
+  to also export Kotlin declarations that are not platform-specific.
+* Together with the [`@JsName` annotation](#jsname-annotation) to specify the names for the generated and exported functions.
+  This helps to resolve ambiguities in exports (like overloads for functions with the same name),
+* At the file level using `@file:JsExport`.
+
+#### Support for value class export
+
+You can export Kotlin's [inline value classes](inline-classes.md) as regular TypeScript classes.
+
+To export a value class, mark it with the `@JsExport` annotation on the Kotlin side:
+
+```kotlin
+// Kotlin
+@JsExport
+@JvmInline
+value class Email(val address: String) {
+    init { require(address.contains("@")) { "Invalid email" } }
+}
+
+@JsExport
+class AuthService {
+    suspend fun login(email: Email): String = ...
+}
+```
+
+From the TypeScript side, it looks like a regular class:
+
+```typescript
+// TypeScript
+import { AuthService, Email } from "..."
+const auth = new AuthService();
+
+console.log(await auth.login(new Email("jane@example.com"))); 
+// "Welcome, jane@example.com!"
+console.log(await auth.login(new Email("not-an-email"))); 
+// "Invalid email"
+```
 
 ### `@JsNoRuntime` annotation
 

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -131,10 +131,10 @@ the JavaScript target, and allows you to also export Kotlin declarations that ar
 
 ### `@JsNoRuntime` annotation
 
-You can export Kotlin interfaces to JavaScript/TypeScript from common code with the `@JsNoRuntime` annotation.
+You can export Kotlin interfaces to JavaScript/TypeScript with the `@JsNoRuntime` annotation.
 It allows for direct mapping to regular TypeScript interfaces.
 
-To export a Kotlin interface from your Kotlin Multiplatform project:
+To export a Kotlin interface, for example from a Kotlin Multiplatform project:
 
 1. Annotate the Kotlin interface with `@JsNoRuntime` in common code:
 
@@ -169,10 +169,19 @@ To export a Kotlin interface from your Kotlin Multiplatform project:
     }
     ```
 
-> Annotated interfaces can't be used with `is` or `as` operators and for [reflection](js-reflection.md).
-> This way, TypeScript can treat Kotlin interfaces as regular TypeScript interfaces.
->
-{type="note"}
+For Kotlin Multiplatform projects, the general rules are:
+
+* Both `expect` and `actual` interface declarations must be annotated with `@JsNoRuntime`. The only exception is
+  `external` implementations in platform-specific code on the `actual` side.
+* Using `external` interface declarations in common code on the `expect` side is not recommended. Instead, use regular 
+  interfaces annotated with `@JsNoRuntime`.
+
+Exporting Kotlin interfaces with `@JsNoRuntime` has some restrictions. The annotation is not allowed with:
+
+* `external` interfaces as they already behave as if they have `@JsNoRuntime` by default. Adding it will result in a compiler warning.
+* `is` and `as` type checks.
+* Class references that use the [`::class` syntax](js-reflection.md).
+* Interfaces that are passed as reified type argument.
 
 ### `@JsStatic`
 <primary-label ref="experimental-general"/>

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -181,7 +181,7 @@ Exporting Kotlin interfaces with `@JsNoRuntime` has some restrictions. The annot
 * `external` interfaces as they already behave as if they have `@JsNoRuntime` by default. Adding it results in a compiler warning.
 * `is` and `as` type checks.
 * Class references that use the [`::class` syntax](js-reflection.md).
-* Interfaces that are passed as reified type argument.
+* Interfaces that are passed as [reified type argument](inline-functions.md#reified-type-parameters).
 
 ### `@JsStatic`
 <primary-label ref="experimental-general"/>

--- a/docs/topics/js/js-to-kotlin-interop.md
+++ b/docs/topics/js/js-to-kotlin-interop.md
@@ -129,12 +129,53 @@ Currently, the `@JsExport` annotation is the only way to make your functions vis
 For multiplatform projects, `@JsExport` is available in common code as well. It only has an effect when compiling for
 the JavaScript target, and allows you to also export Kotlin declarations that are not platform specific.
 
-### @JsStatic
+### `@JsNoRuntime` annotation
 
-> This feature is [Experimental](components-stability.md#stability-levels-explained). It may be dropped or changed at any time.
-> Use it only for evaluation purposes. We would appreciate your feedback on it in [YouTrack](https://youtrack.jetbrains.com/issue/KT-18891/JS-provide-a-way-to-declare-static-members-JsStatic).
+You can more export Kotlin interfaces to JavaScript/TypeScript from common code with the `@JsNoRuntime` annotation.
+It allows for direct mapping to regular TypeScript interfaces.
+
+To export a Kotlin interface from your Kotlin Multiplatform project:
+
+1. Annotate the Kotlin interface with `@JsNoRuntime` in common code:
+
+    ```kotlin
+    // commonMain
+    import kotlin.js.JsNoRuntime
+    
+    @JsNoRuntime
+    expect interface DataProcessor {
+        fun process(data: String): Int 
+    }
+    ```
+
+2. Provide the actual implementation with `@JsNoRuntime` in your JS-specific source code:
+
+    ```kotlin
+    // jsMain
+    import kotlin.js.JsNoRuntime
+    
+    @JsNoRuntime
+    actual interface DataProcessor {
+        actual fun process(data: String): Int
+    } 
+    ```
+    
+3. On the TypeScript side, the interface will be mapped to a regular TypeScript interface:
+    
+    ```typescript
+    // Generated .d.ts
+    export interface DataProcessor {
+        process(data: string): number;
+    }
+    ```
+
+> Annotated interfaces can't be used with `is` or `as` operators and for [reflection](js-reflection.md).
+> This way, TypeScript can treat Kotlin interfaces as regular TypeScript interfaces.
 >
-{style="warning"}
+{type="note"}
+
+### `@JsStatic`
+<primary-label ref="experimental-general"/>
 
 The `@JsStatic` annotation instructs the compiler to generate additional static methods for the target declaration.
 This helps you use static members from your Kotlin code directly in JavaScript.
@@ -166,6 +207,9 @@ C.Companion.callNonStatic(); // The only way it works
 
 It's also possible to apply the `@JsStatic` annotation to a property of an object or a companion object, making its getter
 and setter methods static members in that object or the class containing the companion object.
+
+This feature is [Experimental](components-stability.md#stability-levels-explained). Share your feedback in our issue tracker,
+[YouTrack](https://youtrack.jetbrains.com/issue/KT-18891/JS-provide-a-way-to-declare-static-members-JsStatic).
 
 ### Use `BigInt` type to represent Kotlin's `Long` type
 <primary-label ref="experimental-general"/>

--- a/docs/topics/native/native-binary-options.md
+++ b/docs/topics/native/native-binary-options.md
@@ -12,7 +12,6 @@ You can enable binary options in the `gradle.properties` file, your build file, 
 You can set binary options in your project's `gradle.properties` file using the `kotlin.native.binary` property. For example:
 
 ```none
-kotlin.native.binary.gc=cms
 kotlin.native.binary.latin1Strings=true
 ```
 
@@ -146,24 +145,24 @@ kotlinc-native main.kt -Xbinary=enableSafepointSignposts=true
         <td>Available since 2.2.0</td>
     </tr>
     <tr>
-        <td><code>gc</code></td>
+        <td><a href="native-memory-manager.md#garbage-collector"><code>gc</code></a></td>
         <td>
             <list>
-                <li><code>pmcs</code> (default)</li>
+                <li><code>cms</code> (default)</li>
+                <li><code>pmcs</code></li>
                 <li><code>stwms</code></li>
-                <li><a href="native-memory-manager.md#optimize-gc-performance"><code>cms</code></a></li>
                 <li><a href="native-memory-manager.md#disable-garbage-collection"><code>noop</code></a></li>
             </list>
         </td>
         <td>Controls garbage collection behavior:
             <list>
+                <li><code>cms</code> uses concurrent mark and sweep</li>
                 <li><code>pmcs</code> uses parallel mark concurrent sweep</li>
                 <li><code>stwms</code> uses simple stop-the-world mark and sweep</li>
-                <li><code>cms</code> enables concurrent marking that helps decrease GC pause time</li>
                 <li><code>noop</code> disables garbage collection</li>
             </list>
         </td>
-        <td><code>cms</code> is Experimental since 2.0.20</td>
+        <td><code>cms</code> is default since 2.4.0</td>
     </tr>
     <tr>
         <td><a href="native-memory-manager.md#garbage-collector"><code>gcMarkSingleThreaded</code></a></td>

--- a/docs/topics/native/native-memory-manager.md
+++ b/docs/topics/native/native-memory-manager.md
@@ -9,15 +9,16 @@ the following features:
 
 ## Garbage collector
 
-Kotlin/Native's garbage collector (GC) algorithm is constantly evolving. Currently, it functions as a stop-the-world mark
-and concurrent sweep collector that does not separate the heap into generations.
+Kotlin/Native's garbage collector (GC) algorithm is constantly evolving. Currently, it functions as a concurrent mark
+and sweep (CMS) collector that does not separate the heap into generations.
 
 The GC is executed on a separate thread and started based on the memory pressure heuristics or by a timer. Alternatively,
 it can be [called manually](#enable-garbage-collection-manually).
 
 The GC processes the mark queue on several threads in parallel, including application threads, the GC thread,
 and optional marker threads. Application threads and at least one GC thread participate in the marking process.
-By default, application threads must be paused when the GC is marking objects in the heap.
+By default, the marking phase runs concurrently with application threads, which decreases the GC pause time.
+You can monitor GC performance [through logs](#monitor-gc-performance).
 
 > You can disable the parallelization of the mark phase with the `kotlin.native.binary.gcMarkSingleThreaded=true` compiler option.
 > However, this may increase the garbage collector's pause time on large heaps.
@@ -27,7 +28,12 @@ By default, application threads must be paused when the GC is marking objects in
 When the marking phase is completed, the GC processes weak references and nullifies reference points to an unmarked object.
 By default, weak references are processed concurrently to decrease the GC pause time.
 
-See how to [monitor](#monitor-gc-performance) and [optimize](#optimize-gc-performance) garbage collection.
+If you face problems with CMS, switch back to parallel mark concurrent sweep (PMCS) setup.
+To do that, set the following [binary option](native-binary-options.md) in your `gradle.properties` file:
+
+```none
+kotlin.native.binary.gc=pmcs
+```
 
 ### Enable garbage collection manually
 
@@ -66,17 +72,6 @@ To track GC-related pauses in your app:
    ![Tracking GC pauses as signposts](native-gc-signposts.png){width=700}
 
    Here, each blue blob on the lowest graph represents a separate signpost event, which is a GC pause.
-
-### Optimize GC performance
-
-To improve GC performance, you can enable concurrent marking to decrease the GC pause time. This allows the marking phase of garbage collection to run simultaneously with application threads.
-
-The feature is currently [Experimental](components-stability.md#stability-levels-explained). To enable it, set the
-following compiler option in your `gradle.properties` file:
-  
-```none
-kotlin.native.binary.gc=cms
-```
 
 ### Disable garbage collection
 

--- a/docs/topics/native/native-memory-manager.md
+++ b/docs/topics/native/native-memory-manager.md
@@ -17,8 +17,8 @@ it can be [called manually](#enable-garbage-collection-manually).
 
 The GC processes the mark queue on several threads in parallel, including application threads, the GC thread,
 and optional marker threads. Application threads and at least one GC thread participate in the marking process.
-By default, the marking phase runs concurrently with application threads, which decreases the GC pause time.
-You can monitor GC performance [through logs](#monitor-gc-performance).
+By default, the marking phase runs concurrently with application threads, which reduces the GC pause time.
+You can monitor GC performance through the [GC logs](#monitor-gc-performance).
 
 > You can disable the parallelization of the mark phase with the `kotlin.native.binary.gcMarkSingleThreaded=true` compiler option.
 > However, this may increase the garbage collector's pause time on large heaps.
@@ -28,7 +28,7 @@ You can monitor GC performance [through logs](#monitor-gc-performance).
 When the marking phase is completed, the GC processes weak references and nullifies reference points to an unmarked object.
 By default, weak references are processed concurrently to decrease the GC pause time.
 
-If you face problems with CMS, switch back to parallel mark concurrent sweep (PMCS) setup.
+If you encounter problems with CMS, switch back to the parallel mark concurrent sweep (PMCS) setup.
 To do that, set the following [binary option](native-binary-options.md) in your `gradle.properties` file:
 
 ```none

--- a/docs/topics/native/native-swift-export.md
+++ b/docs/topics/native/native-swift-export.md
@@ -439,7 +439,7 @@ suspend fun hello(): String {
 let msg = try await hello()
 ```
 
-#### Flow types
+#### Flows
 
 You can also export `kotlinx.coroutines` flows as Swift's [`AsyncSequence`](https://developer.apple.com/documentation/Swift/AsyncSequence):
 
@@ -459,12 +459,14 @@ for try await element in flowOfStrings().asAsyncSequence() {
 }
 ```
 
-#### Dispatcher management
+#### Coroutine dispatchers
 
-By default, when calling a Kotlin `suspend` function from Swift, as well as when using `asAsyncSequence`, a coroutine
-context utilizing the `Default` dispatcher is created on the Kotlin side, and execution is delegated to it.
+By default, when you call a Kotlin suspending function from Swift or use the `asAsyncSequence` function,
+Kotlin creates a coroutine context that uses the [`Dispatchers.Default`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-default.html)
+dispatcher and executes the exported code there.
 
-To run the exported code on a different dispatcher, use `withContext()` to switch the coroutine context in Kotlin:
+To run the exported code on a [different dispatcher](coroutines-basics.md#coroutine-dispatchers), use the `withContext()`
+function to switch the coroutine context in Kotlin. For example:
 
 ```kotlin
 suspend fun runOnMain(): Int = withContext(Dispatchers.Main) {

--- a/docs/topics/native/native-swift-export.md
+++ b/docs/topics/native/native-swift-export.md
@@ -253,9 +253,7 @@ public enum Color: Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.Ra
 
 #### Functions
 
-Swift export supports simple top-level functions and methods, including suspending ones.
-
-##### Regular functions
+Swift export supports simple top-level functions and methods:
 
 ```kotlin
 // Kotlin

--- a/docs/topics/native/native-swift-export.md
+++ b/docs/topics/native/native-swift-export.md
@@ -137,7 +137,7 @@ The table below shows how Kotlin concepts are mapped to Swift.
 | [`typealias`](#type-aliases)               | `typealias`                    |
 | [Function](#functions)                     | Function                       |
 | [`suspend fun`](#suspending-functions)     | `async`                        |
-| [`kotlinx.coroutines`' flows](#flow-types) | `AsyncSequence`                |
+| [`kotlinx.coroutines` flows](#flows) | `AsyncSequence`                |
 | [Property](#properties)                    | Property                       |
 | [Constructor](#constructors)               | Initializer                    |
 | [Package](#packages)                       | Nested enum                    |

--- a/docs/topics/native/native-swift-export.md
+++ b/docs/topics/native/native-swift-export.md
@@ -1,8 +1,8 @@
 [//]: # (title: Interoperability with Swift using Swift export)
 
-<primary-label ref="experimental-general"/>
+<primary-label ref="alpha"/>
 
-Kotlin provides experimental support for Swift export. It allows you to export Kotlin sources
+Kotlin's interoperability with Swift through Swift export is currently in Alpha. Swift export allows you to export Kotlin sources
 directly and call Kotlin code from Swift idiomatically, eliminating the need for Objective-C headers.
 
 Swift export makes multiplatform development for Apple targets more streamlined. For example, if you have a Kotlin module
@@ -22,10 +22,12 @@ Current Swift export features are:
   generated Swift code.
 * **Module name customization**. You can customize the resulting Swift module names in the Gradle configuration of your
   Kotlin project.
+* **Concurrency support**. You can seamlessly call suspending Kotlin code from Swift and export `kotlinx.coroutines`'
+  flows out of the box into Swift's `AsyncSequence`.
 
 ## Enable Swift export
 
-The feature is currently [Experimental](components-stability.md#stability-levels-explained) and not ready for production.
+Swift export is currently in [Alpha](components-stability.md#stability-levels-explained) and is still incomplete, so breaking changes are expected.
 To try it out, [configure the build file](#configure-kotlin-project) in your Kotlin project and [set up Xcode](#configure-xcode-project)
 to integrate Swift export.
 
@@ -102,7 +104,6 @@ Other known issues:
 * Types that inherit from `List`, `Set`, or `Map` are ignored during the export ([KT-80416](https://youtrack.jetbrains.com/issue/KT-80416)).
 * Inheritors of `List`, `Set`, or `Map` cannot be instantiated on the Swift side ([KT-80417](https://youtrack.jetbrains.com/issue/KT-80417)).
 * When exported to Swift, Kotlin generic type parameters are type-erased to their upper bounds.
-* Swift closures can be passed into Kotlin, but Kotlin cannot export functional types to Swift.
 * Cross-language inheritance is not supported, so Swift classes cannot directly subclass from Kotlin-exported classes or
   interfaces.
 * No IDE migration tips or automation are available.
@@ -129,31 +130,33 @@ Other known issues:
 
 The table below shows how Kotlin concepts are mapped to Swift.
 
-| Kotlin                 | Swift                          | Notes                   |
-|------------------------|--------------------------------|-------------------------|
-| `class`                | `class`                        | [note](#classes)        |
-| `object`               | `class` with `shared` property | [note](#objects)        |
-| `enum class`           | `enum`                         | [note](#enums)          |
-| `typealias`            | `typealias`                    | [note](#type-aliases)   |
-| Function               | Function                       | [note](#functions)      |
-| Property               | Property                       | [note](#properties)     |
-| Constructor            | Initializer                    | [note](#constructors)   |
-| Package                | Nested enum                    | [note](#packages)       |
-| `Boolean`              | `Bool`                         |                         |
-| `Char`                 | `Unicode.UTF16.CodeUnit`       |                         |
-| `Byte`                 | `Int8`                         |                         |
-| `Short`                | `Int16`                        |                         |
-| `Int`                  | `Int32`                        |                         |
-| `Long`                 | `Int64`                        |                         |
-| `UByte`                | `UInt8`                        |                         |
-| `UShort`               | `UInt16`                       |                         |
-| `UInt`                 | `UInt32`                       |                         |
-| `ULong`                | `UInt64`                       |                         |
-| `Float`                | `Float`                        |                         |
-| `Double`               | `Double`                       |                         |
-| `Any`                  | `KotlinBase` class             |                         |
-| `Unit`                 | `Void`                         |                         |
-| `Nothing`              | `Never`                        | [note](#kotlin-nothing) |
+| Kotlin                      | Swift                          | Notes                         |
+|-----------------------------|--------------------------------|-------------------------------|
+| `class`                     | `class`                        | [note](#classes)              |
+| `object`                    | `class` with `shared` property | [note](#objects)              |
+| `enum class`                | `enum`                         | [note](#enums)                |
+| `typealias`                 | `typealias`                    | [note](#type-aliases)         |
+| Function                    | Function                       | [note](#functions)            |
+| `suspend fun`               | `async`                        | [note](#suspending-functions) |
+| `kotlinx.coroutines`' flows | `AsyncSequence`                | [note](#flow-types)           |
+| Property                    | Property                       | [note](#properties)           |
+| Constructor                 | Initializer                    | [note](#constructors)         |
+| Package                     | Nested enum                    | [note](#packages)             |
+| `Boolean`                   | `Bool`                         |                               |
+| `Char`                      | `Unicode.UTF16.CodeUnit`       |                               |
+| `Byte`                      | `Int8`                         |                               |
+| `Short`                     | `Int16`                        |                               |
+| `Int`                       | `Int32`                        |                               |
+| `Long`                      | `Int64`                        |                               |
+| `UByte`                     | `UInt8`                        |                               |
+| `UShort`                    | `UInt16`                       |                               |
+| `UInt`                      | `UInt32`                       |                               |
+| `ULong`                     | `UInt64`                       |                               |
+| `Float`                     | `Float`                        |                               |
+| `Double`                    | `Double`                       |                               |
+| `Any`                       | `KotlinBase` class             |                               |
+| `Unit`                      | `Void`                         |                               |
+| `Nothing`                   | `Never`                        | [note](#kotlin-nothing)       |
 
 ### Declarations
 
@@ -251,7 +254,9 @@ public enum Color: Swift.CaseIterable, Swift.LosslessStringConvertible, Swift.Ra
 
 #### Functions
 
-Swift export supports simple top-level functions and methods:
+Swift export supports simple top-level functions and methods, including suspending ones.
+
+##### Regular functions
 
 ```kotlin
 // Kotlin
@@ -296,10 +301,28 @@ fun log(vararg messages: String)
 public func log(messages: Swift.String...)
 ```
 
-> Support for functions with `suspend`, `inline`, and `operator` keywords is currently limited.
+> Support for functions with `inline` and `operator` keywords is currently limited.
 > Generic types are generally not supported.
 >
 {style="note"}
+
+##### Suspending functions
+
+You can call suspending Kotlin code from Swift. Kotlin [`suspend` functions](composing-suspending-functions.md) and
+suspend functional types are exported as Swift's `async` counterparts:
+
+```kotlin
+// Kotlin
+suspend fun hello(): String {
+    delay(1000)
+    return "Hello Swift! This is Kotlin."
+}
+```
+
+```swift
+// Swift
+let msg = try await hello()
+```
 
 #### Properties
 
@@ -380,6 +403,26 @@ public func baz(input: Swift.Never) -> Void {
 }
 ```
 
+##### Flow types
+
+You can export `kotlinx.coroutines`' flows as Swift's [`AsyncSequence`](https://developer.apple.com/documentation/Swift/AsyncSequence):
+
+```kotlin
+// Kotlin
+// Type String is preserved when exporting Flow
+fun flowOfStrings(): Flow<String> = flowOf("hello", "any", "world")
+```
+
+```swift
+// Swift
+var actual: [String] = []
+
+// Type String is correctly inferred from Kotlin
+for try await element in flowOfStrings().asAsyncSequence() {
+    actual.append(element)
+}
+```
+
 #### Classifier types
 
 Swift export currently supports only final classes that directly inherit from `Any`.
@@ -420,9 +463,7 @@ public enum foo {
 ## Evolution of Swift export
 
 We're planning to expand and gradually stabilize Swift export in future Kotlin releases, improving interoperability
-between Kotlin and Swift, particularly around coroutines and flows.
-
-You can leave your feedback:
+between Kotlin and Swift. You can leave your feedback:
 
 * In Kotlin Slack – [get an invite](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up?_gl=1*ju6cbn*_ga*MTA3MTk5NDkzMC4xNjQ2MDY3MDU4*_ga_9J976DJZ68*MTY1ODMzNzA3OS4xMDAuMS4xNjU4MzQwODEwLjYw)
   and join the [#swift-export](https://kotlinlang.slack.com/archives/C073GUW6WN9) channel.

--- a/docs/topics/native/native-swift-export.md
+++ b/docs/topics/native/native-swift-export.md
@@ -100,7 +100,6 @@ IDEA or through the [web wizard](https://kmp.jetbrains.com/).
 
 Other known issues:
 
-* Swift export breaks when modules have the same name in Gradle coordinates, for example SQLDelight's Runtime module and Compose Runtime module ([KT-80185](https://youtrack.jetbrains.com/issue/KT-80185)).
 * Types that inherit from `List`, `Set`, or `Map` are ignored during the export ([KT-80416](https://youtrack.jetbrains.com/issue/KT-80416)).
 * Inheritors of `List`, `Set`, or `Map` cannot be instantiated on the Swift side ([KT-80417](https://youtrack.jetbrains.com/issue/KT-80417)).
 * When exported to Swift, Kotlin generic type parameters are type-erased to their upper bounds.
@@ -130,33 +129,33 @@ Other known issues:
 
 The table below shows how Kotlin concepts are mapped to Swift.
 
-| Kotlin                      | Swift                          | Notes                         |
-|-----------------------------|--------------------------------|-------------------------------|
-| `class`                     | `class`                        | [note](#classes)              |
-| `object`                    | `class` with `shared` property | [note](#objects)              |
-| `enum class`                | `enum`                         | [note](#enums)                |
-| `typealias`                 | `typealias`                    | [note](#type-aliases)         |
-| Function                    | Function                       | [note](#functions)            |
-| `suspend fun`               | `async`                        | [note](#suspending-functions) |
-| `kotlinx.coroutines`' flows | `AsyncSequence`                | [note](#flow-types)           |
-| Property                    | Property                       | [note](#properties)           |
-| Constructor                 | Initializer                    | [note](#constructors)         |
-| Package                     | Nested enum                    | [note](#packages)             |
-| `Boolean`                   | `Bool`                         |                               |
-| `Char`                      | `Unicode.UTF16.CodeUnit`       |                               |
-| `Byte`                      | `Int8`                         |                               |
-| `Short`                     | `Int16`                        |                               |
-| `Int`                       | `Int32`                        |                               |
-| `Long`                      | `Int64`                        |                               |
-| `UByte`                     | `UInt8`                        |                               |
-| `UShort`                    | `UInt16`                       |                               |
-| `UInt`                      | `UInt32`                       |                               |
-| `ULong`                     | `UInt64`                       |                               |
-| `Float`                     | `Float`                        |                               |
-| `Double`                    | `Double`                       |                               |
-| `Any`                       | `KotlinBase` class             |                               |
-| `Unit`                      | `Void`                         |                               |
-| `Nothing`                   | `Never`                        | [note](#kotlin-nothing)       |
+| Kotlin                                     | Swift                          |
+|--------------------------------------------|--------------------------------|
+| [`class`](#classes)                        | `class`                        |
+| [`object`](#objects)                       | `class` with `shared` property |
+| [`enum class`](#enums)                     | `enum`                         |
+| [`typealias`](#type-aliases)               | `typealias`                    |
+| [Function](#functions)                     | Function                       |
+| [`suspend fun`](#suspending-functions)     | `async`                        |
+| [`kotlinx.coroutines`' flows](#flow-types) | `AsyncSequence`                |
+| [Property](#properties)                    | Property                       |
+| [Constructor](#constructors)               | Initializer                    |
+| [Package](#packages)                       | Nested enum                    |
+| `Boolean`                                  | `Bool`                         |
+| `Char`                                     | `Unicode.UTF16.CodeUnit`       |
+| `Byte`                                     | `Int8`                         |
+| `Short`                                    | `Int16`                        |
+| `Int`                                      | `Int32`                        |
+| `Long`                                     | `Int64`                        |
+| `UByte`                                    | `UInt8`                        |
+| `UShort`                                   | `UInt16`                       |
+| `UInt`                                     | `UInt32`                       |
+| `ULong`                                    | `UInt64`                       |
+| `Float`                                    | `Float`                        |
+| `Double`                                   | `Double`                       |
+| `Any`                                      | `KotlinBase` class             |
+| `Unit`                                     | `Void`                         |
+| [`Nothing`](#kotlin-nothing)               | `Never`                        |
 
 ### Declarations
 
@@ -301,28 +300,10 @@ fun log(vararg messages: String)
 public func log(messages: Swift.String...)
 ```
 
-> Support for functions with `inline` and `operator` keywords is currently limited.
-> Generic types are generally not supported.
+> * Support for functions with the [`operator` modifier](operator-overloading.md) is currently limited.
+> * Generic types are generally not supported.
 >
 {style="note"}
-
-##### Suspending functions
-
-You can call suspending Kotlin code from Swift. Kotlin [`suspend` functions](composing-suspending-functions.md) and
-suspend functional types are exported as Swift's `async` counterparts:
-
-```kotlin
-// Kotlin
-suspend fun hello(): String {
-    delay(1000)
-    return "Hello Swift! This is Kotlin."
-}
-```
-
-```swift
-// Swift
-let msg = try await hello()
-```
 
 #### Properties
 
@@ -403,26 +384,6 @@ public func baz(input: Swift.Never) -> Void {
 }
 ```
 
-##### Flow types
-
-You can export `kotlinx.coroutines`' flows as Swift's [`AsyncSequence`](https://developer.apple.com/documentation/Swift/AsyncSequence):
-
-```kotlin
-// Kotlin
-// Type String is preserved when exporting Flow
-fun flowOfStrings(): Flow<String> = flowOf("hello", "any", "world")
-```
-
-```swift
-// Swift
-var actual: [String] = []
-
-// Type String is correctly inferred from Kotlin
-for try await element in flowOfStrings().asAsyncSequence() {
-    actual.append(element)
-}
-```
-
 #### Classifier types
 
 Swift export currently supports only final classes that directly inherit from `Any`.
@@ -457,6 +418,60 @@ public enum foo {
     public enum bar {}
 
     public enum baz {}
+}
+```
+
+### Concurrency
+
+#### Suspending functions
+
+You can call suspending Kotlin code from Swift. Kotlin [`suspend` functions](composing-suspending-functions.md) and
+suspend functional types are exported as Swift's `async` counterparts:
+
+```kotlin
+// Kotlin
+suspend fun hello(): String {
+    delay(1000)
+    return "Hello Swift! This is Kotlin."
+}
+```
+
+```swift
+// Swift
+let msg = try await hello()
+```
+
+#### Flow types
+
+You can also export `kotlinx.coroutines`' flows as Swift's [`AsyncSequence`](https://developer.apple.com/documentation/Swift/AsyncSequence):
+
+```kotlin
+// Kotlin
+// Type String is preserved when exporting Flow
+fun flowOfStrings(): Flow<String> = flowOf("hello", "any", "world")
+```
+
+```swift
+// Swift
+var actual: [String] = []
+
+// Type String is correctly inferred from Kotlin
+for try await element in flowOfStrings().asAsyncSequence() {
+    actual.append(element)
+}
+```
+
+#### Dispatcher management
+
+By default, when calling a Kotlin `suspend` function from Swift, as well as when using `asAsyncSequence`, a coroutine
+context utilizing the `Default` dispatcher is created on the Kotlin side, and execution is delegated to it.
+
+If you want to execute Kotlin code on a different dispatcher, you switch the context manually in Kotlin:
+
+```kotlin
+suspend fun runOnMain(): Int = withContext(Dispatchers.Main) {
+    delay(10L)
+    42
 }
 ```
 

--- a/docs/topics/native/native-swift-export.md
+++ b/docs/topics/native/native-swift-export.md
@@ -22,12 +22,12 @@ Current Swift export features are:
   generated Swift code.
 * **Module name customization**. You can customize the resulting Swift module names in the Gradle configuration of your
   Kotlin project.
-* **Concurrency support**. You can seamlessly call suspending Kotlin code from Swift and export `kotlinx.coroutines`'
-  flows out of the box into Swift's `AsyncSequence`.
+* **Concurrency support**. You can seamlessly call suspending Kotlin code from Swift and export `kotlinx.coroutines`
+  flows as Swift's `AsyncSequence` out of the box.
 
 ## Enable Swift export
 
-Swift export is currently in [Alpha](components-stability.md#stability-levels-explained) and is still incomplete, so breaking changes are expected.
+Swift export is currently in [Alpha](components-stability.md#stability-levels-explained) and still incomplete, so breaking changes are expected.
 To try it out, [configure the build file](#configure-kotlin-project) in your Kotlin project and [set up Xcode](#configure-xcode-project)
 to integrate Swift export.
 
@@ -423,8 +423,8 @@ public enum foo {
 
 #### Suspending functions
 
-You can call suspending Kotlin code from Swift. Kotlin [`suspend` functions](composing-suspending-functions.md) and
-suspend functional types are exported as Swift's `async` counterparts:
+You can call suspending Kotlin code from Swift. Kotlin [suspending functions](coroutines-basics.md#suspending-functions) and
+suspending functional types are exported as Swift's `async` counterparts:
 
 ```kotlin
 // Kotlin
@@ -441,11 +441,11 @@ let msg = try await hello()
 
 #### Flow types
 
-You can also export `kotlinx.coroutines`' flows as Swift's [`AsyncSequence`](https://developer.apple.com/documentation/Swift/AsyncSequence):
+You can also export `kotlinx.coroutines` flows as Swift's [`AsyncSequence`](https://developer.apple.com/documentation/Swift/AsyncSequence):
 
 ```kotlin
 // Kotlin
-// Type String is preserved when exporting Flow
+// Preserves the String type when exporting Flow
 fun flowOfStrings(): Flow<String> = flowOf("hello", "any", "world")
 ```
 
@@ -453,7 +453,7 @@ fun flowOfStrings(): Flow<String> = flowOf("hello", "any", "world")
 // Swift
 var actual: [String] = []
 
-// Type String is correctly inferred from Kotlin
+// Infers the String type from Kotlin
 for try await element in flowOfStrings().asAsyncSequence() {
     actual.append(element)
 }
@@ -464,7 +464,7 @@ for try await element in flowOfStrings().asAsyncSequence() {
 By default, when calling a Kotlin `suspend` function from Swift, as well as when using `asAsyncSequence`, a coroutine
 context utilizing the `Default` dispatcher is created on the Kotlin side, and execution is delegated to it.
 
-If you want to execute Kotlin code on a different dispatcher, you switch the context manually in Kotlin:
+To run the exported code on a different dispatcher, use `withContext()` to switch the coroutine context in Kotlin:
 
 ```kotlin
 suspend fun runOnMain(): Int = withContext(Dispatchers.Main) {

--- a/docs/topics/native/native-target-support.md
+++ b/docs/topics/native/native-target-support.md
@@ -31,9 +31,9 @@ Tier tables have the following columns:
 | Gradle target name      | Target triple                 | Running tests | Description                                                   |
 |-------------------------|-------------------------------|---------------|---------------------------------------------------------------|
 | Apple macOS hosts only: |                               |               |                                                               |
-| `macosArm64`            | `aarch64-apple-macos`         | ✅             | Apple macOS 11.0 and later on Apple Silicon platforms         |
-| `iosSimulatorArm64`     | `aarch64-apple-ios-simulator` | ✅             | Apple iOS simulator 14.0 and later on Apple Silicon platforms |
-| `iosArm64`              | `aarch64-apple-ios`           |               | Apple iOS and iPadOS 14.0 and later on ARM64 platforms        |
+| `macosArm64`            | `aarch64-apple-macos`         | ✅             | Apple macOS 12.0 and later on Apple Silicon platforms         |
+| `iosSimulatorArm64`     | `aarch64-apple-ios-simulator` | ✅             | Apple iOS simulator 15.0 and later on Apple Silicon platforms |
+| `iosArm64`              | `aarch64-apple-ios`           |               | Apple iOS and iPadOS 15.0 and later on ARM64 platforms        |
 
 ### Tier 2
 
@@ -45,11 +45,11 @@ Tier tables have the following columns:
 | `linuxX64`              | `x86_64-unknown-linux-gnu`        | ✅             | Linux on x86_64 platforms                                        |
 | `linuxArm64`            | `aarch64-unknown-linux-gnu`       |               | Linux on ARM64 platforms                                         |
 | Apple macOS hosts only: |                                   |               |                                                                  |
-| `watchosSimulatorArm64` | `aarch64-apple-watchos-simulator` | ✅             | Apple watchOS simulator 7.0 and later on Apple Silicon platforms |
-| `watchosArm32`          | `armv7k-apple-watchos`            |               | Apple watchOS 7.0 and later on ARM32 platforms                   |
-| `watchosArm64`          | `arm64_32-apple-watchos`          |               | Apple watchOS 7.0 and later on ARM64 platforms with ILP32        |
-| `tvosSimulatorArm64`    | `aarch64-apple-tvos-simulator`    | ✅             | Apple tvOS simulator 14.0 and later on Apple Silicon platforms   |
-| `tvosArm64`             | `aarch64-apple-tvos`              |               | Apple tvOS 14.0 and later on ARM64 platforms                     |
+| `watchosSimulatorArm64` | `aarch64-apple-watchos-simulator` | ✅             | Apple watchOS simulator 8.0 and later on Apple Silicon platforms |
+| `watchosArm32`          | `armv7k-apple-watchos`            |               | Apple watchOS 8.0 and later on ARM32 platforms                   |
+| `watchosArm64`          | `arm64_32-apple-watchos`          |               | Apple watchOS 8.0 and later on ARM64 platforms with ILP32        |
+| `tvosSimulatorArm64`    | `aarch64-apple-tvos-simulator`    | ✅             | Apple tvOS simulator 15.0 and later on Apple Silicon platforms   |
+| `tvosArm64`             | `aarch64-apple-tvos`              |               | Apple tvOS 15.0 and later on ARM64 platforms                     |
 
 ### Tier 3
 
@@ -70,8 +70,8 @@ Tier tables have the following columns:
 | `androidNativeX64`      | `x86_64-unknown-linux-android`   |               | [Android NDK](https://developer.android.com/ndk) on x86_64 platforms                     |
 | `mingwX64`              | `x86_64-pc-windows-gnu`          | ✅             | 64-bit Windows 10 and later using [MinGW](https://www.mingw-w64.org) compatibility layer |
 | Apple macOS hosts only: |                                  |               |                                                                                          |
-| `watchosDeviceArm64`    | `aarch64-apple-watchos`          |               | Apple watchOS 7.0 and later on ARM64 platforms                                           |
-| `iosX64`                | `x86_64-apple-ios-simulator`     | ✅             | Apple iOS simulator 14.0 and later on x86-64 platforms                                   |
+| `watchosDeviceArm64`    | `aarch64-apple-watchos`          |               | Apple watchOS 8.0 and later on ARM64 platforms                                           |
+| `iosX64`                | `x86_64-apple-ios-simulator`     | ✅             | Apple iOS simulator 15.0 and later on x86-64 platforms                                   |
 
 > The `linuxArm32Hfp` target is deprecated and will be removed in future releases.
 > 
@@ -81,9 +81,32 @@ Tier tables have the following columns:
 
 Starting with Kotlin 2.3.20, the following targets are deprecated:
 
-* `macosX64` (Apple macOS 11.0 and later on x86_64 platforms)
-* `watchosX64` (Apple watchOS 7.0 and later 64-bit simulator on x86_64 platforms)
-* `tvosX64` (Apple tvOS 14.0 and later simulator on x86_64 platforms)
+* `macosX64` (Apple macOS on x86_64 platforms)
+* `watchosX64` (Apple watchOS 64-bit simulator on x86_64 platforms)
+* `tvosX64` (Apple tvOS simulator on x86_64 platforms)
+
+### Supporting lower Apple target versions
+
+Currently, the default minimum supported versions of Apple targets are:
+
+* For iOS and tvOS, 15.0.
+* For macOS, 12.0.
+* For watchOS, 8.0.
+
+If you need to support a lower version in your project than the default one, use the `freeCompilerArgs` option in your build file:
+
+```kotlin
+kotlin {
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>().configureEach {
+        binaries.configureEach {
+            freeCompilerArgs += "-Xoverride-konan-properties=minVersion.ios=14.0"
+            freeCompilerArgs += "-Xoverride-konan-properties=minVersion.macos=11.0"
+            freeCompilerArgs += "-Xoverride-konan-properties=minVersion.tvos=14.0"
+            freeCompilerArgs += "-Xoverride-konan-properties=minVersion.watchos=8.0"
+        }
+    }
+}
+```
 
 ### For library authors
 

--- a/docs/topics/native/native-target-support.md
+++ b/docs/topics/native/native-target-support.md
@@ -102,7 +102,7 @@ kotlin {
             freeCompilerArgs += "-Xoverride-konan-properties=minVersion.ios=14.0"
             freeCompilerArgs += "-Xoverride-konan-properties=minVersion.macos=11.0"
             freeCompilerArgs += "-Xoverride-konan-properties=minVersion.tvos=14.0"
-            freeCompilerArgs += "-Xoverride-konan-properties=minVersion.watchos=8.0"
+            freeCompilerArgs += "-Xoverride-konan-properties=minVersion.watchos=7.0"
         }
     }
 }

--- a/docs/topics/native/native-target-support.md
+++ b/docs/topics/native/native-target-support.md
@@ -93,7 +93,7 @@ Currently, the default minimum supported versions of Apple targets are:
 * For macOS, 12.0.
 * For watchOS, 8.0.
 
-If you need to support a lower version in your project than the default one, use the `freeCompilerArgs` option in your build file:
+If your project needs to support a version lower than the default one, use the `freeCompilerArgs` option in your build file:
 
 ```kotlin
 kotlin {

--- a/docs/topics/wasm/wasm-configuration.md
+++ b/docs/topics/wasm/wasm-configuration.md
@@ -128,28 +128,17 @@ You can place your new `.mjs` file in the resources folder, and it will automati
 You can also place your `.mjs` file in a custom location. In this case, you need to either manually move it next to the main `.mjs` file or 
 adjust the path in the import statement to match its location.
 
-## Slow Kotlin/Wasm compilation
+## Kotlin/Wasm incremental compilation
 
-When working on Kotlin/Wasm projects, you may experience slow compilation times. This happens because the Kotlin/Wasm 
-toolchain recompiles the entire codebase every time you make a change.
+Kotlin/Wasm targets support incremental compilation, which allows the compiler to recompile only
+the files affected by recent changes. This helps reduce compilation time.
 
-To mitigate this issue, Kotlin/Wasm targets support incremental compilation, which enables the compiler to recompile only 
-those files relevant to changes from the last compilation.
-
-Using incremental compilation reduces the compilation time. It doubles 
-the development speed for now, with plans to improve it further in future releases.
-
-In the current setup, incremental compilation for the Wasm targets is disabled by default.
-To enable it, add the following line to your project's `local.properties` or `gradle.properties` file:
+Incremental compilation for the Wasm targets is enabled by default.
+To disable it, add the following line to your project's `local.properties` or `gradle.properties` file:
 
 ```text
-kotlin.incremental.wasm=true
+kotlin.incremental.wasm=false
 ```
-
-> Try out the Kotlin/Wasm incremental compilation and [share your feedback](https://youtrack.jetbrains.com/issue/KT-72158/Kotlin-Wasm-incremental-compilation-feedback).
-> Your insights help make the feature stable and enabled by default sooner.
->
-{style="note"}
 
 ## Diagnostics in fully qualified class names
 


### PR DESCRIPTION
This PR adds missing commits for Kotlin 2.4.0 documentation.
From PRs:
#5557
#5558 
#5560 
#5562 
#5565 
#5566 
#5567 