### PR TITLE
chore: update core api reference docs (2.4.20)

### DIFF
--- a/.teamcity/BuildParams.kt
+++ b/.teamcity/BuildParams.kt
@@ -36,7 +36,7 @@ object BuildParams {
   const val KOTLIN_RELEASE_TAG = "2.4.0"
   const val KOTLIN_RELEASE_LABEL = KOTLIN_RELEASE_TAG
 
-  const val CORE_API_BUILD_ID = "Kotlin_KotlinRelease_240_LibraryReferenceLatestDocs"
+  const val CORE_API_BUILD_ID = "Kotlin_KotlinRelease_2420_LibraryReferenceLatestDocs"
   const val CORE_API_TITLE = "Core API"
 
   const val KOTLINX_METADATA_ID = "kotlinx-metadata-jvm"


### PR DESCRIPTION
Please ensure that the default Kotlin version on play.kotlinlang.org is updated to 2.4.20-... before merging this, otherwise runnable samples for the functions added in 2.4.20 would produce compilation errors, for example one in `kotlin-stdlib/kotlin.collections/all-distinct.html`