### PR TITLE
Replace `kotlin` executable with `kotlinr` in CLI docs

### DIFF
--- a/docs/topics/compiler/command-line.md
+++ b/docs/topics/compiler/command-line.md
@@ -102,10 +102,10 @@ kotlinc hello.kt -d hello.jar
 Since binaries compiled this way depend on the Kotlin runtime, 
 you should ensure that it is present in the classpath whenever your compiled library is used.
 
-You can also use the `kotlin` script to run binaries produced by the Kotlin compiler:
+You can also use the `kotlinr` script to run binaries produced by the Kotlin compiler:
 
 ```bash
-kotlin -classpath hello.jar HelloKt
+kotlinr -classpath hello.jar HelloKt
 ```
 
 `HelloKt` is the main class name that the Kotlin compiler generates for the file named `hello.kt`.


### PR DESCRIPTION
In the scope of KT-86930, we're migrating the `kotlin` executable to `kotlinr` to make room for the Kotlin Toolchain. If the `kotlinr` change is merged into 2.4.10, it would be great to update the documentation soon as well. Otherwise, I'll update it for 2.4.20.