### PR TITLE
Add kotlinx-collections-immutable library to components stability table

### DIFF
--- a/docs/topics/components-stability.md
+++ b/docs/topics/components-stability.md
@@ -96,15 +96,16 @@ to avoid the accidental use of features that have not been released as stable.
 
 ### Kotlin libraries
 
-| **Component**         | **Status** | **Status since version** | **Comments** |
-|-----------------------|------------|--------------------------|--------------|
-| kotlin-stdlib (JVM)   | Stable     | 1.0.0                    |              |
-| kotlinx-coroutines    | Stable     | 1.3.0                    |              |
-| kotlinx-serialization | Stable     | 1.0.0                    |              |
-| kotlin-metadata-jvm   | Stable     | 2.0.0                    |              |
-| kotlin-reflect (JVM)  | Beta       | 1.0.0                    |              |
-| kotlinx-datetime      | Alpha      | 0.2.0                    |              |
-| kotlinx-io            | Alpha      | 0.2.0                    |              |
+| **Component**                 | **Status** | **Status since version** | **Comments** |
+|-------------------------------|------------|--------------------------|--------------|
+| kotlin-stdlib (JVM)           | Stable     | 1.0.0                    |              |
+| kotlinx-coroutines            | Stable     | 1.3.0                    |              |
+| kotlinx-serialization         | Stable     | 1.0.0                    |              |
+| kotlin-metadata-jvm           | Stable     | 2.0.0                    |              |
+| kotlin-reflect (JVM)          | Beta       | 1.0.0                    |              |
+| kotlinx-datetime              | Alpha      | 0.2.0                    |              |
+| kotlinx-io                    | Alpha      | 0.2.0                    |              |
+| kotlinx-collections-immutable | Alpha      | 0.3.5                    |              |
 
 ### Kotlin Multiplatform
 


### PR DESCRIPTION
This PR adds the kotlinx-collections-immutable library to the components stability table.