### PR TITLE
Update KUG MUC URL

### DIFF
--- a/data/user-groups.yml
+++ b/data/user-groups.yml
@@ -180,7 +180,7 @@
       lng: -0.1277583
   - name: Munich KUG
     country: Germany
-    url: https://www.meetup.com/Kotlin-User-Group-Munich/
+    url: https://www.meetup.com/kotlin-munich/
     position:
       lat: 48.1351253
       lng: 11.5819806


### PR DESCRIPTION
Unfortunately, we had to recreate our user group from scratch and couldn't take over the old URL, this update reflects that.