### PR TITLE
feat: Kotlin 2.4.10-RC eap release details

### DIFF
--- a/docs/topics/eap.md
+++ b/docs/topics/eap.md
@@ -72,4 +72,14 @@ _No preview versions are currently available._
             <p>For more details, refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.20-Beta1">changelog</a> or <a href="whatsnew-eap.md">What's new in Kotlin 2.4.20-Beta1</a>.</p>
         </td>
     </tr>
+    <tr>
+        <td><strong>2.4.10-RC</strong>
+            <p>Released: <strong>June 25, 2026</strong></p>
+            <p><a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.10-RC" target="_blank">Release on GitHub</a></p>
+        </td>
+        <td>
+            <p>A bug fix release with performance improvements for Kotlin 2.4.0.</p>
+            <p>For more details, refer to the <a href="https://github.com/JetBrains/kotlin/releases/tag/v2.4.10-RC">changelog</a>.</p>
+        </td>
+    </tr>
 </table>


### PR DESCRIPTION
This PR adds details about the 2.4.10-RC EAP release.