### PR TITLE
KTL-4552 PDF can't generate images with @ in filename

### DIFF
--- a/scripts/pdf/generate-pdf.js
+++ b/scripts/pdf/generate-pdf.js
@@ -91,6 +91,20 @@ function fixImageLinks(content) {
     /data-dark-src="images\/(https?:\/\/[^"]+)"/g,
     (match, url) => `data-dark-src="${url}"`
   );
+
+  // Decode "@" that Writerside percent-encodes as "%40" in local image paths
+  content = content.replace(
+    /(src|data-dark-src)="(images\/[^"]*)"/g,
+    (match, attr, value) => {
+      if (!value.includes('%40')) {
+        return match;
+      }
+      const fixed = value.replace(/%40/g, '@');
+      console.log(`Fix image link "${value}" -> "${fixed}"`);
+      return `${attr}="${fixed}"`;
+    }
+  );
+
   return content;
 }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-4552/PDF-cant-generate-images-with-in-filename

Here's how the image with `@` is displayed:
<img width="1013" height="591" alt="Screenshot 2026-07-28 at 12 48 37" src="https://github.com/user-attachments/assets/1da7fb59-bbc6-4a1b-82cb-56ff22b3afbb" />
