### PR TITLE
feat(docs): add file-based i18n framework with zh-CN proof-of-concept

### DIFF
--- a/components/LanguageSwitcher/LanguageSwitcher.module.css
+++ b/components/LanguageSwitcher/LanguageSwitcher.module.css
@@ -1,0 +1,32 @@
+.switcher {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.option,
+.active {
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 13px;
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: border-color 0.15s, background-color 0.15s;
+}
+
+.option {
+    color: var(--rs-color-primary, #167dff);
+    border-color: currentColor;
+}
+
+.option:hover {
+    background-color: rgba(22, 125, 255, 0.08);
+}
+
+.active {
+    color: #fff;
+    background-color: var(--rs-color-primary, #167dff);
+    cursor: default;
+    pointer-events: none;
+}

--- a/components/LanguageSwitcher/index.tsx
+++ b/components/LanguageSwitcher/index.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { LOCALES, LOCALE_NAMES, LOCALE_DOC_BASE, DEFAULT_LOCALE, Locale } from '../../i18n/config';
+import styles from './LanguageSwitcher.module.css';
+
+interface LanguageSwitcherProps {
+    slug: string;
+}
+
+function localeDocPath(locale: Locale, slug: string): string {
+    return `${LOCALE_DOC_BASE[locale]}/${slug}`;
+}
+
+export const LanguageSwitcher: FC<LanguageSwitcherProps> = ({ slug }) => {
+    const router = useRouter();
+    // infer current locale from path segment
+    const pathParts = router.asPath.split('/').filter(Boolean);
+    const localeInPath = LOCALES.find(l => l !== DEFAULT_LOCALE && pathParts.includes(l));
+    const current: Locale = localeInPath ?? DEFAULT_LOCALE;
+
+    return (
+        <div className={styles.switcher} aria-label="Language switcher">
+            {LOCALES.map(locale => (
+                <Link
+                    key={locale}
+                    href={localeDocPath(locale, slug)}
+                    className={locale === current ? styles.active : styles.option}
+                    aria-current={locale === current ? 'page' : undefined}
+                >
+                    {LOCALE_NAMES[locale]}
+                </Link>
+            ))}
+        </div>
+    );
+};

--- a/i18n/config.ts
+++ b/i18n/config.ts
@@ -1,0 +1,15 @@
+export const LOCALES = ['en', 'zh-CN'] as const;
+export type Locale = typeof LOCALES[number];
+
+export const DEFAULT_LOCALE: Locale = 'en';
+
+export const LOCALE_NAMES: Record<Locale, string> = {
+    'en': 'English',
+    'zh-CN': '中文（简体）',
+};
+
+// en docs live at the canonical URL (served by existing infra)
+export const LOCALE_DOC_BASE: Record<Locale, string> = {
+    'en': '/docs',
+    'zh-CN': '/docs/zh-CN',
+};

--- a/i18n/zh-CN/docs/topics/getting-started.md
+++ b/i18n/zh-CN/docs/topics/getting-started.md
@@ -1,0 +1,57 @@
+---
+title: Kotlin 入门
+description: Kotlin 是一门现代、简洁、跨平台且与 Java 完全互操作的编程语言。
+---
+
+# Kotlin 入门
+
+**最新 Kotlin 版本**：请访问 [What's new in Kotlin](https://kotlinlang.org/docs/whatsnew-eap.html) 查看最新版本信息。
+
+Kotlin 是一门现代编程语言，简洁、跨平台，并与 Java 及其他语言完全互操作。
+
+刚接触 Kotlin？在浏览器中直接体验 [Kotlin 之旅](https://kotlinlang.org/docs/kotlin-tour-welcome.html)，学习语言基础。
+
+## 安装 Kotlin
+
+Kotlin 已内置于 [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) 和 [Android Studio](https://developer.android.com/studio) 中，下载并安装任意一款 IDE 即可开始使用。
+
+## 选择你的使用场景
+
+### 控制台应用
+
+1. **[使用 IntelliJ IDEA 项目向导创建基础 JVM 应用](https://kotlinlang.org/docs/jvm-get-started.html)**
+2. **[编写你的第一个单元测试](https://kotlinlang.org/docs/jvm-test-using-junit.html)**
+
+### 后端开发
+
+- 将 Kotlin 引入现有 Java 项目：
+  - [配置 Java 项目以支持 Kotlin](https://kotlinlang.org/docs/mixing-java-kotlin-intellij.html)
+  - [在 Java Maven 项目中添加 Kotlin 测试](https://kotlinlang.org/docs/jvm-test-using-junit.html)
+- 从零构建后端应用：
+  - [使用 Spring Boot 创建 RESTful Web 服务](https://kotlinlang.org/docs/jvm-get-started-spring-boot.html)
+  - [使用 Ktor 创建 HTTP API](https://ktor.io/docs/creating-http-apis.html)
+
+### 跨平台移动开发
+
+通过 [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform/get-started.html) 开发跨平台应用：
+
+1. **[搭建跨平台开发环境](https://kotlinlang.org/docs/multiplatform/quickstart.html)**
+2. **创建你的第一个 iOS 与 Android 应用**：
+   - [共享业务逻辑，UI 保持原生](https://kotlinlang.org/docs/multiplatform/multiplatform-create-first-app.html)
+   - [同时共享业务逻辑与 UI](https://kotlinlang.org/docs/multiplatform/compose-multiplatform-create-first-app.html)
+
+### Android 开发
+
+- [Google 推荐使用 Kotlin 进行 Android 开发](https://developer.android.com/kotlin/get-started)
+- [Jetpack Compose 入门](https://developer.android.com/jetpack/compose/tutorial)
+
+### 数据分析
+
+- [在 Jupyter Notebook 中使用 Kotlin](https://kotlinlang.org/docs/data-science-overview.html)
+- [Kotlin DataFrame 数据处理库](https://kotlin.github.io/dataframe/overview.html)
+
+## 接下来学什么？
+
+- [Kotlin 基础语法](https://kotlinlang.org/docs/basic-syntax.html)
+- [Kotlin 惯用法](https://kotlinlang.org/docs/idioms.html)
+- [Kotlin 编码规范](https://kotlinlang.org/docs/coding-conventions.html)

--- a/pages/docs/[locale]/[slug].tsx
+++ b/pages/docs/[locale]/[slug].tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { Markdown } from '../../../utils/mdToHtml';
+import { Layout } from '../../../components/layout/layout';
+import { LanguageSwitcher } from '../../../components/LanguageSwitcher';
+import { LOCALES, DEFAULT_LOCALE, Locale } from '../../../i18n/config';
+
+interface DocPageProps {
+    title: string;
+    description: string;
+    content: string;
+    locale: Locale;
+    slug: string;
+}
+
+const I18N_ROOT = path.join(process.cwd(), 'i18n');
+
+function translatedDocPath(locale: Locale, slug: string): string {
+    return path.join(I18N_ROOT, locale, 'docs', 'topics', `${slug}.md`);
+}
+
+function listTranslatedSlugs(locale: Locale): string[] {
+    const dir = path.join(I18N_ROOT, locale, 'docs', 'topics');
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir)
+        .filter(f => f.endsWith('.md'))
+        .map(f => f.replace(/\.md$/, ''));
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+    const paths: { params: { locale: string; slug: string } }[] = [];
+
+    for (const locale of LOCALES) {
+        if (locale === DEFAULT_LOCALE) continue;
+        for (const slug of listTranslatedSlugs(locale)) {
+            paths.push({ params: { locale, slug } });
+        }
+    }
+
+    return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps<DocPageProps> = async ({ params }) => {
+    const locale = params?.locale as Locale;
+    const slug = params?.slug as string;
+
+    const filePath = translatedDocPath(locale, slug);
+    if (!fs.existsSync(filePath)) return { notFound: true };
+
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const { content, data } = matter(raw);
+
+    return {
+        props: {
+            title: (data.title as string) ?? slug,
+            description: (data.description as string) ?? '',
+            content,
+            locale,
+            slug,
+        },
+    };
+};
+
+export default function LocaleDocPage({ title, description, content, slug }: DocPageProps) {
+    return (
+        <Layout title={title} description={description}>
+            <main style={{ maxWidth: 860, margin: '0 auto', padding: '32px 24px' }}>
+                <LanguageSwitcher slug={slug} />
+                <Markdown>{content}</Markdown>
+            </main>
+        </Layout>
+    );
+}


### PR DESCRIPTION
## Summary

- Introduces a file-based i18n framework that works with Next.js `output: 'export'` (built-in i18n routing is not supported in static export mode)
- Adds `i18n/<locale>/docs/topics/` directory convention for translated Markdown files
- Adds `LanguageSwitcher` component that links between locale variants of a doc page
- Adds `pages/docs/[locale]/[slug].tsx` - a static page generator that expands all translated files into locale-prefixed routes (e.g. `/docs/zh-CN/getting-started`)
- Provides a zh-CN translation of `getting-started.md` as a working proof-of-concept

## Design rationale

Since `next.config.js` uses `output: 'export'`, Next.js built-in i18n routing (which requires a Node server) is unavailable. The file-based approach mirrors how projects like MDN and Django docs handle static i18n: each locale lives in its own directory tree, and missing translations fall back to the default locale at the canonical URL. English docs continue to be served at their existing URLs unchanged.

## How to add a new locale or translation

1. Add the locale to `LOCALES` in `i18n/config.ts`
2. Create `i18n/<locale>/docs/topics/<slug>.md` with standard Markdown + YAML frontmatter (`title`, `description`)
3. The page at `/docs/<locale>/<slug>` is generated automatically at build time

## Files changed

| File | Purpose |
|---|---|
| `i18n/config.ts` | Locale registry and display names |
| `i18n/zh-CN/docs/topics/getting-started.md` | zh-CN translation of the getting-started doc |
| `components/LanguageSwitcher/index.tsx` | Language toggle UI |
| `components/LanguageSwitcher/LanguageSwitcher.module.css` | Switcher styles |
| `pages/docs/[locale]/[slug].tsx` | Static page handler for all locale/slug combinations |