### PR TITLE
chore: replace the snippet folder for Lincheck docs

### DIFF
--- a/.teamcity/documentation/builds/KotlinWithCoroutines.kt
+++ b/.teamcity/documentation/builds/KotlinWithCoroutines.kt
@@ -34,7 +34,7 @@ object KotlinWithCoroutines: WritersideBuilder(
         addSubDocumentation("kotlinx-lincheck", KotlinxLincheckRoot, """
             +:.git => kotlinx-lincheck/.git
             +:docs => kotlinx-lincheck/docs
-            +:lincheck => kotlinx-lincheck/lincheck
+            +:examples => kotlinx-lincheck/examples
         """.trimIndent())
     }
 }


### PR DESCRIPTION
Change the snippet folder for Lincheck to [`examples`](https://github.com/JetBrains/lincheck/tree/master/examples)