### PR TITLE
fix: remove redirect in pages.yml and fix link in ksp-overview.md

### DIFF
--- a/docs/topics/ksp/ksp-overview.md
+++ b/docs/topics/ksp/ksp-overview.md
@@ -160,7 +160,7 @@ class HelloFunctionFinderProcessor : SymbolProcessor() {
 * [Incremental processing notes](ksp-incremental.md)
 * [Multiple round processing notes](ksp-multi-round.md)
 * [KSP on multiplatform projects](ksp-multiplatform.md)
-* [Running KSP from command line](https://github.com/google/ksp/blob/main/docs/ksp2cmdline.md)
+* [Running KSP from command line](ksp-command-line.md)
 * [FAQ](ksp-faq.md)
 
 ## Supported libraries

--- a/redirects/pages.yml
+++ b/redirects/pages.yml
@@ -859,6 +859,3 @@
 
 - from: /docs/multiplatform/choosing-web-target.html
   to: /docs/web-overview.html
-
-- from: /docs/ksp-command-line.html
-  to: https://github.com/google/ksp/blob/main/docs/ksp2cmdline.md


### PR DESCRIPTION
Remove redirection and add link to ksp-command-line.md from ksp-overview.md

Part of [KEDOC-236](https://youtrack.jetbrains.com/issue/KEDOC-236/Create-new-KSP-CLI-article)