### PR TITLE
Correct typo in this-expressions documentation

### DIFF
--- a/docs/topics/this-expressions.md
+++ b/docs/topics/this-expressions.md
@@ -135,7 +135,7 @@ Here:
 
 ### Access from a lambda
 
-Unlike a regular lambda, a [lambda with receiver](lambdas.md#function-literals-with-receiver)￼introduces a receiver into its scope.
+Unlike a regular lambda, a [lambda with receiver](lambdas.md#function-literals-with-receiver) introduces a receiver into its scope.
 As a result, `this` inside the lambda refers to the lambda's receiver, not to one from an enclosing scope.
 If a lambda with receiver is nested inside another receiver scope, add a label to the lambda and use a qualified `this`
 to refer explicitly to the lambda's receiver or to a receiver from an enclosing scope:


### PR DESCRIPTION
Fix typo in explanation of lambda with receiver.

### Before
<img width="2266" height="300" alt="Xnip2026-08-12_08-45-52" src="https://github.com/user-attachments/assets/a66b364d-de58-4114-805d-b4784b259ff3" />

### After
<img width="2238" height="278" alt="Xnip2026-08-12_08-50-01" src="https://github.com/user-attachments/assets/a56c3b2b-1634-470a-8d03-6e55cabba556" />


