### PR TITLE
feat: new compilation filter for Power-assert

### DIFF
--- a/docs/topics/compiler-plugins/power-assert.md
+++ b/docs/topics/compiler-plugins/power-assert.md
@@ -63,13 +63,16 @@ plugins {
 
 The Power-assert plugin provides several options to customize its behavior:
 
-* **`functions`** lists fully qualified paths to functions whose calls the Power-assert plugin transforms. If not specified, only `kotlin.assert()` calls are transformed.
-* **`compilationFilter`** controls which Kotlin compilations the Power-assert plugin is applied to. You can create your own custom filter or use the predefined options:
+* **`functions`** lists the fully qualified paths to functions that the Power-assert plugin transforms when they're called.
+  If not specified, the plugin transforms only `kotlin.assert()` calls.
+* **`compilationFilter`** controls which Kotlin compilations the Power-assert plugin is applied to. You can create your
+  own custom filter or use the predefined options:
   * `PowerAssertCompilationFilter.TESTS` applies to all test source sets (default).
   * `PowerAssertCompilationFilter.ALL` applies to all source sets.
 
-  > The `compilationFilter` option has replaced the deprecated `includedSourceSets`, which listed Gradle source sets that the Power-assert plugin transforms.
-  > These two options are mutually exclusive: if `includedSourceSets` is specified, `compilationFilter` is ignored.
+  > The `compilationFilter` option has replaced the deprecated `includedSourceSets`, which listed Gradle source sets that
+  > the Power-assert plugin transforms. These two options are mutually exclusive: if `includedSourceSets` is specified,
+  > `compilationFilter` is ignored.
   >
   {style="note"}
 

--- a/docs/topics/compiler-plugins/power-assert.md
+++ b/docs/topics/compiler-plugins/power-assert.md
@@ -66,7 +66,7 @@ The Power-assert plugin provides several options to customize its behavior:
 * **`functions`** lists fully qualified paths to functions whose calls the Power-assert plugin transforms. If not specified, only `kotlin.assert()` calls are transformed.
 * **`compilationFilter`** controls which Kotlin compilations the Power-assert plugin is applied to. You can create your own custom filter or use the predefined options:
   * `PowerAssertCompilationFilter.TESTS` applies to all test source sets (default).
-  * `PowerAssertCompilationFilter.ALL` – applies to all source sets.
+  * `PowerAssertCompilationFilter.ALL` applies to all source sets.
 
   > The `compilationFilter` option has replaced the deprecated `includedSourceSets`, which listed Gradle source sets that the Power-assert plugin transforms.
   > These two options are mutually exclusive: if `includedSourceSets` is specified, `compilationFilter` is ignored.

--- a/docs/topics/compiler-plugins/power-assert.md
+++ b/docs/topics/compiler-plugins/power-assert.md
@@ -64,8 +64,14 @@ plugins {
 The Power-assert plugin provides several options to customize its behavior:
 
 * **`functions`** lists fully qualified paths to functions whose calls the Power-assert plugin transforms. If not specified, only `kotlin.assert()` calls are transformed.
-* **`includedSourceSets`** lists Gradle source sets that the Power-assert plugin transforms. If not specified, all _test source sets_ are transformed.
-* **`compilationFilter`** controls if the Power-assert plugin is applied to all Kotlin compilations or only to test compilations. If not specified, the plugin is applied to all compilations.
+* **`compilationFilter`** controls which Kotlin compilations the Power-assert plugin is applied to. You can create your own custom filter or use the predefined options:
+  * `PowerAssertCompilationFilter.TESTS` applies to all test source sets (default).
+  * `PowerAssertCompilationFilter.ALL` – applies to all source sets.
+
+  > The `compilationFilter` option has replaced the deprecated `includedSourceSets`, which listed Gradle source sets that the Power-assert plugin transforms.
+  > These two options are mutually exclusive: if `includedSourceSets` is specified, `compilationFilter` is ignored.
+  >
+  {style="note"}
 
 To customize the behavior, add the `powerAssert {}` block to your build script file:
 
@@ -76,8 +82,9 @@ To customize the behavior, add the `powerAssert {}` block to your build script f
 // build.gradle.kts
 powerAssert {
     functions = listOf("kotlin.assert", "kotlin.test.assertTrue", "kotlin.test.assertEquals", "kotlin.test.assertNull")
-    includedSourceSets = listOf("commonMain", "jvmMain", "jsMain", "nativeMain")
-    compilationFilter = PowerAssertCompilationFilter.TESTS
+    compilationFilter = PowerAssertCompilationFilter {
+        it.name in setOf("commonMain", "jvmMain", "jsMain", "nativeMain")
+    }
 }
 ```
 
@@ -88,8 +95,9 @@ powerAssert {
 // build.gradle
 powerAssert {
     functions = ["kotlin.assert", "kotlin.test.assertTrue", "kotlin.test.assertEquals", "kotlin.test.assertNull"]
-    includedSourceSets = ["commonMain", "jvmMain", "jsMain", "nativeMain"]
-    compilationFilter = PowerAssertCompilationFilter.TESTS
+    compilationFilter = PowerAssertCompilationFilter {
+        it.name in ["commonMain", "jvmMain", "jsMain", "nativeMain"]
+    }
 }
 ```
 

--- a/docs/topics/compiler-plugins/power-assert.md
+++ b/docs/topics/compiler-plugins/power-assert.md
@@ -63,8 +63,9 @@ plugins {
 
 The Power-assert plugin provides several options to customize its behavior:
 
-* **`functions`**: A list of fully-qualified function paths. The Power-assert plugin will transform the calls to these functions. If not specified, only `kotlin.assert()` calls will be transformed by default.
-* **`includedSourceSets`**: A list of Gradle source sets that the Power-assert plugin will transform. If not specified, all _test source sets_ will be transformed by default.
+* **`functions`** lists fully qualified paths to functions whose calls the Power-assert plugin transforms. If not specified, only `kotlin.assert()` calls are transformed.
+* **`includedSourceSets`** lists Gradle source sets that the Power-assert plugin transforms. If not specified, all _test source sets_ are transformed.
+* **`compilationFilter`** controls if the Power-assert plugin is applied to all Kotlin compilations or only to test compilations. If not specified, the plugin is applied to all compilations.
 
 To customize the behavior, add the `powerAssert {}` block to your build script file:
 
@@ -76,6 +77,7 @@ To customize the behavior, add the `powerAssert {}` block to your build script f
 powerAssert {
     functions = listOf("kotlin.assert", "kotlin.test.assertTrue", "kotlin.test.assertEquals", "kotlin.test.assertNull")
     includedSourceSets = listOf("commonMain", "jvmMain", "jsMain", "nativeMain")
+    compilationFilter = PowerAssertCompilationFilter.TESTS
 }
 ```
 
@@ -87,6 +89,7 @@ powerAssert {
 powerAssert {
     functions = ["kotlin.assert", "kotlin.test.assertTrue", "kotlin.test.assertEquals", "kotlin.test.assertNull"]
     includedSourceSets = ["commonMain", "jvmMain", "jsMain", "nativeMain"]
+    compilationFilter = PowerAssertCompilationFilter.TESTS
 }
 ```
 


### PR DESCRIPTION
This PR adds the info on the new `compilationFilter` option ([KT-84811](https://youtrack.jetbrains.com/issue/KT-84811))