### PR TITLE
chore(ci): KTL-4590 Docs: Support snippets for non-main docs repos

### DIFF
--- a/.teamcity/documentation/builds/KotlinWithCoroutines.kt
+++ b/.teamcity/documentation/builds/KotlinWithCoroutines.kt
@@ -1,13 +1,10 @@
 package documentation.builds
 
 import documentation.vcsRoots.*
+import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.CheckoutMode
+import jetbrains.buildServer.configs.kotlin.VcsRoot
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
-import jetbrains.buildServer.configs.kotlin.buildSteps.script
-
-//import jetbrains.buildServer.configs.kotlin.BuildType
-//import jetbrains.buildServer.configs.kotlin.FailureAction
-//import jetbrains.buildServer.configs.kotlin.buildSteps.script
 
 object KotlinWithCoroutines: WritersideBuilder(
     module = "kotlin-reference",
@@ -16,29 +13,60 @@ object KotlinWithCoroutines: WritersideBuilder(
         name ="Kotlin Reference with coroutines"
         vcs {
             root(KotlinReferenceRoot, """
-            +:docs => docs
-            +:.git => .git
-            +:.gitmodules => .gitmodules
-        """.trimIndent())
-            root(KotlinxCoroutinesRoot,"""
-            +:docs => kotlinx.coroutines/docs
-            +:.git => kotlinx.coroutines/.git
-        """.trimIndent())
-            root(KotlinxLincheckRoot, """
-            +:docs => kotlinx-lincheck/docs
-            +:.git => kotlinx-lincheck/.git
-        """.trimIndent())
-            root(DokkaRoot, """
-            +:docs => dokka/docs
-            +:.git => dokka/.git
-        """.trimIndent())
-            root(APIGuidelinesRoot, """
-            +:docs => api-guidelines/docs
-            +:.git => api-guidelines/.git
-        """.trimIndent())
+                +:docs => docs
+                +:.git => .git
+                +:.gitmodules => .gitmodules
+            """.trimIndent())
 
             checkoutMode = CheckoutMode.ON_AGENT
             cleanCheckout = true
         }
     }
-)
+) {
+    init {
+        addSubDocumentation("dokka", DokkaRoot)
+        addSubDocumentation("api-guidelines", APIGuidelinesRoot)
+        addSubDocumentation("kotlinx.coroutines", KotlinxCoroutinesRoot)
+        addSubDocumentation("kotlinx-lincheck", KotlinxLincheckRoot, """
+            +:.git => kotlinx-lincheck/.git
+            +:docs => kotlinx-lincheck/docs
+            +:lincheck => kotlinx-lincheck/lincheck
+        """.trimIndent())
+    }
+}
+
+/**
+ * Adds a sub-documentation additional setting to this build type.
+ *
+ * @param checkoutDir the directory to check out the sub-documentation into
+ * @param root the VCS root to use for the sub-documentation
+ * @param rules the checkout rules to use for the sub-documentation
+ */
+private fun BuildType.addSubDocumentation(
+    checkoutDir: String,
+    root: VcsRoot,
+    rules: String? = null,
+    docsDir: String = "$checkoutDir/docs",
+    snippetsDir: String = "$docsDir/snippets"
+) {
+    vcs.root(root, rules ?: """
+        +:.git => $checkoutDir/.git
+        +:docs => $docsDir
+    """.trimIndent())
+
+    steps.items.add(0, ScriptBuildStep {
+        name = "Create docs/snippets for '$checkoutDir'"
+
+        // language=bash
+        scriptContent = """
+            set -e
+            
+            if [ -d "$snippetsDir" ]; then
+                echo "Creating symlink for $snippetsDir"
+                ln -s "$(cd "$snippetsDir" && pwd)"/* "./docs/snippets/"
+            fi
+        """.trimIndent()
+
+        dockerImage = "alpine:latest"
+    })
+}


### PR DESCRIPTION
**Refactoring and simplification:**

* Introduced the `addSubDocumentation` extension function on `BuildType` to encapsulate logic for adding sub-documentation VCS roots and associated checkout rules, reducing code duplication.
* Replaced multiple explicit `root` calls for `KotlinxCoroutinesRoot`, `KotlinxLincheckRoot`, `DokkaRoot`, and `APIGuidelinesRoot` with calls to `addSubDocumentation` in the `init` block, making the code more maintainable and readable.

**Documentation build improvements:**

* For each sub-documentation, added a build step that creates symlinks for documentation snippets if they exist, ensuring that documentation snippets are properly linked during the build.

**Code cleanup:**

* Removed unused imports and commented-out code for clarity and maintainability.