### PR TITLE
update: document the reflection library

### DIFF
--- a/docs/kr.tree
+++ b/docs/kr.tree
@@ -97,7 +97,6 @@
             <toc-element topic="async-programming.md"/>
             <toc-element topic="coroutines-overview.md"/>
         </toc-element>
-        <toc-element topic="reflection.md"/>
         <toc-element accepts-web-file-names="multi-declarations.html" topic="destructuring-declarations.md"/>
         <toc-element toc-title="Language reference">
             <toc-element toc-title="Grammar" href="https://kotlinlang.org/grammar/"/>
@@ -292,6 +291,7 @@
             <include from="serialization.tree" origin="serialization" element-id="serialization"/>
         </toc-element>
         <toc-element toc-title="Kotlin Metadata JVM (kotlin-metadata-jvm)" topic="metadata-jvm.md"/>
+        <toc-element toc-title="Reflection (kotlin-reflection)" topic="reflection.md"/>
         <toc-element toc-title="Lincheck (kotlinx.lincheck)">
             <include from="kl.tree" origin="lincheck" element-id="lincheck"/>
         </toc-element>

--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -444,6 +444,31 @@ fun main() {
 ```
 {kotlin-runnable="true" id="class-delegation-sequence"}
 
+## Constructor references
+
+Use a constructor reference when an API needs a factory, but construction already provides the required behavior. In this case,
+you don't need to repeat it in a [lambda](lambdas.md).
+
+To create a reference to a constructor, use `::ClassName`:
+
+```kotlin
+data class User(val name: String, val age: Int)
+
+fun createUser(factory: (String, Int) -> User): User =
+    factory("Jane Doe", 22)
+
+fun main() {
+    val user = createUser(::User)
+    println(user)
+    // User(name=Jane Doe, age=22)
+}
+```
+{kotlin-runnable="true"}
+
+Callable references to constructors are typed as one of the [`KFunction<out R>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-function/) subtypes depending on the parameter count.
+However, the compiler resolves and checks the constructor references at compile time and doesn't require the
+[kotlin-reflect](reflection.md) library.
+
 ### Classes without constructors
 
 Classes that don't declare any constructors (primary or secondary) have an implicit primary constructor

--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -444,31 +444,6 @@ fun main() {
 ```
 {kotlin-runnable="true" id="class-delegation-sequence"}
 
-### Constructor references
-
-Use a constructor reference when an API needs a factory, but construction already provides the required behavior. In this case,
-you don't need to repeat it in a [lambda](lambdas.md).
-
-To create a reference to a constructor, use `::ClassName`:
-
-```kotlin
-data class User(val name: String, val age: Int)
-
-fun createUser(factory: (String, Int) -> User): User =
-    factory("Jane Doe", 22)
-
-fun main() {
-    val user = createUser(::User)
-    println(user)
-    // User(name=Jane Doe, age=22)
-}
-```
-{kotlin-runnable="true"}
-
-Callable references to constructors are typed as one of the [`KFunction<out R>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-function/) subtypes depending on the parameter count.
-However, the compiler resolves and checks the constructor references at compile time and doesn't require the
-[kotlin-reflect](reflection.md) library.
-
 ### Classes without constructors
 
 Classes that don't declare any constructors (primary or secondary) have an implicit primary constructor

