### PR TITLE
Do not render courses without a URL as links

### DIFF
--- a/blocks/education/courses-list/courses-list.tsx
+++ b/blocks/education/courses-list/courses-list.tsx
@@ -34,9 +34,13 @@ export const CoursesList: FC<CoursesListProps> = ({ universities }) => {
                     <div className={cn(styles.cell, styles.cellSecond)}>{university.location}</div>
                     <div className={cn(styles.cell, styles.cellThird)}>
                         {university.courses.map((course) => (
-                            <a className={textCn('rs-link', { external: true, hardness: 'hard' })} href={course.url} target="_blank" rel="noopener noreferrer" key={`${course.name}-${course.url}`}>
-                                {course.name}
-                            </a>
+                            course.url ? (
+                                <a className={textCn('rs-link', { external: true, hardness: 'hard' })} href={course.url} target="_blank" rel="noopener noreferrer" key={`${course.name}-${course.url}`}>
+                                    {course.name}
+                                </a>
+                            ) : (
+                                <div key={`${course.name}-${course.url}`}>{course.name}</div>
+                            )
                         ))}
                     </div>
                 </div>

--- a/test/e2e/teach/courses.spec.ts
+++ b/test/e2e/teach/courses.spec.ts
@@ -100,5 +100,14 @@ test.describe('Courses page appearance and functionality', async () => {
         await checkTeachMap(page, map);
     });
 
+    test('Should not render courses without a URL as links', async ({ page }) => {
+        // an empty url in data/universities.yml used to produce <a href=""
+        // target="_blank">, which reopens the courses page in a new tab
+        const emptyLinks = await page.locator('a[target="_blank"]').evaluateAll(
+            (anchors) => anchors.filter((anchor) => !anchor.getAttribute('href')).length
+        );
+        expect(emptyLinks).toBe(0);
+    });
+
     test('Should have action buttons for educators', checkTeachCta);
 });


### PR DESCRIPTION
### Problem

On [the courses page](https://kotlinlang.org/education/courses.html), 96 course entries look like links but lead back to the same page.

`data/universities.yml` has 502 course entries and 96 of them carry an empty url:

```yaml
- title: University of Oxford
  location: Oxford, UK
  courses:
  - name: 'Agile Engineering Practices'
    url: ''
```

`blocks/education/courses-list/courses-list.tsx` renders every entry as an anchor, without checking:

```tsx
<a className={textCn('rs-link', { external: true, hardness: 'hard' })}
   href={course.url} target="_blank" rel="noopener noreferrer">
```

So the markup ends up as `<a href="" target="_blank">`. An empty href resolves to the current document, and with `target="_blank"` the click opens a second copy of the courses list in a new tab. The `external: true` styling means these look exactly like the working links next to them.

Counted on the live page just now:

```js
[...document.querySelectorAll('a')]
  .filter(a => !a.getAttribute('href') && a.getAttribute('target') === '_blank').length
// 96, out of 553 anchors on the page
```

Oxford, NYU, University of Cauca and 93 others are affected.

The schema does not catch it: `data/schemas/universities.json` marks url as `"format": "uri"`, and `format` is an annotation in draft-04, not a constraint. An empty string passes.

### Change

Render the course name as plain text when there is no url. One condition in the component, so the same thing cannot come back with the next data update.

I did not touch `data/universities.yml`. Filling in 96 real course URLs is not something I can do without guessing, and the component should not produce a broken link either way.

### Test

Added to `test/e2e/teach/courses.spec.ts`, next to your existing checks for that page: no `target="_blank"` anchor may be missing its href.

It guards the actual bug rather than the fix. Run against the current production page it returns 96 and fails; with this change it returns 0.

### What I could not run

The e2e suite needs the Docker setup from `scripts/test/up.sh` and I did not stand it up, so I have not executed the suite. Both changed files parse clean through esbuild. Saying this plainly rather than implying a run I did not do.

### One question

Would you like the schema tightened too, so an empty url cannot be committed again? `"minLength": 1` would do it, but it would fail the validation workflow on the 96 rows already in the file, so it only makes sense together with a data cleanup. Happy to do either, or both, if you say which.
