### PR TITLE
Remove note about 2026.2 in whatsnew24.md

### DIFF
--- a/docs/topics/whatsnew/whatsnew24.md
+++ b/docs/topics/whatsnew/whatsnew24.md
@@ -97,10 +97,6 @@ For more information, see [KT-30155](https://youtrack.jetbrains.com/issue/KT-301
 
 <secondary-label ref="language"/>
 
-> Support for using explicit context arguments for context parameters in IntelliJ IDEA will be available in 2026.2.
-> 
-{style="note"}
-
 Kotlin 2.4.0 introduces explicit context arguments for [context parameters](context-parameters.md).
 
 Kotlin 2.3.20 [changed the overload resolution for context parameters](whatsnew2320.md#changes-to-overload-resolution-for-context-parameters).


### PR DESCRIPTION
This PR removes a note about What's new in Kotlin 2.4.0 that says a feature will receive IDE support in 2026.2. This IDE release is now available so the note isn't needed anymore.