### PR TITLE
Fix -XIntrinsic-const-evaluation compiler option naming

### DIFF
--- a/docs/topics/compiler/compiler-reference.md
+++ b/docs/topics/compiler/compiler-reference.md
@@ -201,7 +201,7 @@ The option supports the following modes:
 * `disabled`: disables intra-module inlining for Kotlin/Native, Kotlin/JS, and Kotlin/Wasm.
 * `full`: enables cross-module inlining.
 
-### -XIntrinsic-const-evaluation
+### -Xintrinsic-const-evaluation
 <primary-label ref="experimental-general"/>
 
 Enables [improved compile-time constants](whatsnew24.md#improved-compile-time-constants).

--- a/docs/topics/whatsnew/whatsnew24.md
+++ b/docs/topics/whatsnew/whatsnew24.md
@@ -306,7 +306,7 @@ This feature is [Experimental](components-stability.md#stability-levels-explaine
 ```kotlin
 kotlin {
     compilerOptions {
-        freeCompilerArgs.add("-XIntrinsic-const-evaluation")
+        freeCompilerArgs.add("-Xintrinsic-const-evaluation")
     }
 }
 ```
@@ -322,7 +322,7 @@ kotlin {
             <artifactId>kotlin-maven-plugin</artifactId>
             <configuration>
                 <args>
-                    <arg>-XIntrinsic-const-evaluation</arg>
+                    <arg>-Xintrinsic-const-evaluation</arg>
                 </args>
             </configuration>
         </plugin>


### PR DESCRIPTION
This PR corrects the compiler option naming for `-XIntrinsic-const-evaluation`.