### PR TITLE
chore(ci): update VCS root to use monorepo configuration

### DIFF
--- a/.teamcity/documentation/builds/WritersideBuilder.kt
+++ b/.teamcity/documentation/builds/WritersideBuilder.kt
@@ -13,7 +13,7 @@ abstract class WritersideBuilder(
     customInit: BuildType.() -> Unit = {},
     postProcessAdditions: String = postProcessingScript(),
 ) : BuildType({
-    val dockerImageTag = "2.1.2245-p8929" // stable-2026.07 + KTL-4152
+    val dockerImageTag = "ked-websites-stable"
     val frontend = "file:///opt/static/"
 
     name = "${instance.uppercase()} documentation build"
@@ -71,6 +71,7 @@ abstract class WritersideBuilder(
                 bash -euo pipefail /usr/local/bin/script.sh
             """.trimIndent()
             dockerImage = "registry.jetbrains.team/p/writerside/builder/writerside-builder:$dockerImageTag"
+            dockerPull = true
             dockerRunParameters = """
                 --rm -v %teamcity.build.checkoutDir%:/opt/sources
                 -v %teamcity.build.checkoutDir%/static:/opt/static

--- a/.teamcity/kotlinlang/builds/BuildWebHelpFrontend.kt
+++ b/.teamcity/kotlinlang/builds/BuildWebHelpFrontend.kt
@@ -9,8 +9,8 @@ object BuildWebHelpFrontend : BuildType({
   name = "Webhelp Frontend"
 
   artifactRules = """
-        build/** => static.zip
-        -:build/*.map=>static.zip
+        webhelp/build/** => static.zip
+        -:webhelp/build/*.map => static.zip
     """.trimIndent()
 
   params {
@@ -18,18 +18,24 @@ object BuildWebHelpFrontend : BuildType({
   }
 
   vcs {
-    root(WebHelp)
+    root(WebHelp, """
+      +:webhelp
+    """.trimIndent())
   }
 
   steps {
     script {
+      // language=sh
       scriptContent = """
+        PACKAGE_MANAGER_VERSION=$(node -e "console.log(JSON.parse(fs.readFileSync('./package.json').toString()).packageManager)")
+        
         corepack enable
-        corepack prepare pnpm@latest --activate
+        corepack prepare "${'$'}PACKAGE_MANAGER_VERSION" --activate
         
         pnpm i --no-frozen-lockfile
         pnpm run build:kotlin
       """.trimIndent()
+      workingDir = "webhelp"
       formatStderrAsError = true
       dockerImage = "node:18-alpine"
     }

--- a/.teamcity/kotlinlang/vcsRoots/WebHelp.kt
+++ b/.teamcity/kotlinlang/vcsRoots/WebHelp.kt
@@ -4,7 +4,7 @@ import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 
 object WebHelp : GitVcsRoot({
   name = "webhelp"
-  url = "ssh://git@git.jetbrains.team/writerside/writerside-webhelp.git"
+  url = "ssh://git@git.jetbrains.team/writerside/writerside-monorepo.git"
   branch = "refs/heads/ked-websites-stable"
   branchSpec = """
         refs/heads/(*)


### PR DESCRIPTION
**Writerside documentation build improvements:**

* Changed the Docker image tag in `WritersideBuilder` to use `ked-websites-stable` for more consistent builds.
* Added `dockerPull = true` to always pull the latest Docker image before building, ensuring up-to-date build environments.

**WebHelp frontend build enhancements:**

* Updated the VCS root for `WebHelp` to point to the `writerside-monorepo` repository.
* Scoped the VCS checkout to only the `webhelp` directory, reducing unnecessary files in the build context.
* Modified the frontend build script to dynamically use the package manager version specified in `package.json`, ensuring compatibility with the project's configuration. Also set the working directory to `webhelp` for the build step.