### PR TITLE
fix: correct comment in functions.md

### DIFF
--- a/docs/topics/functions.md
+++ b/docs/topics/functions.md
@@ -527,7 +527,7 @@ class MyStringCollection {
 
 fun main() {
     val myStrings = MyStringCollection()
-    // Adds "first" and "second" to the list twice
+    // Adds "first" and "second" to the list
     myStrings.build()
       
     myStrings.printAll()


### PR DESCRIPTION
Thanks for the great docs.

This example comment incorrectly says items are added to a list `twice`.  

Output of running the example:
```
Adding: first
Adding: second
Items = [first, second]
```

