### PR TITLE
Update coding conventions for `@Composable`

### DIFF
--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -160,24 +160,24 @@ var declarationCount = 1
 
 ### Named for class-like functions
 
-There are two exceptions in which the name of the function should instead follow the conventions for class names.
+There are two exceptions where function names should follow class-naming convention instead.
 Functions of this kind are usually defined at the top level.
 
-Factory functions used to create instances of classes can have the same name as the abstract return type:
+* Factory functions that create class instances can have the same name as the abstract return type:
 
-```kotlin
-interface Foo { /*...*/ }
+   ```kotlin
+   interface Foo { /*...*/ }
 
-class FooImpl : Foo { /*...*/ }
+   class FooImpl : Foo { /*...*/ }
 
-fun Foo(): Foo { return FooImpl() }
-```
+   fun Foo(): Foo { return FooImpl() }
+   ```
 
-`@Composable` functions returning `Unit`:
+* `@Composable` functions that return `Unit`:
 
-```kotlin
-@Composable fun TabHeader { /*...*/ }
-```
+   ```kotlin
+   @Composable fun TabHeader { /*...*/ }
+   ```
 
 ### Names for test methods
 

--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -158,7 +158,12 @@ fun processDeclarations() { /*...*/ }
 var declarationCount = 1
 ```
 
-Exception: factory functions used to create instances of classes can have the same name as the abstract return type:
+### Named for class-like functions
+
+There are two exceptions in which the name of the function should instead follow the conventions for class names.
+Functions of this kind are usually defined at the top level.
+
+Factory functions used to create instances of classes can have the same name as the abstract return type:
 
 ```kotlin
 interface Foo { /*...*/ }
@@ -166,6 +171,12 @@ interface Foo { /*...*/ }
 class FooImpl : Foo { /*...*/ }
 
 fun Foo(): Foo { return FooImpl() }
+```
+
+`@Composable` functions returning `Unit`:
+
+```kotlin
+@Composable fun TabHeader { /*...*/ }
 ```
 
 ### Names for test methods

--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -158,7 +158,7 @@ fun processDeclarations() { /*...*/ }
 var declarationCount = 1
 ```
 
-### Named for class-like functions
+### Names for class-like functions
 
 There are two exceptions where function names should follow class-naming convention instead.
 Functions of this kind are usually defined at the top level.

--- a/docs/topics/coding-conventions.md
+++ b/docs/topics/coding-conventions.md
@@ -151,7 +151,7 @@ object EmptyDeclarationProcessor : DeclarationProcessor() { /*...*/ }
 
 ### Function names
  
-Names of functions, properties and local variables start with a lowercase letter and use camel case with no underscores:
+Names of functions, properties, and local variables start with a lowercase letter and use camel case without underscores:
 
 ```kotlin
 fun processDeclarations() { /*...*/ }


### PR DESCRIPTION
Fix for [KT-62260](https://youtrack.jetbrains.com/issue/KT-62260).

I've slightly reworked the section to clarify that the two exceptions come from the same core idea: those functions represent "classes" and thus their coding conventions apply.