### PR TITLE
Add BKUG to user-groups.yml

### DIFF
--- a/data/user-groups.yml
+++ b/data/user-groups.yml
@@ -34,6 +34,12 @@
     position:
       lat: 54.597285
       lng: -5.93012
+  - name: Belgium KUG
+    country: Belgium
+    url: https://www.meetup.com/belgian-kotlin-user-group/
+    position:
+      lat: 50.8503396
+      lng: 4.3517103
   - name: Berlin KUG
     country: Germany
     url: https://www.meetup.com/kotlin-berlin/


### PR DESCRIPTION
Hi,

This PR adds the [BKUG](https://www.meetup.com/belgian-kotlin-user-group/) to the Kotlin website.
The meetup is organised throughout the entire country too so I picked Brussels (most central province) as the lat/lng location which would be the most useful on the Kotlin Website map.