### PR TITLE
Fix spelling: 'spelt' to 'spelled' in Exercise 3 example solution

### DIFF
--- a/docs/topics/tour/kotlin-tour-collections.md
+++ b/docs/topics/tour/kotlin-tour-collections.md
@@ -500,7 +500,7 @@ fun main() {
 fun main() {
     val number2word = mapOf(1 to "one", 2 to "two", 3 to "three")
     val n = 2
-    println("$n is spelt as '${number2word[n]}'")
+    println("$n is spelled as '${number2word[n]}'")
 }
 ```
 {initial-collapse-state="collapsed" collapsible="true" collapsed-title="Example solution" id="kotlin-tour-collections-solution-3"}


### PR DESCRIPTION
#5411 changed the spelling of 'spelt' to 'spelled' in the exercise 3 input, but left the example solution as 'spelt'. This updates the example solution to align with that form.