### PR TITLE
feat: add memory allocation details for SAM conversions

### DIFF
--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -62,6 +62,25 @@ fun main() {
 ```
 {kotlin-runnable="true" kotlin-min-compiler-version="1.4"}
 
+### Memory allocation
+
+The memory allocation behavior of a SAM conversion depends on whether the lambda captures variables from its surrounding
+scope.
+
+A _non-capturing lambda_ doesn't reference external variables. The Kotlin compiler optimizes these lambdas into
+singletons. It instructs the runtime to allocate the instance only once and reuse it on every evaluation of the lambda
+expression, keeping it in memory for the application lifecycle, just like an `object` declaration.
+
+A _capturing lambda_ references variables from outside its scope. In this case, the compiler can't perform the singleton
+optimization. It instructs the runtime to allocate a new instance on every evaluation of the lambda expression because
+it can't share the captured state across multiple instances.
+
+> If you instantiate the interface using an anonymous object (`object : IntPredicate { ... }`), you bypass this
+> optimization entirely. The anonymous object syntax always instructs the runtime to allocate a new instance on every
+> evaluation of the expression, regardless of whether you capture any variables.
+>
+{style="note"}
+
 You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conversions).
 
 ## Migration from an interface with constructor function to a functional interface


### PR DESCRIPTION
This PR adds a new section explaining the memory allocation behavior when using SAM conversions. 

I am not exactly sure if ~~this should have been~~ I should have placed this in the lambdas page or here, but since I was using SAM and got to know about the allocation from Baeldung, there might be common cases where this explicit explanation might make sense alongside the usual anonymous object's allocation.