### PR TITLE
chore: update developers list in the CODEOWNERS 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @zoobestik @nikpachoo @krutilov @berezinant
+* @JetBrains/kotlinlang-code-reviewer
 
 # Community events
 /data/events.yml @MKrishtal @meilalina


### PR DESCRIPTION
Assigning a group will enable round-robin auto-assignment.

