### PR TITLE
Fix link to Kotlin Nights page

### DIFF
--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -158,7 +158,7 @@ Yes! Kotlin has a very vibrant community. Kotlin developers hang out on the [Kot
 ### Are there Kotlin events?
  
 Yes! There are many User Groups and Meetups now focused exclusively around Kotlin. You can find [a list on the website](https://kotlinlang.org/user-groups/user-group-list.html).
-In addition, there are community-organized [Kotlin Nights](https://kotlinlang.org/community/events.html) events around the world.
+In addition, there are community-organized [Kotlin Nights](kotlin-night-guidelines.html) events around the world.
 
 ### Is there a Kotlin conference?
 


### PR DESCRIPTION
The events page has been removed, so this is a replacement. https://youtrack.jetbrains.com/issue/KTL-4570


