### PR TITLE
Improve description of type parameter inference in generics

### DIFF
--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -14,7 +14,7 @@ To create an instance of such a class, simply provide the type arguments:
 val box: Box<Int> = Box<Int>(1)
 ```
 
-But if the class type parameters can be inferred by the constructor type parameters with the generic signature, for example, from the constructor arguments,
+If the compiler can infer the type arguments, for example, from the constructor arguments, you don’t need to specify them explicitly:
 you can omit the type arguments:
 
 ```kotlin

--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -14,7 +14,7 @@ To create an instance of such a class, simply provide the type arguments:
 val box: Box<Int> = Box<Int>(1)
 ```
 
-But if the parameters can be inferred, for example, from the constructor arguments,
+But if the class type parameters can be inferred by the constructor type parameters with the generic signature, for example, from the constructor arguments,
 you can omit the type arguments:
 
 ```kotlin

--- a/docs/topics/generics.md
+++ b/docs/topics/generics.md
@@ -15,7 +15,6 @@ val box: Box<Int> = Box<Int>(1)
 ```
 
 If the compiler can infer the type arguments, for example, from the constructor arguments, you don’t need to specify them explicitly:
-you can omit the type arguments:
 
 ```kotlin
 val box = Box(1) // 1 has type Int, so the compiler figures out that it is Box<Int>


### PR DESCRIPTION
Clarify the explanation about inferring class type parameters in Kotlin generics differentiating:

1. parameters of the class; 
2. parameters of the constructor by itself;