### PR TITLE
chore: more consistent and readable code examples in calling the Derived class

### DIFF
--- a/docs/topics/delegation.md
+++ b/docs/topics/delegation.md
@@ -21,6 +21,7 @@ fun main() {
     val derived = Derived(base) 
     
     derived.print()
+    // 10
 }
 ```
 {kotlin-runnable="true"}
@@ -46,7 +47,7 @@ class BaseImpl(val x: Int) : Base {
 }
 
 class Derived(b: Base) : Base by b {
-    override fun printMessage() { print("abc") }
+    override fun printMessage() { println("abc") }
 }
 
 fun main() {
@@ -54,7 +55,9 @@ fun main() {
     val derived = Derived(base)
 
     derived.printMessage()
+    // abc
     derived.printMessageLine()
+    // 10
 }
 ```
 {kotlin-runnable="true"}
@@ -84,7 +87,9 @@ fun main() {
     val derived = Derived(base)
     
     derived.print()
+    // BaseImpl: x = 10
     println(derived.message)
+    // Message of Derived
 }
 ```
 {kotlin-runnable="true"}

--- a/docs/topics/delegation.md
+++ b/docs/topics/delegation.md
@@ -18,7 +18,9 @@ class Derived(b: Base) : Base by b
 
 fun main() {
     val base = BaseImpl(10)
-    Derived(base).print()
+    val derived = Derived(base) 
+    
+    derived.print()
 }
 ```
 {kotlin-runnable="true"}
@@ -49,8 +51,10 @@ class Derived(b: Base) : Base by b {
 
 fun main() {
     val base = BaseImpl(10)
-    Derived(base).printMessage()
-    Derived(base).printMessageLine()
+    val derived = Derived(base)
+
+    derived.printMessage()
+    derived.printMessageLine()
 }
 ```
 {kotlin-runnable="true"}
@@ -70,13 +74,15 @@ class BaseImpl(x: Int) : Base {
 }
 
 class Derived(b: Base) : Base by b {
-    // This property is not accessed from b's implementation of `print`
+    // This property is not accessible
+    // from b's implementation of `print()`
     override val message = "Message of Derived"
 }
 
 fun main() {
-    val b = BaseImpl(10)
-    val derived = Derived(b)
+    val base = BaseImpl(10)
+    val derived = Derived(base)
+    
     derived.print()
     println(derived.message)
 }


### PR DESCRIPTION
We're already using the `val derived` in some samples. I think this is a more readable version so I made it consistent.