### PR TITLE
chore: Kotlin evolution principles﻿ page clean up

### DIFF
--- a/docs/topics/kotlin-evolution-principles.md
+++ b/docs/topics/kotlin-evolution-principles.md
@@ -32,7 +32,7 @@ want most of the code in the world to be already updated and thus have no issues
 incompatible changes we'll be making in the future. Apart from using our best judgement, we believe that trying things out
 in real life is the best way to validate a design. Before casting things in stone, we want them battle-tested. This is why
 we use every opportunity to make early versions of our designs available in production versions of the language, but in one
-of the _pre-stable_ statuses: [Experimental, Alpha, or Beta](components-stability.md). Such features are not stable,
+of the _pre-stable_ statuses: [Experimental, Alpha, or Beta](components-stability.md). Such features are not stable;
 they can be changed at any time, and the users that opt into using them do so explicitly to indicate that they are ready
 to deal with the future migration issues. These users provide invaluable feedback that we gather to iterate on the design
 and make it rock-solid.
@@ -49,7 +49,7 @@ There can be debates as to what "doesn't work anymore" means precisely in some c
 
 The less obvious cases that belong to the "gray area" include handling corner cases differently, throwing an exception of a different type than before,
 changing behavior observable only through reflection, modifying undocumented or undefined behavior, renaming binary artifacts, and others.
-Sometimes such changes are crucial and affect migration experience dramatically, sometimes they are insignificant.
+Sometimes such changes are crucial and affect migration experience dramatically; sometimes they are insignificant.
 
 Some examples of what definitely isn't an incompatible change include:
 
@@ -132,11 +132,11 @@ A Kotlin language feature can have one of the following statuses:
   This involves discussing how it would integrate with existing features, gathering use cases,
   and assessing its potential impact.
   We need feedback from users on the problems this feature would solve and the use cases it addresses.
-  Whenever possible, we try to estimate how often these use cases and problems occur would also be beneficial.
+  Whenever possible, we also try to estimate how often these use cases and problems occur.
   Typically, ideas are documented as YouTrack issues, where the discussion continues.
 
 * **KEEP discussion**. We are fairly certain that the feature should be added to the language.
-  We aim to provide motivation, use-cases, design, and other important details in a document called a _KEEP_.
+  We aim to provide motivation, use cases, design, and other important details in a document called a _Kotlin Evolution and Enhancement Process_ (KEEP).
   We expect feedback from users to focus on discussing all the information provided in the KEEP.
 
 * **In preview**. A feature prototype is ready, and you can enable it using a feature-specific compiler option.
@@ -179,7 +179,7 @@ Here are some assumptions that we make when considering language changes from th
     thus never relying on type inference for public API. Subtle changes in type inference may cause return types to change inadvertently,
     leading to binary compatibility issues.
 * Overloaded functions and properties provided by the same library should do essentially the same thing. 
-    Changes in type inference may result in more precise static types to be known at call sites,
+    Changes in type inference may result in more precise static types being known at call sites,
     causing changes in overload resolution.
 
 Library authors can use the `@Deprecated` and [`@RequiresOptIn`](opt-in-requirements.md) annotations


### PR DESCRIPTION
This PR adds small clean-up additions to the Kotlin evolution principles﻿ page