--- a/docs/topics/classes.md
+++ b/docs/topics/classes.md
@@ -444,7 +444,7 @@ fun main() {
 ```
 {kotlin-runnable="true" id="class-delegation-sequence"}
 
-## Constructor references
+### Constructor references
 
 Use a constructor reference when an API needs a factory, but construction already provides the required behavior. In this case,
 you don't need to repeat it in a [lambda](lambdas.md).

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -66,7 +66,7 @@ You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conve
 
 ### Pass callable references to SAM parameters
 
-If the required behavior already exists as a named function, you can pass a callable reference instead of repeating the call
+If the required behavior already exists as a named function, you can pass a [callable reference](lambdas.md#callable-reference) instead of repeating the call
 in a lambda. Kotlin adapts a compatible callable reference to the expected functional interface.
 
 In the following example, `::start` refers to the existing `start()` function. Because `execute()` expects `Action`,

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -64,9 +64,43 @@ fun main() {
 
 You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conversions).
 
+### Pass callable references to SAM parameters
+
+If the required behavior already exists as a named function, you can pass a callable reference instead of repeating the call
+in a lambda. Kotlin adapts a compatible callable reference to the expected functional interface.
+
+In the following example, `::start` refers to the existing `start()` function. Because `execute()` expects `Action`,
+the Kotlin compiler adapts the reference to an `Action` instance, which `run()` method calls `start()`:
+
+```kotlin
+fun interface Action {
+    fun run()
+}
+
+fun execute(action: Action) {
+    action.run()
+}
+
+fun start() {
+    println("Run from a callable reference")
+}
+
+fun main() {
+    execute(::start)
+    // Run from a callable reference
+}
+```
+{kotlin-runnable="true"}
+
+The lambda and the callable reference produce compatible `Action` instances, but they begin as different expressions.
+The first is a function literal and uses SAM conversion. The second refers to an existing declaration and uses SAM adaptation.
+
+SAM adaptation happens at compile time and doesn't perform runtime [reflection](reflection.md) or require the `kotlin-reflect` library.
+The compiler checks that the referenced function is compatible with the interface's single abstract method.
+
 ## Migration from an interface with constructor function to a functional interface
 
-Starting from 1.6.20, Kotlin supports [callable references](reflection.md#callable-references) to functional interface constructors, which
+Starting from 1.6.20, Kotlin supports callable references to functional interface constructors, which
 adds a source-compatible way to migrate from an interface with a constructor function to a functional interface.
 Consider the following code:
 

--- a/docs/topics/fun-interfaces.md
+++ b/docs/topics/fun-interfaces.md
@@ -66,11 +66,8 @@ You can also use [SAM conversions for Java interfaces](java-interop.md#sam-conve
 
 ### Pass callable references to SAM parameters
 
-If the required behavior already exists as a named function, you can pass a [callable reference](lambdas.md#callable-reference) instead of repeating the call
-in a lambda. Kotlin adapts a compatible callable reference to the expected functional interface.
-
-In the following example, `::start` refers to the existing `start()` function. Because `execute()` expects `Action`,
-the Kotlin compiler adapts the reference to an `Action` instance, which `run()` method calls `start()`:
+If the required behavior already exists as a named function, you can pass a [callable reference](lambdas.md#callable-reference).
+Kotlin adapts a compatible callable reference to the expected functional interface:
 
 ```kotlin
 fun interface Action {
@@ -86,17 +83,27 @@ fun start() {
 }
 
 fun main() {
+    // Kotlin converts the lambda to an Action instance
+    execute { start() }
+    // Run from a callable reference
+
+    // Kotlin adapts the reference to an Action instance
     execute(::start)
     // Run from a callable reference
 }
 ```
 {kotlin-runnable="true"}
 
-The lambda and the callable reference produce compatible `Action` instances, but they begin as different expressions.
-The first is a function literal and uses SAM conversion. The second refers to an existing declaration and uses SAM adaptation.
+The lambda in `execute { start ()}` and the callable reference in `execute(::start)` produce compatible `Action` instances,
+but they begin as different expressions. The first is a function literal and uses SAM conversion.
+The second refers to an existing declaration and uses SAM adaptation.
 
 SAM adaptation happens at compile time and doesn't perform runtime [reflection](reflection.md) or require the `kotlin-reflect` library.
 The compiler checks that the referenced function is compatible with the interface's single abstract method.
+
+Don't confuse a callable reference adapted to a SAM parameter with a callable reference to a functional interface constructor.
+In `execute(::start)`, `::start` supplies the implementation of `Action.run()`. A reference, such as `::Action`, refers
+to the implicit constructor that creates an `Action` from compatible behavior.
 
 ## Migration from an interface with constructor function to a functional interface
 

--- a/docs/topics/js/js-reflection.md
+++ b/docs/topics/js/js-reflection.md
@@ -3,7 +3,7 @@
 Kotlin/JS provides a limited support for the Kotlin [reflection API](reflection.md). The only supported parts of the API
 are:
 
-* [Class references](reflection.md#class-references) (`::class`)
+* [Class references](reflection.md#obtain-a-runtime-class) (`::class`)
 * [`KType` and `typeof()`](#ktype-and-typeof)
 * [`KClass` and `createInstance()`](#kclass-and-createinstance)
 

--- a/docs/topics/jvm/java-interop.md
+++ b/docs/topics/jvm/java-interop.md
@@ -832,13 +832,13 @@ Or explicitly cast to `java.lang.Object` and suppress the `PLATFORM_CLASS_MAPPED
 
 ### `getClass()`
 
-To retrieve the Java class of an object, use the `java` extension property on a [class reference](reflection.md#class-references):
+To retrieve the Java class of an object, use the `java` extension property on a [class reference](reflection.md#obtain-a-runtime-class):
 
 ```kotlin
 val fooClass = foo::class.java
 ```
 
-The code above uses a [bound class reference](reflection.md#bound-class-references). You can also use the `javaClass` extension property:
+The code above uses a [bound class reference](lambdas.md#bound-and-unbound-references). You can also use the `javaClass` extension property:
 
 ```kotlin
 val fooClass = foo.javaClass

--- a/docs/topics/keyword-reference.md
+++ b/docs/topics/keyword-reference.md
@@ -148,7 +148,7 @@ Kotlin supports the following operators and special symbols:
  * `!!` [asserts that an expression is non-nullable](null-safety.md#not-null-assertion-operator).
  * `?.` performs a [safe call](null-safety.md#safe-call-operator) (calls a method or accesses a property if the receiver is non-nullable).
  * `?:` takes the right-hand value if the left-hand value is null (the [elvis operator](null-safety.md#elvis-operator)).
- * `::` creates a [member reference](reflection.md#function-references) or a [class reference](reflection.md#class-references).
+ * `::` creates a [member reference](lambdas.md#function-references) or a [class reference](reflection.md#obtain-a-runtime-class).
  * `.`
      - accesses [members](classes.md), including [nested classes](nested-classes.md) and [enum entries](enum-classes.md#working-with-enum-constants).
      - defines and calls [extensions](extensions.md).

--- a/docs/topics/lambdas.md
+++ b/docs/topics/lambdas.md
@@ -114,11 +114,11 @@ There are several ways to obtain an instance of a function type:
   [Function literals with receiver](#function-literals-with-receiver) can be used as values of function types with receiver.
 
 * Use a callable reference to an existing declaration:
-    * a top-level, local, member, or extension [function](reflection.md#function-references): `::isOdd`, `String::toInt`,
-    * a top-level, member, or extension [property](reflection.md#property-references): `List<Int>::size`,
-    * a [constructor](reflection.md#constructor-references): `::Regex`
+    * a top-level, local, member, or extension [function](#function-references): `::isOdd`, `String::toInt`,
+    * a top-level, member, or extension [property](properties.md#property-references): `List<Int>::size`,
+    * a [constructor](classes.md#constructor-references): `::Regex`
 
-  These include [bound callable references](reflection.md#bound-function-and-property-references) that point to a member of a particular instance: `foo::toString`.
+  These include [bound callable references](#bound-and-unbound-references) that point to a member of a particular instance: `foo::toString`.
 
 * Use instances of a custom class that implements a function type as an interface:
 
@@ -193,6 +193,101 @@ fun main() {
 ### Inline functions
 
 Sometimes it is beneficial to use [inline functions](inline-functions.md), which provide flexible control flow, for higher-order functions.
+
+## Callable reference
+
+Callable references let you refer to a function, property, or constructor without calling or accessing it immediately.
+You can store the reference in a variable, pass it to another function, or invoke it later.
+
+To create a callable reference, use the `::` operator:
+
+```kotlin
+fun isOdd(number: Int) = number % 2 != 0
+
+fun main() {
+val numbers = listOf(1, 2, 3, 4, 5)
+
+    // Pass a reference to isOdd()
+    println(numbers.filter(::isOdd))
+    // [1, 3, 5]
+}
+```
+{kotlin-runnable="true"}
+
+Callable-reference objects implement [reflection](reflection.md) interfaces, such as `KFunction` and `KProperty`.
+
+### Function references
+
+Use a function reference when an API expects behavior as a value, and you already have a function that implements it.
+To refer to a top-level or local named function, use `::functionName`:
+
+```kotlin
+fun calculateLength(text: String) = text.length
+
+fun main() {
+val length: (String) -> Int = ::calculateLength
+
+    println(length("Kotlin"))
+    // 6
+    println(::calculateLength.name)
+    // calculateLength
+}
+```
+{kotlin-runnable="true"}
+
+Function references belong to one of the [`KFunction<out R>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-function/) subtypes, depending on the parameter count.
+For instance, `KFunction3<T1, T2, T3, R>`.
+
+If several functions have the same name, the compiler uses the expected function type to select the matching overload:
+
+```kotlin
+fun parse(value: String) = "String: $value"
+fun parse(value: Int) = "Int: $value"
+
+fun main() {
+val parseText: (String) -> String = ::parse
+val parseNumber: (Int) -> String = ::parse
+
+    println(parseText("Kotlin"))
+    // String: Kotlin
+    println(parseNumber(22))
+    // Int: 22
+}
+```
+{kotlin-runnable="true"}
+
+### Bound and unbound references
+
+A reference to a member can be _bound_ and _unbound_:
+
+* Bound reference captures a particular instance and requires only the function's declared arguments. Use it when every
+  invocation should use the same object.
+* Unbound reference isn't attached to an instance, so its function type includes the receiver. Use it when the caller
+  should provide the object.
+
+```kotlin
+class User(val name: String) {
+fun hasName(prefix: String) = name.startsWith(prefix)
+}
+
+fun main() {
+    // The first parameter of an unbound reference is the User receiver
+    val unbound: (User, String) -> Boolean = User::hasName
+    println(unbound(User("Jane"), "Ja"))
+    // true
+
+    val jane = User("Jane")
+
+    // Reference captures jane as its receiver
+    val bound: (String) -> Boolean = jane::hasName
+    println(bound("Doe"))
+    // false
+}
+```
+{kotlin-runnable="true"}
+
+Extension functions follow the same rule. For example, `String::isBlank` is unbound and needs a `String` receiver.
+`"Kotlin"::isBlank` is bound to one string.
 
 ## Lambda expressions and anonymous functions
 

--- a/docs/topics/lambdas.md
+++ b/docs/topics/lambdas.md
@@ -115,8 +115,8 @@ There are several ways to obtain an instance of a function type:
 
 * Use a callable reference to an existing declaration:
     * a top-level, local, member, or extension [function](#function-references): `::isOdd`, `String::toInt`,
-    * a top-level, member, or extension [property](properties.md#property-references): `List<Int>::size`,
-    * a [constructor](classes.md#constructor-references): `::Regex`
+    * a top-level, member, or extension [property](#property-references): `List<Int>::size`,
+    * a [constructor](#constructor-references): `::Regex`
 
   These include [bound callable references](#bound-and-unbound-references) that point to a member of a particular instance: `foo::toString`.
 
@@ -255,6 +255,81 @@ val parseInt: (Int) -> String = ::parse
 }
 ```
 {kotlin-runnable="true"}
+
+### Property references
+
+Use a property reference when you need to pass a statically checked property accessor. For example, another function can
+use the reference to select which value to read or update.
+
+To create a property reference, use the `::` operator. You can read the property by calling the reference as a function
+or by using the `get()` function. A mutable property reference also provides `set()`:
+
+```kotlin
+var greeting = "Hello"
+
+class User(var name: String)
+
+fun main() {
+    // A top-level property reference
+    // No receiver is needed
+    println(::greeting.get())
+    // Hello
+
+    ::greeting.set("Hi")
+    println(greeting)
+    // Hi
+
+    // An unbound member property
+    // a User receiver is needed
+    val name = User::name
+    val user = User("Jane")
+
+    println(name.get(user))
+    // Jane
+    name.set(user, "Jane Doe")
+    println(user.name)
+    // Jane Doe
+}
+```
+{kotlin-runnable="true"}
+
+Property-reference types indicate how many receivers are required:
+
+* [`KProperty0<V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property0/) requires no receiver. This includes top-level properties and properties bound to an object.
+* [`KProperty1<T, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property1/) requires one receiver.
+* [`KProperty2<D, E, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property2/) requires two receivers and represents a member extension property: one receiver for the containing class and another for the extended type.
+
+Mutable properties have corresponding [`KMutableProperty0`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property0/), [`KMutableProperty1`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property1/), and [`KMutableProperty2`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property2/) types.
+Usually, you don't need to write these types explicitly because the compiler infers them from the reference.
+
+> To discover the property at runtime, use [Kotlin reflection](reflection.md).
+>
+{style="tip"}
+
+### Constructor references
+
+Use a constructor reference when an API needs a factory and an existing constructor already has the required parameters
+and return type. The constructor reference lets the API create new instances through a function value.
+
+To create a reference to a constructor, use `::ClassName`:
+
+```kotlin
+data class User(val name: String, val age: Int)
+
+fun createUser(factory: (String, Int) -> User): User =
+    factory("Jane Doe", 22)
+
+fun main() {
+    val user = createUser(::User)
+    println(user)
+    // User(name=Jane Doe, age=22)
+}
+```
+{kotlin-runnable="true"}
+
+Callable references to constructors are typed as one of the [`KFunction<out R>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-function/) subtypes depending on the parameter count.
+However, the compiler resolves and checks the constructor references at compile time and doesn't require the
+[kotlin-reflect](reflection.md) library.
 
 ### Bound and unbound references
 

--- a/docs/topics/lambdas.md
+++ b/docs/topics/lambdas.md
@@ -245,12 +245,12 @@ fun parse(value: String) = "String: $value"
 fun parse(value: Int) = "Int: $value"
 
 fun main() {
-val parseText: (String) -> String = ::parse
-val parseNumber: (Int) -> String = ::parse
+val parseString: (String) -> String = ::parse
+val parseInt: (Int) -> String = ::parse
 
-    println(parseText("Kotlin"))
+    println(parseString("Kotlin"))
     // String: Kotlin
-    println(parseNumber(22))
+    println(parseInt(22))
     // Int: 22
 }
 ```

--- a/docs/topics/properties.md
+++ b/docs/topics/properties.md
@@ -237,56 +237,6 @@ fun main() {
 
 This example uses [reflection](reflection.md) to show which annotations are present on the getter and setter.
 
-## Property references
-
-Use a property reference when you need to pass a statically checked property accessor. For example, another function can
-use the reference to select which value to read or update.
-
-To create a property reference, use the `::` operator. You can read the property by calling the reference as a function
-or by using the `get()` function. A mutable property reference also provides `set()`:
-
-```kotlin
-var greeting = "Hello"
-
-class User(var name: String)
-
-fun main() {
-    // A top-level property reference
-    // No receiver is needed
-    println(::greeting.get())
-    // Hello
-
-    ::greeting.set("Hi")
-    println(greeting)
-    // Hi
-
-    // An unbound member property
-    // a User receiver is needed
-    val name = User::name
-    val user = User("Jane")
-
-    println(name.get(user))
-    // Jane
-    name.set(user, "Jane Doe")
-    println(user.name)
-    // Jane Doe
-}
-```
-{kotlin-runnable="true"}
-
-Property-reference types indicate how many receivers are required:
-
-* [`KProperty0<V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property0/) requires no receiver. This includes top-level properties and properties bound to an object.
-* [`KProperty1<T, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property1/) requires one receiver.
-* [`KProperty2<D, E, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property2/) requires two receivers and represents a member extension property: one receiver for the containing class and another for the extended type.
-
-Mutable properties have corresponding [`KMutableProperty0`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property0/), [`KMutableProperty1`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property1/), and [`KMutableProperty2`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property2/) types.
-Usually, you don't need to write these types explicitly because the compiler infers them from the reference.
-
-> To discover the property at runtime, use [Kotlin reflection](reflection.md).
->
-{style="tip"}
-
 ## Backing fields
 
 The compiler automatically generates backing fields for properties when a value needs to be stored in memory.
@@ -468,6 +418,56 @@ const val SUBSYSTEM_DEPRECATED: String = "This subsystem is deprecated"
 
 @Deprecated(SUBSYSTEM_DEPRECATED) fun processLegacyOrders() { ... }
 ```
+
+## Property references
+
+Use a property reference when you need to pass a statically checked property accessor. For example, another function can
+use the reference to select which value to read or update.
+
+To create a property reference, use the `::` operator. You can read the property by calling the reference as a function
+or by using the `get()` function. A mutable property reference also provides `set()`:
+
+```kotlin
+var greeting = "Hello"
+
+class User(var name: String)
+
+fun main() {
+    // A top-level property reference
+    // No receiver is needed
+    println(::greeting.get())
+    // Hello
+
+    ::greeting.set("Hi")
+    println(greeting)
+    // Hi
+
+    // An unbound member property
+    // a User receiver is needed
+    val name = User::name
+    val user = User("Jane")
+
+    println(name.get(user))
+    // Jane
+    name.set(user, "Jane Doe")
+    println(user.name)
+    // Jane Doe
+}
+```
+{kotlin-runnable="true"}
+
+Property-reference types indicate how many receivers are required:
+
+* [`KProperty0<V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property0/) requires no receiver. This includes top-level properties and properties bound to an object.
+* [`KProperty1<T, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property1/) requires one receiver.
+* [`KProperty2<D, E, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property2/) requires two receivers and represents a member extension property: one receiver for the containing class and another for the extended type.
+
+Mutable properties have corresponding [`KMutableProperty0`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property0/), [`KMutableProperty1`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property1/), and [`KMutableProperty2`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property2/) types.
+Usually, you don't need to write these types explicitly because the compiler infers them from the reference.
+
+> To discover the property at runtime, use [Kotlin reflection](reflection.md).
+>
+{style="tip"}
 
 ## Late-initialized properties and variables
 

--- a/docs/topics/properties.md
+++ b/docs/topics/properties.md
@@ -237,6 +237,56 @@ fun main() {
 
 This example uses [reflection](reflection.md) to show which annotations are present on the getter and setter.
 
+## Property references
+
+Use a property reference when you need to pass a statically checked property accessor. For example, another function can
+use the reference to select which value to read or update.
+
+To create a property reference, use the `::` operator. You can read the property by calling the reference as a function
+or by using the `get()` function. A mutable property reference also provides `set()`:
+
+```kotlin
+var greeting = "Hello"
+
+class User(var name: String)
+
+fun main() {
+    // A top-level property reference
+    // No receiver is needed
+    println(::greeting.get())
+    // Hello
+
+    ::greeting.set("Hi")
+    println(greeting)
+    // Hi
+
+    // An unbound member property
+    // a User receiver is needed
+    val name = User::name
+    val user = User("Jane")
+
+    println(name.get(user))
+    // Jane
+    name.set(user, "Jane Doe")
+    println(user.name)
+    // Jane Doe
+}
+```
+{kotlin-runnable="true"}
+
+Property-reference types indicate how many receivers are required:
+
+* [`KProperty0<V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property0/) requires no receiver. This includes top-level properties and properties bound to an object.
+* [`KProperty1<T, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property1/) requires one receiver.
+* [`KProperty2<D, E, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property2/) requires two receivers and represents a member extension property: one receiver for the containing class and another for the extended type.
+
+Mutable properties have corresponding [`KMutableProperty0`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property0/), [`KMutableProperty1`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property1/), and [`KMutableProperty2`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property2/) types.
+Usually, you don't need to write these types explicitly because the compiler infers them from the reference.
+
+> To discover the property at runtime, use [Kotlin reflection](reflection.md).
+>
+{style="tip"}
+
 ## Backing fields
 
 The compiler automatically generates backing fields for properties when a value needs to be stored in memory.
@@ -479,7 +529,7 @@ fun main() {
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="kotlin-lateinit-property" validate="false"}
 
 To check whether a `lateinit var` has already been initialized, use the [`isInitialized`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/is-initialized.html)
-property on the [reference to that property](reflection.md#property-references):
+property on the [reference to that property](#property-references):
 
 ```kotlin
 class WeatherStation {

--- a/docs/topics/properties.md
+++ b/docs/topics/properties.md
@@ -419,56 +419,6 @@ const val SUBSYSTEM_DEPRECATED: String = "This subsystem is deprecated"
 @Deprecated(SUBSYSTEM_DEPRECATED) fun processLegacyOrders() { ... }
 ```
 
-## Property references
-
-Use a property reference when you need to pass a statically checked property accessor. For example, another function can
-use the reference to select which value to read or update.
-
-To create a property reference, use the `::` operator. You can read the property by calling the reference as a function
-or by using the `get()` function. A mutable property reference also provides `set()`:
-
-```kotlin
-var greeting = "Hello"
-
-class User(var name: String)
-
-fun main() {
-    // A top-level property reference
-    // No receiver is needed
-    println(::greeting.get())
-    // Hello
-
-    ::greeting.set("Hi")
-    println(greeting)
-    // Hi
-
-    // An unbound member property
-    // a User receiver is needed
-    val name = User::name
-    val user = User("Jane")
-
-    println(name.get(user))
-    // Jane
-    name.set(user, "Jane Doe")
-    println(user.name)
-    // Jane Doe
-}
-```
-{kotlin-runnable="true"}
-
-Property-reference types indicate how many receivers are required:
-
-* [`KProperty0<V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property0/) requires no receiver. This includes top-level properties and properties bound to an object.
-* [`KProperty1<T, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property1/) requires one receiver.
-* [`KProperty2<D, E, V>`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-property2/) requires two receivers and represents a member extension property: one receiver for the containing class and another for the extended type.
-
-Mutable properties have corresponding [`KMutableProperty0`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property0/), [`KMutableProperty1`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property1/), and [`KMutableProperty2`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-mutable-property2/) types.
-Usually, you don't need to write these types explicitly because the compiler infers them from the reference.
-
-> To discover the property at runtime, use [Kotlin reflection](reflection.md).
->
-{style="tip"}
-
 ## Late-initialized properties and variables
 
 Normally, you must initialize properties in the constructor.
@@ -529,7 +479,7 @@ fun main() {
 {kotlin-runnable="true" kotlin-min-compiler-version="1.3" id="kotlin-lateinit-property" validate="false"}
 
 To check whether a `lateinit var` has already been initialized, use the [`isInitialized`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/is-initialized.html)
-property on the [reference to that property](#property-references):
+property on the [reference to that property](lambdas.md#property-references):
 
 ```kotlin
 class WeatherStation {

--- a/docs/topics/reflection.md
+++ b/docs/topics/reflection.md
@@ -1,369 +1,309 @@
 [//]: # (title: Reflection)
+[//]: # (description: Learn how to use Kotlin reflection to inspect classes, types, properties, and functions at runtime.)
 
 _Reflection_ is a set of language and library features that allows you to introspect the structure of your program at runtime.
-Functions and properties are first-class citizens in Kotlin, and the ability to introspect them (for example, learning the name or
-the type of a property or function at runtime) is essential when using a functional or reactive style.
+For example, you can inspect declarations, access properties, or create objects. This is helpful when you don't know
+the declarations at compile time.
 
-> Kotlin/JS provides limited support for reflection features. [Learn more about reflection in Kotlin/JS](js-reflection.md).
+Reflection provides runtime objects that describe compiled declarations. For example, a class is represented by [`KClass`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/),
+a type by [`KType`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-type/), and a property or function by a subtype of [`KCallable`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-callable/).
+You can inspect these objects and use them to access a value or invoke a function.
+
+## How reflection works
+
+The Kotlin compiler records metadata about declarations in the compiled output. The reflection API reads this metadata and
+presents it through Kotlin types such as `KClass` or `KFunction`. A reflection object describes this declaration, but it isn't
+the declaration's value. For example, you can use a `KProperty` to get a property's name and return its type without reading
+that property from an object.
+
+Reflection can only inspect declarations that are present in the compiled program. It doesn't parse the original source code or
+search the classpath for every class matching a condition.
+
+Kotlin provides some basic features, such as class literals or callable references, as part of the language and standard
+library. To access more extensive runtime introspection, import the [`kotlin-reflect`](https://kotlinlang.org/api/core/kotlin-reflect/) library
+that consists of the following packages:
+
+* [`kotlin.reflect`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/) with core reflection types and functions.
+* [`kotlin.reflect.full`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/) with extensions for inspecting Kotlin declarations.
+* [`kotlin.reflect.jvm`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.jvm/) with JVM-specific extensions that connect Kotlin and Java reflections.
+
+> Reflection support differs between platforms. This page aligns with Kotlin/JVM reflection API. Learn more about [reflection
+> in Kotlin/JS](js-reflection.md).
+> 
+{style="note"}
+
+## Obtain a runtime class
+
+If your code receives a general value like `Any`, you need a runtime class. However, you must choose processing based
+on the concrete object it received:
+
+* If you know the class from the sourse code, use `ClassName::class`.
+* If you need the actual class of a runtime value, use `object::class`.
+
+The approach depends on the way an API accepts values: through a common superclass or through `Any`. The declared type tells
+the compiler which operations are safe in source code, while `object::class` reveals the class that produced the value
+at runtime:
+
+```kotlin
+class User(val name: String)
+
+open class Language
+class English : Language()
+
+fun main() {
+    // The class written before ::class
+    val userClass = User::class
+    println(userClass.simpleName)
+    // User
+
+    val language: Language = English()
+
+    // The actual class of the object
+    println(language::class.simpleName)
+    // English
+}
+```
+{kotlin-runnable="true"}
+
+The obtained reference is a [`KClass`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/) type value.
+
+### Inspect types
+
+Even though [`KClass`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/) represents a class, it doesn't preserve type arguments.
+For example, `List<Int>` has the same `List::class` representaion as `List<String>`.
+To return a [`KType`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-type/) that includes type arguments and nullability, use the [`typeOf()`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/type-of.html) function:
+
+```kotlin
+import kotlin.reflect.typeOf
+
+fun main() {
+    val type = typeOf<List<String?>>()
+
+    println(type.classifier)
+    // class kotlin.collections.List
+    println(type.arguments.single().type)
+    // kotlin.String?
+}
+```
+
+In this example, the `classifier` connects the type to its class or type parameter. The `arguments` collection contains
+its type arguments. Therefore, the code can inspect `String?` separately from `List`.
+
+> On the JVM, the created type has no annotations, even when you annotate the type in the source code. Support for type
+> annotations might be added in a future version.
 >
 {style="note"}
 
-## JVM dependency
+### Check values
 
-On the JVM platform, the Kotlin compiler distribution includes the runtime component required for using the reflection features as a separate
-artifact, `kotlin-reflect.jar`. This is done to reduce the required size of the runtime
-library for applications that do not use reflection features.
+The `as` and `as?` operators work when you write the target type directly in the code. However, if you store the target in
+a `KClass`, use:
+
+* The [`cast()`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/cast.html) function if a mismatch should stop the operation.
+* The [`safeCast()`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/safe-cast.html) function if mismatch is an expected possibility.
+
+```kotlin
+import kotlin.reflect.full.cast
+import kotlin.reflect.full.safeCast
+
+fun main() {
+val expectedClass = String::class
+val value: Any = "Kotlin"
+    
+    val text = expectedClass.cast(value)
+    println(text)
+    // Kotlin
+    
+    val number = Int::class.safeCast(value)
+    println(number)
+    // null
+}
+```
+
+## Inspect a class
+
+After obtaining a `KClass`, you can inspect its members. This way, your program learns which declarations exist before
+deciding whether to use any of them. You can use:
+
+* The [`declaredMemberProperties`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/declared-member-properties.html) and [`declaredMemberFunctions`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/declared-member-functions.html) properties to return the declarations from the class itself.
+* The [`memberProperties`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/member-properties.html) and [`memberFunctions`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/member-functions.html) properties to return the declarations from the class and all of its superclasses.
+
+For example, the following code lists the properties declared directly in a class. Each returned `KProperty` describes a
+declaration without reading it from a `User` object. Therefore, you can inspect metadata without creating an instance:
+
+```kotlin
+import kotlin.reflect.full.declaredMemberProperties
+
+data class User(val name: String, val age: Int)
+
+fun main() {
+    // Return properties declared in User, but not inherited properties
+    User::class.declaredMemberProperties.forEach { property ->
+        println("${property.name}: ${property.returnType}")
+    }
+}
+```
+
+Reflection can inspect classes to which you already have a reference. However, it doesn't scan the classpath or discover
+every implementation of an open class or interface. For that, maintain an explicit registry or use a dedicated classpath-scanning
+library.
+
+> Learn how to [inspect sealed subclasses](sealed-classes.md#inspect-sealed-subclasses-with-reflection) with reflection.
+> 
+{style="tip"}
+
+## Read a property
+
+Reflection allows you to read a property selected at runtime.
+For example, you have a UI configuration contains `name` and asks the application to display that property for a `User`.
+For that, the application must find the matching property declaration and then invoke its getter:
+
+```kotlin
+import kotlin.reflect.full.memberProperties
+
+data class User(val name: String, val age: Int)
+
+fun readProperty(instance: Any, propertyName: String): Any? {
+// Inspect the runtime class
+val runtimeClass = instance::class
+
+    // Find the property declaration
+    val property = runtimeClass.memberProperties
+        .firstOrNull { it.name == propertyName }
+        ?: error("Unknown property: $propertyName")
+
+    // Call the getter with the object as a receiver
+    return property.getter.call(instance)
+}
+
+fun main() {
+val user = User("Jane Doe", 22)
+
+    println(readProperty(user, "name"))
+    // Jane Doe
+    println(readProperty(user, "age"))
+    // 22
+}
+```
+
+This example uses [`memberProperties`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/member-properties.html) to return unbound property objects. These objects describe properties
+that belong to the class but aren't attached to a particular instance. Therefore, `getter.call()` needs `instance` as its
+receiver. The result has the `Any?` type because a property selected at runtime can return any type.
+
+> If the property is known at compile time, use normal access or a callable reference.
+> 
+{style="tip"}
+
+## Call functions
+
+Dynamic function calls follow the same pattern as properties. If all arguments are available in their declared order, you
+can use [`call()`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-callable/call.html). Declare an unbound member function with its object instance first, then add its regular arguments:
+
+```kotlin
+import kotlin.reflect.full.memberFunctions
+
+class Formatter {
+fun format(text: String, uppercase: Boolean): String =
+if (uppercase) text.uppercase() else text
+}
+
+fun main() {
+val formatter = Formatter()
+
+    // Discover the function from runtime metadata
+    val function = Formatter::class.memberFunctions
+        .single { it.name == "format" }
+    
+    val result = function.call(formatter, "Kotlin", true)
+
+    println(result)
+    // KOTLIN
+}
+```
+
+In this example, the call contains three values: the `Formatter` receiver, `text`, and `uppercase`. It also returns the `Any?` type
+and reports an incompatible receiver or argument at runtime.
+
+You can also associate values with `KParameter` objects instead of supplying them by position. For that, use the [`callBy()`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-callable/call-by.html) to.
+function:
+
+```kotlin
+import kotlin.reflect.full.instanceParameter
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.full.valueParameters
+
+class Greeter {
+    fun greet(name: String, punctuation: String = "!") =
+        "Hello, $name$punctuation"
+}
+
+fun main() {
+    val greeter = Greeter()
+    val function = Greeter::class.memberFunctions
+        .single { it.name == "greet" }
+
+    // valueParameters contains parameters declared in greet()
+    // but not the Greeter receiver
+    val nameParameter = function.valueParameters
+        .single { it.name == "name" }
+
+    val result = function.callBy(
+        mapOf(
+            // Member functions need an instance receiver
+            function.instanceParameter!! to greeter,
+            nameParameter to "Kotlin"
+        )
+    )
+
+    println(result)
+    // Hello, Kotlin!
+}
+```
+
+In this example, `instanceParameter` identifies the member-function receiver, and `valueParameters` contains only parameters declared in the function signature.
+
+> Use `call()` when the complete ordered argument list is already available.
+> 
+> Use `callBy()` when you match the arguments by metadata or should omit the optional arguments.
+> 
+{style="tip"}
+
+## Add the JVM dependency
+
+On the JVM platform, the Kotlin compiler distribution includes the runtime component required for using the reflection
+features as a separate artifact, `kotlin-reflect.jar`. This allows applications without reflection features to reduce the
+required size of the runtime library.
 
 To use reflection in a Gradle or Maven project, add the dependency on `kotlin-reflect`:
 
-* In Gradle:
+<tabs group="build-script">
+<tab title="Gradle" group-key="gradle">
 
-    <tabs group="build-script">
-    <tab title="Kotlin" group-key="kotlin">
+```kotlin
+dependencies {
+    implementation(kotlin("reflect"))
+}
+```
 
-    ```kotlin
-    dependencies {
-        implementation(kotlin("reflect"))
-    }
-    ```
+</tab>
+<tab title="Maven" group-key="maven">
 
-    </tab>
-    <tab title="Groovy" group-key="groovy">
-    
-    ```groovy
-    dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-reflect:%kotlinVersion%"
-    }
-    ```
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-reflect</artifactId>
+    </dependency>
+</dependencies>
+```
 
-    </tab>
-    </tabs>
-
-* In Maven:
-    
-    ```xml
-    <dependencies>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-        </dependency>
-    </dependencies>
-    ```
+</tab>
+</tabs>
 
 If you don't use Gradle or Maven, make sure you have `kotlin-reflect.jar` in the classpath of your project.
 In other supported cases (IntelliJ IDEA projects that use the command-line compiler),
 it is added by default. In the command-line compiler, you can use the `-no-reflect` compiler option to exclude
 `kotlin-reflect.jar` from the classpath.
 
-## Class references
-
-The most basic reflection feature is getting the runtime reference to a Kotlin class. To obtain the reference to a
-statically known Kotlin class, you can use the _class literal_ syntax:
-
-```kotlin
-val c = MyClass::class
-```
-
-The reference is a [KClass](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-class/index.html) type value.
-
->On JVM: a Kotlin class reference is not the same as a Java class reference. To obtain a Java class reference,
->use the `.java` property on a `KClass` instance.
->
-{style="note"}
-
-### Bound class references
-
-You can get the reference to the class of a specific object with the same `::class` syntax by using the object as a receiver:
-
-```kotlin
-val widget: Widget = ...
-assert(widget is GoodWidget) { "Bad widget: ${widget::class.qualifiedName}" }
-```
-
-You will obtain the reference to the exact class of an object, for example, `GoodWidget` or `BadWidget`,
-regardless of the type of the receiver expression (`Widget`).
-
-## Callable references
-
-References to functions, properties, and constructors can
-also be called or used as instances of [function types](lambdas.md#function-types).
-
-The common supertype for all callable references is [`KCallable<out R>`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-callable/index.html),
-where `R` is the return value type. It is the property type for properties, and the constructed type for constructors.
-
-### Function references
-
-When you have a named function declared as below, you can call it directly (`isOdd(5)`):
-
-```kotlin
-fun isOdd(x: Int) = x % 2 != 0
-```
-
-Alternatively, you can use the function as a function type value, that is, pass it
-to another function. To do so, use the `::` operator:
-
-```kotlin
-fun isOdd(x: Int) = x % 2 != 0
-
-fun main() {
-//sampleStart
-    val numbers = listOf(1, 2, 3)
-    println(numbers.filter(::isOdd))
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-Here `::isOdd` is a value of function type `(Int) -> Boolean`.
-
-Function references belong to one of the [`KFunction<out R>`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-function/index.html)
-subtypes, depending on the parameter count. For instance, `KFunction3<T1, T2, T3, R>`.
-
-`::` can be used with overloaded functions when the expected type is known from the context.
-For example:
-
-```kotlin
-fun main() {
-//sampleStart
-    fun isOdd(x: Int) = x % 2 != 0
-    fun isOdd(s: String) = s == "brillig" || s == "slithy" || s == "tove"
-    
-    val numbers = listOf(1, 2, 3)
-    println(numbers.filter(::isOdd)) // refers to isOdd(x: Int)
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-Alternatively, you can provide the necessary context by storing the method reference in a variable with an explicitly specified type:
-
-```kotlin
-val predicate: (String) -> Boolean = ::isOdd   // refers to isOdd(x: String)
-```
-
-If you need to use a member of a class or an extension function, it needs to be qualified: `String::toCharArray`.
-
-Even if you initialize a variable with a reference to an extension function, the inferred function type will
-have no receiver, but it will have an additional parameter accepting a receiver object. To have a function type
-with a receiver instead, specify the type explicitly:
-
-```kotlin
-val isEmptyStringList: List<String>.() -> Boolean = List<String>::isEmpty
-```
-
-#### Example: function composition
-
-Consider the following function:
-
-```kotlin
-fun <A, B, C> compose(f: (B) -> C, g: (A) -> B): (A) -> C {
-    return { x -> f(g(x)) }
-}
-```
-
-It returns a composition of two functions passed to it: `compose(f, g) = f(g(*))`.
-You can apply this function to callable references:
-
-```kotlin
-fun <A, B, C> compose(f: (B) -> C, g: (A) -> B): (A) -> C {
-    return { x -> f(g(x)) }
-}
-
-fun isOdd(x: Int) = x % 2 != 0
-
-fun main() {
-//sampleStart
-    fun length(s: String) = s.length
-    
-    val oddLength = compose(::isOdd, ::length)
-    val strings = listOf("a", "ab", "abc")
-    
-    println(strings.filter(oddLength))
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-### Property references
-
-To access properties as first-class objects in Kotlin, use the `::` operator:
-
-```kotlin
-val x = 1
-
-fun main() {
-    println(::x.get())
-    println(::x.name) 
-}
-```
-
-The expression `::x` evaluates to a `KProperty0<Int>` type property object. You can read its
-value using `get()` or retrieve the property name using the `name` property. For more information, see
-the [docs on the `KProperty` class](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-property/index.html).
-
-For a mutable property such as `var y = 1`, `::y` returns a value with the [`KMutableProperty0<Int>`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-mutable-property/index.html) type
-which has a `set()` method:
-
-```kotlin
-var y = 1
-
-fun main() {
-    ::y.set(2)
-    println(y)
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-A property reference can be used where a function with a single generic parameter is expected:
-
-```kotlin
-fun main() {
-//sampleStart
-    val strs = listOf("a", "bc", "def")
-    println(strs.map(String::length))
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-To access a property that is a member of a class, qualify it as follows:
-
-```kotlin
-fun main() {
-//sampleStart
-    class A(val p: Int)
-    val prop = A::p
-    println(prop.get(A(1)))
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-For an extension property:
-
-```kotlin
-val String.lastChar: Char
-    get() = this[length - 1]
-
-fun main() {
-    println(String::lastChar.get("abc"))
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-### Interoperability with Java reflection
-
-On the JVM platform, the standard library contains extensions for reflection classes that provide a mapping to and from Java
-reflection objects (see package `kotlin.reflect.jvm`).
-For example, to find a backing field or a Java method that serves as a getter for a Kotlin property, you can write something like this:
-
-```kotlin
-import kotlin.reflect.jvm.*
- 
-class A(val p: Int)
- 
-fun main() {
-    println(A::p.javaGetter) // prints "public final int A.getP()"
-    println(A::p.javaField)  // prints "private final int A.p"
-}
-```
-
-To get the Kotlin class that corresponds to a Java class, use the `.kotlin` extension property:
-
-```kotlin
-fun getKClass(o: Any): KClass<Any> = o.javaClass.kotlin
-```
-
-### Constructor references
-
-Constructors can be referenced just like methods and properties. You can use them wherever the program expects a function type object
-that takes the same parameters as the constructor and returns an object of the appropriate type.
-Constructors are referenced by using the `::` operator and adding the class name. Consider the following function
-that expects a function parameter with no parameters and return type `Foo`:
-
-```kotlin
-class Foo
-
-fun function(factory: () -> Foo) {
-    val x: Foo = factory()
-}
-```
-
-Using `::Foo`, the zero-argument constructor of the class `Foo`, you can call it like this:
-
-```kotlin
-function(::Foo)
-```
-
-Callable references to constructors are typed as one of the
-[`KFunction<out R>`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-function/index.html) subtypes
-depending on the parameter count.
-
-### Bound function and property references
-
-You can refer to an instance method of a particular object:
-
-```kotlin
-fun main() {
-//sampleStart
-    val numberRegex = "\\d+".toRegex()
-    println(numberRegex.matches("29"))
-     
-    val isNumber = numberRegex::matches
-    println(isNumber("29"))
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-Instead of calling the method `matches` directly, the example uses a reference to it.
-Such a reference is bound to its receiver.
-It can be called directly (like in the example above) or used whenever a function type expression is expected:
-
-```kotlin
-fun main() {
-//sampleStart
-    val numberRegex = "\\d+".toRegex()
-    val strings = listOf("abc", "124", "a70")
-    println(strings.filter(numberRegex::matches))
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-Compare the types of the bound and the unbound references.
-The bound callable reference has its receiver "attached" to it, so the type of the receiver is no longer a parameter:
-
-```kotlin
-val isNumber: (CharSequence) -> Boolean = numberRegex::matches
-
-val matches: (Regex, CharSequence) -> Boolean = Regex::matches
-```
-
-A property reference can be bound as well:
-
-```kotlin
-fun main() {
-//sampleStart
-    val prop = "abc"::length
-    println(prop.get())
-//sampleEnd
-}
-```
-{kotlin-runnable="true" kotlin-min-compiler-version="1.3"}
-
-You don't need to specify `this` as the receiver: `this::foo` and `::foo` are equivalent.
-
-### Bound constructor references
-
-A bound callable reference to a constructor of an [inner class](nested-classes.md#inner-classes) can
-be obtained by providing an instance of the outer class:
-
-```kotlin
-class Outer {
-    inner class Inner
-}
-
-val o = Outer()
-val boundInnerCtor = o::Inner
-```
+To convert the class representations themselves, use `.java` on a `KClass` and `.kotlin` on a Java Class.
+The conversion changes the API used to describe the class, not the underlying class itself.

--- a/docs/topics/reflection.md
+++ b/docs/topics/reflection.md
@@ -11,10 +11,9 @@ You can inspect these objects and use them to access a value or invoke a functio
 
 ## How reflection works
 
-The Kotlin compiler records metadata about declarations in the compiled output. The [reflection API](https://kotlinlang.org/api/core/kotlin-reflect/) reads this metadata and
-presents it through Kotlin types such as `KClass` or `KFunction`. A reflection object describes this declaration, but it isn't
-the declaration's value. For example, you can use a `KProperty` to get a property's name and return its type without reading
-that property from an object.
+The [reflection API](https://kotlinlang.org/api/core/kotlin-reflect/) represents compiled declarations through Kotlin types such as `KClass` or `KFunction`.
+A reflection object describes this declaration, but it isn't the declaration's value. For example, you can use a `KProperty`
+to get a property's name and return its type without reading that property from an object.
 
 Kotlin provides some basic features, such as class literals or callable references, as part of the language and standard
 library. To access more extensive runtime introspection, import the [`kotlin-reflect`](https://kotlinlang.org/api/core/kotlin-reflect/) library
@@ -24,30 +23,67 @@ that consists of the following packages:
 * [`kotlin.reflect.full`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/) with extensions for inspecting Kotlin declarations.
 * [`kotlin.reflect.jvm`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.jvm/) with JVM-specific extensions that connect Kotlin and Java reflections.
 
-Reflection can only inspect declarations that are present in the compiled program. It doesn't parse the original source code or
-search the classpath for every class matching a condition.
-
 > Reflection support may differ between platforms. This page aligns with Kotlin/JVM reflection API. Learn more about [reflection
 > in Kotlin/JS](js-reflection.md).
 > 
 {style="note"}
 
+## Add the JVM dependency
+
+On the JVM platform, the Kotlin compiler distribution includes the runtime component required for using the reflection
+features as a separate artifact, `kotlin-reflect.jar`. This allows applications without reflection features to reduce the
+size of the runtime classpath.
+
+To use reflection in a Gradle or Maven project, add the dependency on `kotlin-reflect`:
+
+<tabs group="build-script">
+<tab title="Gradle" group-key="gradle">
+
+```kotlin
+dependencies {
+    implementation(kotlin("reflect"))
+}
+```
+
+</tab>
+<tab title="Maven" group-key="maven">
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-reflect</artifactId>
+    </dependency>
+</dependencies>
+```
+
+</tab>
+</tabs>
+
+If you don't use Gradle or Maven, make sure you have `kotlin-reflect.jar` in the classpath of your project.
+In other supported cases (IntelliJ IDEA projects that use the command-line compiler),
+it is added by default. In the command-line compiler, you can use the `-no-reflect` compiler option to exclude
+`kotlin-reflect.jar` from the classpath.
+
+To convert the class representations themselves, use `.java` on a `KClass` and `.kotlin` on a Java Class.
+The conversion changes the API used to describe the class, not the underlying class itself.
+
 ## Obtain a runtime class
 
 To obtain a runtime class, choose processing based on the concrete object it received:
 
-* If you know the class from the sourse code, use `ClassName::class`.
-* If you need the actual class of a runtime value, use `object::class`.
+* If you know the class from the source code, use `ClassName::class`.
+* If you need the actual class of a runtime value, use `value::class`.
 
 The approach depends on the way an API accepts values: through a common superclass or through `Any`. The declared type tells
-the compiler which operations are safe in the source code, while `object::class` reveals the class that produced the value
+the compiler which operations are safe in the source code, while `value::class` reveals the class that produced the value
 at runtime:
 
 ```kotlin
 class User(val name: String)
 
 open class Language
-class English : Language()
+class Kotlin : Language()
 
 fun main() {
     // The class written before ::class
@@ -55,11 +91,11 @@ fun main() {
     println(userClass.simpleName)
     // User
 
-    val language: Language = English()
+    val language: Language = Kotlin()
 
     // The actual class of the object
     println(language::class.simpleName)
-    // English
+    // Kotlin
 }
 ```
 {kotlin-runnable="true"}
@@ -127,8 +163,9 @@ deciding whether to use any of them. For example, you can use:
 * The [`declaredMemberProperties`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/declared-member-properties.html) and [`declaredMemberFunctions`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/declared-member-functions.html) properties to return the declarations from the class itself.
 * The [`memberProperties`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/member-properties.html) and [`memberFunctions`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/member-functions.html) properties to return the declarations from the class and all of its superclasses.
 
-For example, the following code lists the properties declared directly in a class. Each returned `KProperty` describes a
-declaration without reading it from a `User` object. Therefore, you can inspect metadata without creating an instance:
+For example, the following code lists the properties declared directly in a class. `declaredMemberProperties` returns `KProperty`
+objects that describe the declarations. Reading `property.name` or `property.returnType` doesn't access a `User` value.
+It inspects the declaration itself. You need a `User` instance only if you want to read the property's value:
 
 ```kotlin
 import kotlin.reflect.full.declaredMemberProperties
@@ -143,13 +180,7 @@ fun main() {
 }
 ```
 
-Reflection can inspect classes to which you already have a reference. However, it doesn't scan the classpath or discover
-every implementation of an open class or interface. For that, maintain an explicit registry or use a dedicated classpath-scanning
-library.
-
-> Learn how to [inspect sealed subclasses](sealed-classes.md#inspect-sealed-subclasses-with-reflection) with reflection.
-> 
-{style="tip"}
+You can also [inspect sealed subclasses](sealed-classes.md#inspect-sealed-subclasses-with-reflection) with reflection.
 
 ## Read a property
 
@@ -202,17 +233,18 @@ can use [`call()`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/
 import kotlin.reflect.full.memberFunctions
 
 class Formatter {
-fun format(text: String, uppercase: Boolean): String =
-if (uppercase) text.uppercase() else text
+    fun format(text: String, uppercase: Boolean): String =
+        if (uppercase) text.uppercase() else text
 }
 
 fun main() {
-val formatter = Formatter()
+    val formatter = Formatter()
 
-    // Discover the function from runtime metadata
+    // Find the function by its name at runtime
     val function = Formatter::class.memberFunctions
         .single { it.name == "format" }
-    
+
+    // Supply the receiver first, then the declared arguments in order
     val result = function.call(formatter, "Kotlin", true)
 
     println(result)
@@ -263,46 +295,6 @@ In this example, `instanceParameter` identifies the member-function receiver, an
 
 > Use `call()` when the complete ordered argument list is already available.
 > 
-> Use `callBy()` when you match the arguments by metadata or should omit the optional arguments.
+> Use `callBy()` when you match arguments to parameter objects or let optional parameters use their defaults.
 > 
 {style="tip"}
-
-## Add the JVM dependency
-
-On the JVM platform, the Kotlin compiler distribution includes the runtime component required for using the reflection
-features as a separate artifact, `kotlin-reflect.jar`. This allows applications without reflection features to reduce the
-required size of the runtime library.
-
-To use reflection in a Gradle or Maven project, add the dependency on `kotlin-reflect`:
-
-<tabs group="build-script">
-<tab title="Gradle" group-key="gradle">
-
-```kotlin
-dependencies {
-    implementation(kotlin("reflect"))
-}
-```
-
-</tab>
-<tab title="Maven" group-key="maven">
-
-```xml
-<dependencies>
-    <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-reflect</artifactId>
-    </dependency>
-</dependencies>
-```
-
-</tab>
-</tabs>
-
-If you don't use Gradle or Maven, make sure you have `kotlin-reflect.jar` in the classpath of your project.
-In other supported cases (IntelliJ IDEA projects that use the command-line compiler),
-it is added by default. In the command-line compiler, you can use the `-no-reflect` compiler option to exclude
-`kotlin-reflect.jar` from the classpath.
-
-To convert the class representations themselves, use `.java` on a `KClass` and `.kotlin` on a Java Class.
-The conversion changes the API used to describe the class, not the underlying class itself.

--- a/docs/topics/reflection.md
+++ b/docs/topics/reflection.md
@@ -11,13 +11,10 @@ You can inspect these objects and use them to access a value or invoke a functio
 
 ## How reflection works
 
-The Kotlin compiler records metadata about declarations in the compiled output. The reflection API reads this metadata and
+The Kotlin compiler records metadata about declarations in the compiled output. The [reflection API](https://kotlinlang.org/api/core/kotlin-reflect/) reads this metadata and
 presents it through Kotlin types such as `KClass` or `KFunction`. A reflection object describes this declaration, but it isn't
 the declaration's value. For example, you can use a `KProperty` to get a property's name and return its type without reading
 that property from an object.
-
-Reflection can only inspect declarations that are present in the compiled program. It doesn't parse the original source code or
-search the classpath for every class matching a condition.
 
 Kotlin provides some basic features, such as class literals or callable references, as part of the language and standard
 library. To access more extensive runtime introspection, import the [`kotlin-reflect`](https://kotlinlang.org/api/core/kotlin-reflect/) library
@@ -27,21 +24,23 @@ that consists of the following packages:
 * [`kotlin.reflect.full`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/) with extensions for inspecting Kotlin declarations.
 * [`kotlin.reflect.jvm`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.jvm/) with JVM-specific extensions that connect Kotlin and Java reflections.
 
-> Reflection support differs between platforms. This page aligns with Kotlin/JVM reflection API. Learn more about [reflection
+Reflection can only inspect declarations that are present in the compiled program. It doesn't parse the original source code or
+search the classpath for every class matching a condition.
+
+> Reflection support may differ between platforms. This page aligns with Kotlin/JVM reflection API. Learn more about [reflection
 > in Kotlin/JS](js-reflection.md).
 > 
 {style="note"}
 
 ## Obtain a runtime class
 
-If your code receives a general value like `Any`, you need a runtime class. However, you must choose processing based
-on the concrete object it received:
+To obtain a runtime class, choose processing based on the concrete object it received:
 
 * If you know the class from the sourse code, use `ClassName::class`.
 * If you need the actual class of a runtime value, use `object::class`.
 
 The approach depends on the way an API accepts values: through a common superclass or through `Any`. The declared type tells
-the compiler which operations are safe in source code, while `object::class` reveals the class that produced the value
+the compiler which operations are safe in the source code, while `object::class` reveals the class that produced the value
 at runtime:
 
 ```kotlin
@@ -123,7 +122,7 @@ val value: Any = "Kotlin"
 ## Inspect a class
 
 After obtaining a `KClass`, you can inspect its members. This way, your program learns which declarations exist before
-deciding whether to use any of them. You can use:
+deciding whether to use any of them. For example, you can use:
 
 * The [`declaredMemberProperties`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/declared-member-properties.html) and [`declaredMemberFunctions`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/declared-member-functions.html) properties to return the declarations from the class itself.
 * The [`memberProperties`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/member-properties.html) and [`memberFunctions`](https://kotlinlang.org/api/core/kotlin-reflect/kotlin.reflect.full/member-functions.html) properties to return the declarations from the class and all of its superclasses.
@@ -155,7 +154,7 @@ library.
 ## Read a property
 
 Reflection allows you to read a property selected at runtime.
-For example, you have a UI configuration contains `name` and asks the application to display that property for a `User`.
+For example, you have a UI configuration that contains `name` and asks the application to display that property for a `User`.
 For that, the application must find the matching property declaration and then invoke its getter:
 
 ```kotlin
@@ -190,13 +189,13 @@ This example uses [`memberProperties`](https://kotlinlang.org/api/core/kotlin-re
 that belong to the class but aren't attached to a particular instance. Therefore, `getter.call()` needs `instance` as its
 receiver. The result has the `Any?` type because a property selected at runtime can return any type.
 
-> If the property is known at compile time, use normal access or a callable reference.
+> If the property is known at compile time, use normal access or callable references.
 > 
 {style="tip"}
 
 ## Call functions
 
-Dynamic function calls follow the same pattern as properties. If all arguments are available in their declared order, you
+Dynamic function calls follow the same pattern as [properties](#read-a-property). If all arguments are available in their declared order, you
 can use [`call()`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-callable/call.html). Declare an unbound member function with its object instance first, then add its regular arguments:
 
 ```kotlin

--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -217,6 +217,41 @@ For more information, see [Guard conditions in when expressions](control-flow.md
 >
 {style="note"}
 
+## Inspect sealed subclasses with reflection
+
+You can use [Reflection](reflection.md) functionality to inspect sealed subclasses. If you need to inspect a known direct subclass,
+use [sealedSubclasses](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/sealed-subclasses.html).
+
+The complier returns a [`KClass`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/) that can represent a regular class or an object declaration. For an object declaration,
+[`objectInstance`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/object-instance.html) returns its singleton instance:
+
+```kotlin
+sealed interface Status
+data class Send(val message: String) : Status
+data object Start : Status
+data object Stop : Status
+
+fun main() {
+    // Get the direct subclasses known to the sealed hierarchy
+    val subclasses = Status::class.sealedSubclasses
+    println(subclasses.mapNotNull { it.simpleName })
+
+    val singletonStatus = subclasses.mapNotNull { subclass ->
+        // Return null for Send because it is a regular class
+        subclass.objectInstance
+    }
+    println(singletonStatus)
+    // [Start, Stop]
+}
+```
+
+In this example, `objectInstance` filters out `Send` because every `Send` value must be constructed separately. Since `Start`
+and `Stop` are object declarations, the compiler returns their existing singleton instances.
+
+> If one of the direct subclasses is also sealed, traverse its `sealedSubclasses` recursively to collect the complete hierarchy.
+> 
+{style="tip"}
+
 ## Use case scenarios
 
 Let's explore some practical scenarios where sealed classes and interfaces can be particularly useful.

--- a/docs/topics/sealed-classes.md
+++ b/docs/topics/sealed-classes.md
@@ -219,9 +219,9 @@ For more information, see [Guard conditions in when expressions](control-flow.md
 
 ## Inspect sealed subclasses with reflection
 
-You can use [Reflection](reflection.md) functionality to inspect sealed subclasses. If you need to inspect a known direct subclass,
-use [sealedSubclasses](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/sealed-subclasses.html).
+You can use [Reflection](reflection.md) functionality to inspect sealed subclasses. 
 
+If you need to inspect a known direct subclass, use [sealedSubclasses](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/sealed-subclasses.html).
 The complier returns a [`KClass`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/) that can represent a regular class or an object declaration. For an object declaration,
 [`objectInstance`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.reflect/-k-class/object-instance.html) returns its singleton instance:
 
@@ -245,7 +245,7 @@ fun main() {
 }
 ```
 
-In this example, `objectInstance` filters out `Send` because every `Send` value must be constructed separately. Since `Start`
+In this example, `objectInstance` filters out `Send`, because every `Send` value must be constructed separately. Since `Start`
 and `Stop` are object declarations, the compiler returns their existing singleton instances.
 
 > If one of the direct subclasses is also sealed, traverse its `sealedSubclasses` recursively to collect the complete hierarchy.

--- a/docs/topics/whatsnew/whatsnew11.md
+++ b/docs/topics/whatsnew/whatsnew11.md
@@ -127,7 +127,7 @@ See the [type aliases documentation](type-aliases.md) and [KEEP](https://github.
 
 ### Bound callable references
 
-You can now use the `::` operator to get a [member reference](reflection.md#function-references) pointing to a method or
+You can now use the `::` operator to get a [member reference](lambdas.md#function-references) pointing to a method or
 property of a specific object instance. Previously this could only be expressed with a lambda.
 Here's an example:
 

--- a/docs/topics/whatsnew/whatsnew1620.md
+++ b/docs/topics/whatsnew/whatsnew1620.md
@@ -202,7 +202,7 @@ If your project consists of lots of small modules and has a build parallelized b
 >
 {style="warning"}
 
-Support for [callable references](reflection.md#callable-references) to functional interface constructors adds a source-compatible way to migrate from an interface with a constructor function to a [functional interface](fun-interfaces.md).
+Support for [callable references](fun-interfaces.md#migration-from-an-interface-with-constructor-function-to-a-functional-interface) to functional interface constructors adds a source-compatible way to migrate from an interface with a constructor function to a [functional interface](fun-interfaces.md).
 
 Consider the following code:
 

--- a/docs/topics/whatsnew/whatsnew17.md
+++ b/docs/topics/whatsnew/whatsnew17.md
@@ -230,7 +230,7 @@ on [this YouTrack ticket](https://youtrack.jetbrains.com/issue/KT-29974/Add-a-co
 
 ### Stable callable references to functional interface constructors
 
-[Callable references](reflection.md#callable-references) to functional interface constructors are
+[Callable references](fun-interfaces.md#pass-callable-references-to-sam-parameters) to functional interface constructors are
 now [Stable](components-stability.md). Learn how
 to [migrate](fun-interfaces.md#migration-from-an-interface-with-constructor-function-to-a-functional-interface)
 from an interface with a constructor function to a functional interface using callable references.


### PR DESCRIPTION
Document kotlin reflection. Changes:

- reflection.md describes kotlin-reflect; mobed to the Library guides section
- Callable references are documented on the corresponding pages:
  - classes.md: Constructor references
  - fun-interfaces.md: Pass callable references to SAM parameters
  - lambdas.md: Callable reference
  - properties.md: Property references
  - sealed-classes.md: Inspect sealed subclasses with reflection